### PR TITLE
Add command to list routes

### DIFF
--- a/src/mantle/framework/console/class-route-list-command.php
+++ b/src/mantle/framework/console/class-route-list-command.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Route_List_Command class file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Framework\Console;
+
+use Mantle\Framework\Console\Command;
+use Mantle\Framework\Contracts\Http\Routing\Router;
+use Mantle\Framework\Http\Routing\Route;
+use Mantle\Framework\Support\Collection;
+
+use function Mantle\Framework\Helpers\collect;
+
+/**
+ * Route_List_Command Controller
+ */
+class Route_List_Command extends Command {
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'route:list';
+
+	/**
+	 * Command Short Description.
+	 *
+	 * @var string
+	 */
+	protected $short_description = 'List the registered routes in the application.';
+
+	/**
+	 * Command Description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'List the registered routes in the application.';
+
+	/**
+	 * Command synopsis.
+	 *
+	 * Supports registering command arguments in a string or array format.
+	 * For example:
+	 *
+	 *     <argument> --example-flag
+	 *
+	 * @var string|array
+	 */
+	protected $synopsis = [
+		[
+			'description' => 'Output format.',
+			'name'        => 'format',
+			'optional'    => true,
+			'options'     => [ 'table', 'json', 'csv', 'count' ],
+			'type'        => 'flag',
+		],
+	];
+
+	/**
+	 * Router instance.
+	 *
+	 * @var Router
+	 */
+	protected $router;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Router $router Router instance.
+	 */
+	public function __construct( Router $router ) {
+		$this->router = $router;
+	}
+
+	/**
+	 * Callback for the command.
+	 *
+	 * @param array $args Command Arguments.
+	 * @param array $assoc_args Command flags.
+	 */
+	public function handle( array $args, array $assoc_args ) {
+		$routes = $this->collect_routes();
+
+		\WP_CLI\Utils\format_items(
+			$this->get_flag( 'format', 'table' ),
+			$routes->to_array(),
+			[
+				'method',
+				'url',
+				'name',
+				'action',
+				'middleware',
+			]
+		);
+	}
+
+	/**
+	 * Collect the routes in the application.
+	 *
+	 * @return Collection
+	 */
+	protected function collect_routes(): Collection {
+		$routes = $this->router->get_routes()->all();
+
+		if ( empty( $routes ) ) {
+			return collect();
+		}
+
+		return collect( $routes )
+			->map(
+				function ( Route $route, string $name ) {
+					return [
+						'action'     => $route->get_callback_name(),
+						'method'     => implode( '|', $route->getMethods() ),
+						'middleware' => implode( '|', $route->middleware() ),
+						'name'       => $name,
+						'url'        => $route->getPath(),
+					];
+				}
+			);
+	}
+}

--- a/src/mantle/framework/contracts/http/routing/interface-router.php
+++ b/src/mantle/framework/contracts/http/routing/interface-router.php
@@ -9,6 +9,7 @@ namespace Mantle\Framework\Contracts\Http\Routing;
 
 use Mantle\Framework\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * Router Contract
@@ -69,6 +70,13 @@ interface Router {
 	 * @return Response|null
 	 */
 	public function dispatch( Request $request ): ?Response;
+
+	/**
+	 * Get registered routes.
+	 *
+	 * @return RouteCollection
+	 */
+	public function get_routes(): RouteCollection;
 
 	/**
 	 * Substitute Explicit Bindings

--- a/src/mantle/framework/http/routing/class-route.php
+++ b/src/mantle/framework/http/routing/class-route.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Route as Symfony_Route;
 use Symfony\Component\HttpFoundation\Response as Symfony_Response;
 
+use function Mantle\Framework\Helpers\get_callable_fqn;
+
 /**
  * Route Class
  */
@@ -234,6 +236,25 @@ class Route extends Symfony_Route {
 		}
 
 		return $response ? static::ensure_response( $response ) : null;
+	}
+
+
+	/**
+	 * Retrieve the route's callback name.
+	 *
+	 * @return string
+	 */
+	public function get_callback_name(): string {
+		if ( $this->has_controller_callback() ) {
+			$controller = $this->get_controller_name();
+			$method     = $this->get_controller_method();
+
+			return get_callable_fqn( [ $controller, $method ] );
+		} elseif ( $this->has_callback() ) {
+			return get_callable_fqn( $this->action['callback'] );
+		}
+
+		return '';
 	}
 
 	/**

--- a/src/mantle/framework/providers/class-console-service-provider.php
+++ b/src/mantle/framework/providers/class-console-service-provider.php
@@ -19,6 +19,7 @@ use Mantle\Framework\Console\Generators\Seeder_Make_Command;
 use Mantle\Framework\Console\Generators\Service_Provider_Make_Command;
 use Mantle\Framework\Console\Hook_Usage_Command;
 use Mantle\Framework\Console\Package_Discover_Command;
+use Mantle\Framework\Console\Route_List_Command;
 use Mantle\Framework\Service_Provider;
 
 /**
@@ -43,6 +44,7 @@ class Console_Service_Provider extends Service_Provider {
 		Middleware_Make_Command::class,
 		Model_Make_Command::class,
 		Package_Discover_Command::class,
+		Route_List_Command::class,
 		Seeder_Make_Command::class,
 		Service_Provider_Make_Command::class,
 	];

--- a/src/mantle/framework/support/traits/trait-enumerates-values.php
+++ b/src/mantle/framework/support/traits/trait-enumerates-values.php
@@ -2,7 +2,7 @@
 /**
  * Enumerates_Values trait file.
  *
- * @package mantle
+ * @package Mantle
  */
 
 // phpcs:disable Squiz.Commenting.FunctionComment.MissingParamComment


### PR DESCRIPTION
```
$ wp mantle route:list
+----------+------------+--------------------+----------------------------------------------+------------+
| method   | url        | name               | action                                       | middleware |
+----------+------------+--------------------+----------------------------------------------+------------+
| GET|HEAD | /example   | get.head./example  | Closure                                      | web        |
| POST     | /asdnadsad | post./asdnadsad    | Closure                                      | web        |
| GET|HEAD | /asdasdad  | get.head./asdasdad | App\Http\Controller\Test_Controller::index() | web        |
+----------+------------+--------------------+----------------------------------------------+------------+
```