### PR TITLE
Remove dependancy on core unit test library and use PHPUnit 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 .run
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,12 @@ install:
     cd $og_dir
 
     # Go into the core directory and replace wp-content.
-    rm -rf ${WP_CORE_DIR}wp-content
-    mkdir ${WP_CORE_DIR}wp-content
-    cp -R . "${WP_CORE_DIR}wp-content"
+    mkdir ${WP_CORE_DIR}wp-content/plugins/mantle-framework
+    cp -R . "${WP_CORE_DIR}wp-content/plugins/mantle-framework"
 
   # Install Composer
   - |
-    cd ${WP_CORE_DIR}wp-content/
+    cd ${WP_CORE_DIR}wp-content/plugins/mantle-framework
     composer install
     pwd
     ls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 dist: bionic
 
-sudo: false
-
 language: php
 
 services:
@@ -35,18 +33,37 @@ before_install:
   # Turn off Xdebug. See https://core.trac.wordpress.org/changeset/40138.
   - phpenv config-rm xdebug.ini || echo "Xdebug not available"
 
+  - og_dir="$(pwd)"
+
   - export PATH="${HOME}/.config/composer/vendor/bin:${PATH}"
+  - export WP_DEVELOP_DIR=/tmp/wordpress
+  - export WP_CORE_DIR=/tmp/wordpress/
 
 install:
   - composer validate --strict
+  - bash bin/install-wp-tests.sh wordpress_unit_tests root '' localhost $WP_VERSION
+
+  # Copy the wp-tests-config.php to the WP installation.
+  - cp ${WP_TESTS_DIR-/tmp/wordpress-tests-lib}/wp-tests-config.php ${WP_CORE_DIR-/tmp/wordpress/}wp-tests-config.php
+
+  # Set up the wp-content directory.
   - |
-    if [[ ! -z "$WP_VERSION" ]] ; then
-      bash bin/install-wp-tests.sh wordpress_test root "" 127.0.0.1 "$WP_VERSION"
-    fi
+    cd $og_dir
+
+    # Go into the core directory and replace wp-content.
+    rm -rf ${WP_CORE_DIR}wp-content
+    mkdir ${WP_CORE_DIR}wp-content
+    cp -R . "${WP_CORE_DIR}wp-content"
+
+  # Install Composer
   - |
+    cd ${WP_CORE_DIR}wp-content/
     composer install
+    pwd
+    ls
 
 script:
+  - pwd
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
       composer run phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-branches:
-  only:
-  - main
-  - develop
-
 matrix:
   include:
     - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ before_install:
 
   - export PATH="${HOME}/.config/composer/vendor/bin:${PATH}"
 
-  # Couple the PHPUnit version to the PHP version.
-  - composer global require "phpunit/phpunit=6.1.*"
-
 install:
   - composer validate --strict
   - |
@@ -55,5 +52,4 @@ script:
       composer run phpcs
     fi
   - |
