### PR TITLE
Ensure typehinting a single model works

### DIFF
--- a/src/mantle/database/model/class-model.php
+++ b/src/mantle/database/model/class-model.php
@@ -468,12 +468,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	}
 
 	/**
-	 * Get the route key for the model.
+	 * Get the route key for models.
 	 *
 	 * @return string
 	 */
 	public function get_route_key_name(): string {
-		return $this->get_key_name();
+		return 'slug';
 	}
 
 	/**
@@ -515,7 +515,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 			return static::find( $value );
 		}
 
-		return $this->where( $key, $value )->first();
+		return static::query()->where( $key, $value )->first();
 	}
 
 	/**

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -389,7 +389,7 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 					$structure
 				);
 
-				$route_structure = str_replace( '{postname}', '{slug}', $structure );
+				$route_structure = str_replace( '{postname}', '{post}', $structure );
 			} else {
 				$route_structure = null;
 			}

--- a/src/mantle/database/query/class-post-query-builder.php
+++ b/src/mantle/database/query/class-post-query-builder.php
@@ -29,6 +29,7 @@ class Post_Query_Builder extends Builder {
 		'id'          => 'p',
 		'post_author' => 'author',
 		'post_name'   => 'name',
+		'slug'        => 'name',
 	];
 
 	/**

--- a/src/mantle/http/routing/trait-route-dependency-resolver.php
+++ b/src/mantle/http/routing/trait-route-dependency-resolver.php
@@ -51,9 +51,17 @@ trait Route_Dependency_Resolver {
 
 		$values = array_values( $parameters );
 
-		$skippable_value = new \stdClass();
+		$skippable_value   = new \stdClass();
+		$method_parameters = [];
+		$has_typehint      = false;
 
 		foreach ( $reflector->getParameters() as $key => $parameter ) {
+			if ( $parameter->getType() ) {
+				$has_typehint = true;
+			}
+
+			$method_parameters[] = $parameter->getName();
+
 			$instance = $this->transform_dependency( $parameter, $parameters, $skippable_value );
 
 			if ( $instance !== $skippable_value ) {
@@ -64,6 +72,14 @@ trait Route_Dependency_Resolver {
 				$parameter->isDefaultValueAvailable() ) {
 				$this->splice_into_parameters( $parameters, $key, $parameter->getDefaultValue() );
 			}
+		}
+
+		// Ensure the order of the parameters matches the order defined on the method.
+		if ( $has_typehint ) {
+			$parameters = array_replace(
+				array_flip( $method_parameters ),
+				$parameters,
+			);
 		}
 
 		return $parameters;

--- a/tests/framework/http/test-router.php
+++ b/tests/framework/http/test-router.php
@@ -205,6 +205,28 @@ class Test_Router extends Framework_Test_Case {
 		$this->assertSame( 'first_name-last_name', $router->dispatch( Request::create( 'names/first_name/last_name', 'GET' ) )->getContent() );
 	}
 
+	// Ensure that a route with multiple variables and a single type-hinted one
+	// works properly.
+	public function test_implicit_binding_multiple_variables() {
+		$router = $this->get_router();
+
+		$router->get(
+			'{year}/{month}/{day}/{post}',
+			array(
+				'middleware' => Substitute_Bindings::class,
+				'callback'   => function ( Routing_Test_Post_Model $post ) {
+					$this->assertInstanceOf( Routing_Test_Post_Model::class, $post );
+
+					return $post->name();
+				},
+			)
+		);
+
+		$post = static::factory()->post->create_and_get();
+
+		$this->assertSame( $post->post_title, $router->dispatch( Request::create( 'year/month/day/' . $post->post_name, 'GET' ) )->getContent() );
+	}
+
 	public function test_route_name_url() {
 		$router = $this->get_router();
 		$router->get(
@@ -291,4 +313,8 @@ class Routing_Test_User_Model extends Post {
 	public function firstOrFail() {
 		return $this;
 	}
+}
+
+class Routing_Test_Post_Model extends Post {
+	public static $object_name = 'post';
 }


### PR DESCRIPTION
Support a post controller with a single typehint on a route with multiple variables: `/{year}/{month}/{day}/{slug}/`

```php
class Post_Controller extends Controller {
	public function show( Post $post ) {
		// $post->id();
	}
}
```