### PR TITLE
Allow routes to define name fluently as well as other methods

### DIFF
--- a/src/mantle/framework/contracts/http/routing/interface-router.php
+++ b/src/mantle/framework/contracts/http/routing/interface-router.php
@@ -94,4 +94,16 @@ interface Router {
 	 *                              Not used if $route is a callback.
 	 */
 	public function rest_api( string $namespace, $route, $args = [] );
+
+	/**
+	 * Rename a route.
+	 *
+	 * @param string $old_name Old route name.
+	 * @param string $new_name New route name.
+	 * @return static
+	 *
+	 * @throws InvalidArgumentException Thrown when attempting to rename a route
+	 *                                  a name that is already taken.
+	 */
+	public function rename_route( string $old_name, string $new_name );
 }

--- a/src/mantle/framework/helpers.php
+++ b/src/mantle/framework/helpers.php
@@ -212,7 +212,7 @@ if ( ! function_exists( 'route' ) ) {
 	 * @param array  $args Route arguments.
 	 * @return string
 	 */
-	function route( string $name, array $args, bool $relative = false ) {
+	function route( string $name, array $args = [], bool $relative = false ) {
 		return app( 'url' )->generate( $name, $args, $relative ? UrlGenerator::ABSOLUTE_PATH : UrlGenerator::ABSOLUTE_URL );
 	}
 }

--- a/src/mantle/framework/http/routing/class-url-generator.php
+++ b/src/mantle/framework/http/routing/class-url-generator.php
@@ -232,4 +232,15 @@ class Url_Generator extends UrlGenerator implements Generator_Contract {
 
 		$this->force_scheme = $scheme . '://';
 	}
+
+	/**
+	 * Set the routes in the generator.
+	 *
+	 * @param RouteCollection $routes Route collection.
+	 * @return static
+	 */
+	public function set_routes( RouteCollection $routes ) {
+		$this->routes = $routes;
+		return $this;
+	}
 }

--- a/src/mantle/framework/providers/class-route-service-provider.php
+++ b/src/mantle/framework/providers/class-route-service-provider.php
@@ -51,6 +51,14 @@ class Route_Service_Provider extends Service_Provider implements Route_Service_P
 		if ( method_exists( $this, 'map' ) ) {
 			$this->app->call( [ $this, 'map' ] );
 		}
+
+		// Setup the default request object.
+		if ( ! isset( $this->app['request'] ) ) {
+			$this->app['request'] = new Request();
+		}
+
+		// Sync the loaded routes to the URL generator.
+		$this->app['router']->sync_routes_to_url_generator();
 	}
 
 	/**

--- a/src/mantle/framework/providers/class-routing-service-provider.php
+++ b/src/mantle/framework/providers/class-routing-service-provider.php
@@ -44,6 +44,9 @@ class Routing_Service_Provider extends Service_Provider {
 
 	/**
 	 * Register the URL generator service.
+	 *
+	 * @todo Improve on this URL generator to allow the routes to be shared
+	 * instantly from the router.
 	 */
 	protected function register_url_generator() {
 		$this->app->singleton(


### PR DESCRIPTION
```php
Route::get( '/endpoint' )
	->name( 'name-here' )
	->callback( ... );
```