### PR TITLE
MNTL-165 generator generators

### DIFF
--- a/src/mantle/framework/console/generators/class-generator-make-command.php
+++ b/src/mantle/framework/console/generators/class-generator-make-command.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Generator_Make_Command class file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Framework\Console\Generators;
+
+use Mantle\Framework\Console\Generator_Command;
+
+/**
+ * Generator Generator
+ */
+class Generator_Make_Command extends Generator_Command {
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:generator';
+
+	/**
+	 * Command Description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Generate a generator.';
+
+	/**
+	 * The type of class being generated.
+	 *
+	 * @var string
+	 */
+	protected $type = 'Console\Generators';
+
+	/**
+	 * Command synopsis.
+	 *
+	 * @var string|array
+	 */
+	protected $synopsis = [
+		[
+			'description' => 'Class name',
+			'name'        => 'name',
+			'optional'    => false,
+			'type'        => 'positional',
+		],
+		[
+			'description' => 'Type of Generator',
+			'name'				=> 'type',
+			'optional'		=> false,
+			'type'				=> 'positional',
+		],
+	];
+
+	/**
+	 * Generator Command.
+	 *
+	 * @todo Replace with a filesystem abstraction.
+	 *
+	 * @param array $args Command Arguments.
+	 * @param array $assoc_args Command flags.
+	 */
+	public function handle( array $args, array $assoc_args ) {
+		// Prevent command being run in non-local environments.
+		if ( 'local' !== $this->app->environment() ) {
+			$this->error( 'Generator cannot be used outside of local environment.', true );
+		}
+
+		if ( empty( $args[0] ) ) {
+			$this->error( 'Missing class name.', true );
+		}
+
+		list( $name, $type ) = $args;
+
+		$path = $this->get_folder_path( $name );
+
+		// Ensure the folder path exists.
+		if ( ! is_dir( $path ) && ! mkdir( $path, 0700, true ) ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.directory_mkdir
+			$this->error( 'Error creating folder: ' . $path );
+		}
+
+		$file_path = $this->get_file_path( $name . '-make-command' );
+		if ( file_exists( $file_path ) ) {
+			$this->error( $this->type . ' already exists: ' . $file_path, true );
+		}
+
+		// Build the stub file and apply replacements.
+		$this->build_stub( $name );
+		$this->replacements->add( '{{ type }}', $type );
+		$this->set_stub( $this->replacements->replace( $this->get_stub() ) );
+
+		if ( false === file_put_contents( $file_path, $this->get_stub() ) ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+			$this->error( 'Error writing to ' . $file_path );
+		}
+
+		// Create the stub file for the generated generator.
+		$stub_path = $this->get_base_path() . 'console/generators/stubs';
+		if ( ! is_dir( $stub_path ) && ! mkdir( $stub_path, 0700, true ) ) { // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.directory_mkdir
+			$this->error( 'Error creating folder: ' . $stub_path );
+		}
+
+		if ( ! copy( __DIR__ . '/stubs/stub.stub', $stub_path . '/' . $name . '.stub' ) ) {
+			$this->error( 'Error copying stub file to ' . $stub_path );
+		}
+
+		$this->log( $this->type . ' created successfully: ' . $file_path );
+		$this->synopsis( $name );
+	}
+
+	/**
+	 * Get the stub file for the generator.
+	 *
+	 * @return string
+	 */
+	public function get_file_stub(): string {
+		$filename = 'generator.stub';
+		return __DIR__ . '/stubs/' . $filename;
+	}
+
+	/**
+	 * Command synopsis.
+	 *
+	 * @param string $name Class name.
+	 */
+	public function synopsis( string $name ) {
+		$this->log(
+			PHP_EOL . sprintf(
+				'You can auto-register this model by adding "%s\\%s::class" to the "commands" in "app/console/class-kernel.php".',
+				$this->get_namespace( $name ),
+				$this->get_class_name( $name )
+			)
+		);
+	}
+}

--- a/src/mantle/framework/console/generators/class-generator-make-command.php
+++ b/src/mantle/framework/console/generators/class-generator-make-command.php
@@ -127,10 +127,11 @@ class Generator_Make_Command extends Generator_Command {
 	public function synopsis( string $name ) {
 		$this->log(
 			PHP_EOL . sprintf(
-				'You can auto-register this model by adding "%s\\%s::class" to the "commands" in "app/console/class-kernel.php".',
+				'You can auto-register this generator by adding "%s\\%s::class" to the "commands" in "app/console/class-kernel.php".',
 				$this->get_namespace( $name ),
 				$this->get_class_name( $name )
 			)
 		);
+		$this->log( 'You can customize the template this generator uses by editing its stub file in "app/console/generators/stubs/"' );
 	}
 }