-    which phpunit
-    phpunit
+    composer run phpunit

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^0.2.0",
-        "mockery/mockery": "^1.3"
+        "mockery/mockery": "^1.3",
+        "nunomaduro/collision": "^5.0",
+        "phpunit/phpunit": "^8.5.8|^9.3.3"
     },
     "config": {
         "apcu-autoloader": true,
@@ -38,6 +40,7 @@
     "autoload": {
         "files": [
             "src/autoload.php",
+            "src/mantle/framework/testing/autoload.php",
             "src/mantle/framework/helpers.php",
             "src/mantle/framework/helpers/helpers.php"
         ]

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,9 +5,10 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
-    >
+		printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
+>
     <testsuites>
-        <testsuite>
+        <testsuite name="mantle-framework">
             <directory prefix="test-" suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>

--- a/src/mantle/framework/testing/autoload.php
+++ b/src/mantle/framework/testing/autoload.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Autoloaded File to support Testing
+ *
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+ *
+ * @package Mantle
+ */
+
+/**
+ * Retrieve the Mantle Framework Directory
+ *
+ * @return string
+ */
+function mantle_tests_get_framework_directory(): string {
+	$preload_path = '/src/mantle/framework/testing/preload.php';
+
+	$mantle_dir = getenv( 'MANTLE_FRAMEWORK_DIR' );
+
+	if ( getenv( 'MANTLE_FRAMEWORK_DIR' ) ) {
+		return (string) getenv( 'MANTLE_FRAMEWORK_DIR' );
+	}
+
+	if ( defined( 'MANTLE_FRAMEWORK_DIR' ) ) {
+		return (string) MANTLE_FRAMEWORK_DIR;
+	}
+
+	$mantle_dir = dirname( __DIR__ ) . '/vendor/alleyinteractive/mantle-framework';
+	if ( file_exists( $mantle_dir . $preload_path ) ) {
+		return $mantle_dir;
+	}
+
+
+	$dir = preg_replace( '#/mantle-framework/.*$#', '/mantle-framework', __DIR__ );
+	if ( is_dir( $dir ) ) {
+		return $dir;
+	}
+
+	return dirname( __DIR__, 4 );
+}
+
+/**
+ * Install the Mantle Tests Framework
+ *
+ * @param callable $callback_after_preload Callback to invoke before WordPress is loaded.
+ * @return void
+ */
+function mantle_tests_install( callable $callback_after_preload = null ): void {
+	$dir = mantle_tests_get_framework_directory();
+
+	if ( ! file_exists( $dir . '/src/mantle/framework/testing/preload.php' ) ) {
+		echo "ERROR: Failed to locate valid mantle-framework location. \n";
+		echo "Location: {$dir} \n";
+		exit( 1 );
+	}
+
+	require_once $dir . '/src/mantle/framework/testing/preload.php';
+
+	if ( $callback_after_preload ) {
+		$callback_after_preload();
+	}
+
+	try {
+		require_once $dir . '/src/mantle/framework/testing/wordpress-bootstrap.php';
+	} catch ( \Throwable $throwable ) {
+		echo "ERROR: Failed to load WordPress!\n";
+		echo "{$throwable}\n";
+		exit( 1 );
+	}
+}

--- a/src/mantle/framework/testing/autoload.php
+++ b/src/mantle/framework/testing/autoload.php
@@ -7,12 +7,14 @@
  * @package Mantle
  */
 
+namespace Mantle\Framework\Testing;
+
 /**
  * Retrieve the Mantle Framework Directory
  *
  * @return string
  */
-function mantle_tests_get_framework_directory(): string {
+function get_framework_directory(): string {
 	$preload_path = '/src/mantle/framework/testing/preload.php';
 
 	$mantle_dir = getenv( 'MANTLE_FRAMEWORK_DIR' );
@@ -45,8 +47,8 @@ function mantle_tests_get_framework_directory(): string {
  * @param callable $callback_after_preload Callback to invoke before WordPress is loaded.
  * @return void
  */
-function mantle_tests_install( callable $callback_after_preload = null ): void {
-	$dir = mantle_tests_get_framework_directory();
+function install( callable $callback_after_preload = null ): void {
+	$dir = get_framework_directory();
 
 	if ( ! file_exists( $dir . '/src/mantle/framework/testing/preload.php' ) ) {
 		echo "ERROR: Failed to locate valid mantle-framework location. \n";

--- a/src/mantle/framework/testing/core-polyfill.php
+++ b/src/mantle/framework/testing/core-polyfill.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Functions from the core unit test library that help with testing.
+ *
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound,
+ *
+ * @package Mantle
+ */
+
+if ( ! function_exists( 'rand_str' ) ) :
+	/**
+	 * Provide a random string.
+	 *
+	 * @param int $len String length.
+	 * @return string
+	 */
+	function rand_str( $len = 32 ): string {
+		return substr( md5( uniqid( wp_rand() ) ), 0, $len );
+	}
+endif;

--- a/src/mantle/framework/testing/preload.php
+++ b/src/mantle/framework/testing/preload.php
@@ -7,6 +7,8 @@
 
 namespace Mantle\Framework\Testing;
 
+require_once __DIR__ . '/core-polyfill.php';
+
 /**
  * Adds hooks before loading WP.
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,24 +1,14 @@
 <?php
+/**
+ * Framework Tests Bootstrap
+ *
+ * @package Mantle
+ */
 
 namespace Mantle\Tests;
 
 define( 'MULTISITE', true );
-
-$_tests_dir = getenv( 'WP_TESTS_DIR' );
-if ( ! $_tests_dir ) {
-	$_tests_dir = '/tmp/wordpress-tests-lib';
-}
-
-require_once $_tests_dir . '/includes/functions.php';
-
-function _manually_load_plugin() {
-	require dirname( dirname( __FILE__ ) ) . '/mantle.php';
-}
-tests_add_filter( 'muplugins_loaded', __NAMESPACE__  . '\_manually_load_plugin' );
-
-require_once __DIR__ . '/../vendor/autoload.php';
-
 define( 'MANTLE_PHPUNIT_INCLUDES_PATH', __DIR__ . '/includes' );
 define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 
-require $_tests_dir . '/includes/bootstrap.php';
+mantle_tests_install();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,4 @@ define( 'MULTISITE', true );
 define( 'MANTLE_PHPUNIT_INCLUDES_PATH', __DIR__ . '/includes' );
 define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 
-mantle_tests_install();
+\Mantle\Framework\Testing\install();

--- a/tests/config/test-repository.php
+++ b/tests/config/test-repository.php
@@ -13,7 +13,7 @@ class Test_Repository extends TestCase {
 	/**
 	 * Setup the unit test.
 	 */
-	protected function setUp() {
+	protected function setUp(): void {
 		$this->repository = new Repository(
 			[
 				'foo' => 'bar',

--- a/tests/database/model/registration/test-register-post-type.php
+++ b/tests/database/model/registration/test-register-post-type.php
@@ -12,6 +12,11 @@ use Mantle\Framework\REST_API\Registered_REST_Field;
 use Mantle\Framework\Testing\Framework_Test_Case;
 
 class Test_Register_Post_Type extends Framework_Test_Case {
+	protected function setUp(): void {
+		parent::setUp();
+		remove_all_actions( 'init' );
+	}
+
 	protected function tearDown(): void {
 		parent::tearDown();
 		m::close();

--- a/tests/database/model/registration/test-register-taxonomy.php
+++ b/tests/database/model/registration/test-register-taxonomy.php
@@ -7,6 +7,11 @@ use Mantle\Framework\Testing\Framework_Test_Case;
 use Mockery as m;
 
 class Test_Register_Taxonomy extends Framework_Test_Case {
+	protected function setUp(): void {
+		parent::setUp();
+		remove_all_actions( 'init' );
+	}
+
 	protected function tearDown(): void {
 		parent::tearDown();
 		m::close();

--- a/tests/database/query/test-paginator.php
+++ b/tests/database/query/test-paginator.php
@@ -107,10 +107,10 @@ class Test_Paginator extends Framework_Test_Case {
 			$render    = (string) $paginator->render();
 
 			if ( $i > 2 ) {
-				$this->assertContains( '<li><a href="/?page=' . ( $i - 1 ) . '" rel="prev">Previous</a></li>', $render );
+				$this->assertStringContainsString( '<li><a href="/?page=' . ( $i - 1 ) . '" rel="prev">Previous</a></li>', $render );
 			}
 
-			$this->assertContains( '<li><a href="/?page=' . ( $i + 1 ) .'" rel="next">Next</a></li>', $render );
+			$this->assertStringContainsString( '<li><a href="/?page=' . ( $i + 1 ) .'" rel="next">Next</a></li>', $render );
 		}
 	}
 
@@ -135,23 +135,23 @@ class Test_Paginator extends Framework_Test_Case {
 			// On the last page there should be no valid next link.
 			if ( $i >= $max_pages ) {
 				$this->assertFalse( $paginator->has_more() );
-				$this->assertContains( '<li class="disabled" aria-disabled="true"><span>&rsaquo;</span></li>', $render );
+				$this->assertStringContainsString( '<li class="disabled" aria-disabled="true"><span>&rsaquo;</span></li>', $render );
 			} else {
 				$this->assertTrue( $paginator->has_more() );
 
 				if ( $paginator->has_more() ) {
-					$this->assertContains( '<li><a href="' . $paginator->next_url() . '" rel="next">&rsaquo;</a></li>', $render );
+					$this->assertStringContainsString( '<li><a href="' . $paginator->next_url() . '" rel="next">&rsaquo;</a></li>', $render );
 				}
 			}
 
 			// On page one the previous link should be disabled.
 			if ( 1 === $i ) {
-				$this->assertContains( '<li class="disabled" aria-disabled="true"><span>&lsaquo;</span></li>', $render );
+				$this->assertStringContainsString( '<li class="disabled" aria-disabled="true"><span>&lsaquo;</span></li>', $render );
 			} else {
-				$this->assertContains( '<li><a href="' . $paginator->previous_url() . '" rel="prev">&lsaquo;</a></li>', $render );
+				$this->assertStringContainsString( '<li><a href="' . $paginator->previous_url() . '" rel="prev">&lsaquo;</a></li>', $render );
 
 				if ( $paginator->has_more() ) {
-					$this->assertContains( '<li><a href="/?page=' . ( $i + 1 ) . '"', $render );
+					$this->assertStringContainsString( '<li><a href="/?page=' . ( $i + 1 ) . '"', $render );
 				}
 			}
 		}

--- a/tests/events/test-wordpress-action-dispatcher.php
+++ b/tests/events/test-wordpress-action-dispatcher.php
@@ -40,7 +40,7 @@ class Test_WordPress_Action_Dispatcher extends Framework_Test_Case {
 
 		do_action( 'test_action_handler', $_SERVER['__action_value'] );
 
-		$this->assertInternalType( 'array', $_SERVER['__action_value'] );
+		$this->assertIsArray( $_SERVER['__action_value'] );
 	}
 
 	public function test_action_handler_non_builtin_typecast() {
@@ -72,7 +72,7 @@ class Test_WordPress_Action_Dispatcher extends Framework_Test_Case {
 
 		do_action( 'test_action_handler_non_builtin_typecast_to_array', $_SERVER['__action_value'] );
 
-		$this->assertInternalType( 'array', $_SERVER['__action_value'] );
+		$this->assertIsArray( $_SERVER['__action_value'] );
 
 		// Assert that it converted it to an array of values.
 		$this->assertEquals( [ 1, 2, 3 ], $_SERVER['__action_value'] );
@@ -130,7 +130,7 @@ class Test_WordPress_Action_Dispatcher extends Framework_Test_Case {
 		$d->listen(
 			'event-typehint:WP_Query',
 			function( $arg, $parameter ) {
-				$this->assertInternalType( 'array', $arg );
+				$this->assertIsArray( $arg );
 				$this->assertInstanceOf( ReflectionParameter::class, $parameter );
 
 				$instance = new WP_Query();

--- a/tests/framework/testing/test-core-test-shim.php
+++ b/tests/framework/testing/test-core-test-shim.php
@@ -20,7 +20,7 @@ class Test_Core_Test_Shim extends Framework_Test_Case {
 
 		$this->assertCount( 10, $posts );
 		foreach ( $posts as $post_id ) {
-			$this->assertInternalType( 'int', $post_id );
+			$this->assertIsInt( $post_id );
 		}
 
 		$this->assertEquals( 'draft', get_post_status( array_shift( $posts ) ) );
@@ -59,7 +59,7 @@ class Test_Core_Test_Shim extends Framework_Test_Case {
 
 		$object_ids = static::factory()->$property->create_many( 10 );
 		foreach ( $object_ids as $object_id ) {
-			$this->assertInternalType( 'int', $object_id );
+			$this->assertIsInt( $object_id );
 		}
 
 		$this->assertCount( 10, $object_ids );

--- a/tests/framework/view/test-blade-views.php
+++ b/tests/framework/view/test-blade-views.php
@@ -18,19 +18,19 @@ class Test_Blade_Views extends Framework_Test_Case {
 	}
 
 	public function test_if_else() {
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'True!',
 			(string) view( '@blade/if-else', [ 'should_if' => true ] ),
 		);
 
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'False',
 			(string) view( '@blade/if-else', [ 'should_if' => false ] ),
 		);
 	}
 
 	public function test_include() {
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'child',
 			(string) view( '@blade/parent' )
 		);

--- a/tests/framework/view/test-php-views.php
+++ b/tests/framework/view/test-php-views.php
@@ -50,29 +50,29 @@ class Test_Php_Views extends Framework_Test_Case {
 
 	public function test_basic_load() {
 		$contents = (string) view( 'basic' );
-		$this->assertContains( 'Template loaded: successfully', $contents );
+		$this->assertStringContainsString( 'Template loaded: successfully', $contents );
 	}
 
 	public function test_basic_load_name() {
 		$contents = (string) view( 'basic', 'variant' );
-		$this->assertContains( 'Variant loaded: successfully', $contents );
+		$this->assertStringContainsString( 'Variant loaded: successfully', $contents );
 	}
 
 	public function test_basic_load_name_fallback() {
 		$contents = (string) view( 'basic', 'phony' );
-		$this->assertContains( 'Template loaded: successfully', $contents );
+		$this->assertStringContainsString( 'Template loaded: successfully', $contents );
 	}
 
 	public function test_basic_var() {
 		$test = wp_rand();
 		$contents = (string) view( 'basic', [ 'custom_var' => $test ] );
-		$this->assertContains( "Template loaded: {$test}", $contents );
+		$this->assertStringContainsString( "Template loaded: {$test}", $contents );
 	}
 
 	public function test_parent_child_load() {
 		$contents = (string) view( 'parent' );
-		$this->assertContains( 'Parent loaded: successfully', $contents );
-		$this->assertContains( 'Child loaded: successfully', $contents );
+		$this->assertStringContainsString( 'Parent loaded: successfully', $contents );
+		$this->assertStringContainsString( 'Child loaded: successfully', $contents );
 	}
 
 	public function test_iterate() {
@@ -83,7 +83,7 @@ class Test_Php_Views extends Framework_Test_Case {
 		];
 		$contents = iterate( $items, 'iterate-item' );
 		foreach ( $items as $key => $value ) {
-			$this->assertContains( "Item {$key}: {$value}", $contents );
+			$this->assertStringContainsString( "Item {$key}: {$value}", $contents );
 		}
 	}
 
@@ -95,7 +95,7 @@ class Test_Php_Views extends Framework_Test_Case {
 		];
 		$contents = iterate( $items, 'iterate-item' );
 		foreach ( $items as $key => $value ) {
-			$this->assertContains( "Item {$key}: {$value}", $contents );
+			$this->assertStringContainsString( "Item {$key}: {$value}", $contents );
 		}
 	}
 
@@ -109,7 +109,7 @@ class Test_Php_Views extends Framework_Test_Case {
 		$contents = loop( $post_ids, 'loop-post' );
 
 		foreach ( $post_ids as $key => $post_id ) {
-			$this->assertContains( "Post {$key}: {$post_id}", $contents );
+			$this->assertStringContainsString( "Post {$key}: {$post_id}", $contents );
 		}
 	}
 
@@ -143,7 +143,7 @@ class Test_Php_Views extends Framework_Test_Case {
 
 		$contents = loop( new \WP_Query( 'orderby=date&order=desc&meta_key=loop_query&meta_value=1' ), 'loop-post' );
 		foreach ( $posts as $key => $post_id ) {
-			$this->assertContains( "Post {$key}: {$post_id}", $contents );
+			$this->assertStringContainsString( "Post {$key}: {$post_id}", $contents );
 		}
 	}
 
@@ -162,7 +162,7 @@ class Test_Php_Views extends Framework_Test_Case {
 
 		$contents = loop( new \WP_Query( 'year=2015' ), 'loop-post' );
 		foreach ( [ 1, 2, 3 ] as $i => $key ) {
-			$this->assertContains( "Post {$i}: {$posts[ $key ]}", $contents );
+			$this->assertStringContainsString( "Post {$i}: {$posts[ $key ]}", $contents );
 		}
 
 		$this->assertSame( $posts[0], get_the_ID() );
@@ -176,7 +176,7 @@ class Test_Php_Views extends Framework_Test_Case {
 		];
 		$contents = loop( $posts, 'loop-post' );
 		foreach ( $posts as $key => $post_id ) {
-			$this->assertContains( "Post {$key}: {$post_id}", $contents );
+			$this->assertStringContainsString( "Post {$key}: {$post_id}", $contents );
 		}
 	}
 

--- a/tests/support/providers/test-model-register-provider.php
+++ b/tests/support/providers/test-model-register-provider.php
@@ -14,6 +14,11 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class Test_Model_Service_Provider extends MockeryTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		remove_all_actions( 'init' );
+	}
+
 	public function test_register_model() {
 		$app    = new Application();
 		$config = new Repository();

--- a/tests/support/test-arr.php
+++ b/tests/support/test-arr.php
@@ -1246,8 +1246,4 @@ class SupportArrTest extends TestCase {
 		$this->assertEquals( [ $obj ], Arr::wrap( $obj ) );
 		$this->assertSame( $obj, Arr::wrap( $obj )[0] );
 	}
-
-	protected function assertIsArray( $value ) {
-		$this->assertInternalType( 'array', $value );
-	}
 }

--- a/tests/test-faker.php
+++ b/tests/test-faker.php
@@ -42,7 +42,7 @@ class Test_Faker extends \PHPUnit\Framework\TestCase {
 	public function test_paragraph() {
 		$block = $this->faker->paragraph_block();
 
-		$this->assertContains( '<!-- wp:paragraph -->' . PHP_EOL . '<p>', $block );
-		$this->assertContains( '</p>' . PHP_EOL . '<!-- /wp:paragraph -->', $block );
+		$this->assertStringContainsString( '<!-- wp:paragraph -->' . PHP_EOL . '<p>', $block );
+		$this->assertStringContainsString( '</p>' . PHP_EOL . '<!-- /wp:paragraph -->', $block );
 	}
 }

--- a/tests/test-service-provider.php
+++ b/tests/test-service-provider.php
@@ -8,6 +8,11 @@ use Mantle\Framework\Service_Provider;
 use Mockery as m;
 
 class Test_Service_Provider extends \Mockery\Adapter\Phpunit\MockeryTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		remove_all_actions( 'init' );
+	}
 
 	public function test_service_provider_registered() {
 		$service_provider = m::mock( Service_Provider::class )->makePartial();


### PR DESCRIPTION
Removes WordPress core unit test dependency

![bye](https://media1.tenor.com/images/ba3d706d4b0ee93d1dce8131bc6ba39f/tenor.gif?itemid=5788956)