### PR TITLE
Fix alley-coding-standards phpcs relative rule ref

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 
 	<exclude-pattern>tests/</exclude-pattern>
 
-	<rule ref="vendor/alley/alley-coding-standards" />
+	<rule ref="./vendor/alley/alley-coding-standards" />
 
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 


### PR DESCRIPTION
Relative ref paths for phpcs rules need a `./`.