--- a/src/mantle/framework/console/generators/class-generator-make-command.php
+++ b/src/mantle/framework/console/generators/class-generator-make-command.php
@@ -48,9 +48,9 @@ class Generator_Make_Command extends Generator_Command {
 		],
 		[
 			'description' => 'Type of Generator',
-			'name'				=> 'type',
-			'optional'		=> false,
-			'type'				=> 'positional',
+			'name'        => 'type',
+			'optional'    => false,
+			'type'        => 'positional',
 		],
 	];
 

--- a/src/mantle/framework/console/generators/stubs/generator.stub
+++ b/src/mantle/framework/console/generators/stubs/generator.stub
@@ -27,7 +27,6 @@ class {{ class }}_Make_Command extends Generator_Command {
 	 */
 	protected $description = 'Generate a {{ class }}.';
 
-
 	/**
 	 * Command synopsis.
 	 *
@@ -48,7 +47,6 @@ class {{ class }}_Make_Command extends Generator_Command {
 	 * @var string
 	 */
 	protected $type = '{{ type }}';
-
 
 	/**
 	 * Get the stub file for the generator.

--- a/src/mantle/framework/console/generators/stubs/generator.stub
+++ b/src/mantle/framework/console/generators/stubs/generator.stub
@@ -1,0 +1,70 @@
+<?php
+/**
+ * {{ class }} Generator file.
+ *
+ * @package {{ namespace }}
+ */
+
+namespace App\Console\Generators;
+
+use Mantle\Framework\Console\Generator_Command;
+
+/**
+ * {{ class }} Generator Command
+ */
+class {{ class }}_Make_Command extends Generator_Command {
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'make:{{ class }}';
+
+	/**
+	 * Command Description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Generate a {{ class }}.';
+
+
+	/**
+	 * Command synopsis.
+	 *
+	 * @var string|array
+	 */
+	protected $synopsis = [
+		[
+			'description' => 'Class name',
+			'name'        => 'name',
+			'optional'    => false,
+			'type'        => 'positional',
+		],
+	];
+
+	/**
+	 * The type of class being generated.
+	 *
+	 * @var string
+	 */
+	protected $type = '{{ type }}';
+
+
+	/**
+	 * Get the stub file for the generator.
+	 *
+	 * @return string
+	 */
+	public function get_file_stub(): string {
+		$filename = '{{ class }}.stub';
+		return __DIR__ . '/stubs/' . $filename;
+	}
+
+	/**
+	 * Command synopsis.
+	 * Provides information to the user about how to use the generated file.
+	 *
+	 * @param string $name Class name.
+	 */
+	public function synopsis( string $name ) { }
+}

--- a/src/mantle/framework/console/generators/stubs/generator.stub
+++ b/src/mantle/framework/console/generators/stubs/generator.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} Generator file.
+ * {{ class }}_Make_Command class file.
  *
  * @package {{ namespace }}
  */

--- a/src/mantle/framework/console/generators/stubs/stub.stub
+++ b/src/mantle/framework/console/generators/stubs/stub.stub
@@ -1,0 +1,10 @@
+<?php
+/**
+ * {{ class }} file.
+ *
+ * @package {{ namespace }}
+ */
+
+namespace {{ namespace }};
+
+// Stub file for {{ class }}.

--- a/src/mantle/framework/providers/class-console-service-provider.php
+++ b/src/mantle/framework/providers/class-console-service-provider.php
@@ -11,6 +11,7 @@ use Mantle\Framework\Console\Clear_Cache_Command;
 use Mantle\Framework\Console\Generators\Command_Make_Command;
 use Mantle\Framework\Console\Generators\Controller_Make_Command;
 use Mantle\Framework\Console\Generators\Factory_Make_Command;
+use Mantle\Framework\Console\Generators\Generator_Make_Command;
 use Mantle\Framework\Console\Generators\Job_Make_Command;
 use Mantle\Framework\Console\Generators\Middleware_Make_Command;
 use Mantle\Framework\Console\Generators\Model_Make_Command;
@@ -36,6 +37,7 @@ class Console_Service_Provider extends Service_Provider {
 		Command_Make_Command::class,
 		Controller_Make_Command::class,
 		Factory_Make_Command::class,
+		Generator_Make_Command::class,
 		Hook_Usage_Command::class,
 		Job_Make_Command::class,
 		Middleware_Make_Command::class,


### PR DESCRIPTION
Add a generator to generate generators.
`wp mantle make:generator <name> <type>`

Generates the generator class, and creates a basic stub template for that specific generator.

There is a bug with passing a `type` that has backslashes. https://alleyinteractive.atlassian.net/browse/MNTL-185

Doesn't handle capitalization very well, i.e. ideally, `wp mantle make:generator foo` would give you `class Foo_...` and `protected $name = 'make:foo';`.