### PR TITLE
Allow entity routes to setup the global post object and global variables

### DIFF
--- a/src/mantle/contracts/http/routing/interface-entity-router.php
+++ b/src/mantle/contracts/http/routing/interface-entity-router.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Entity_Router interface file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Contracts\Http\Routing;
+
+/**
+ * Entity Router Contract
+ */
+interface Entity_Router {
+	/**
+	 * Add an entity to the router.
+	 *
+	 * @param Router $router Router instance.
+	 * @param string $entity Entity class name.
+	 * @param string $controller Controller class name.
+	 * @return void
+	 */
+	public function add( Router $router, string $entity, string $controller ): void;
+}

--- a/src/mantle/database/model/class-permalink-generator.php
+++ b/src/mantle/database/model/class-permalink-generator.php
@@ -119,7 +119,12 @@ class Permalink_Generator {
 	 * @return string
 	 */
 	public function get_attribute( string $attribute ): string {
-		$value = $this->attributes[ $attribute ] ?? null;
+		$value = $this->attributes[ $attribute ] ?? $this->model->get( $attribute );
+
+		// Fallback to the model's slug when using the object name as an attribute.
+		if ( empty( $value ) && $attribute === $this->model::get_object_name() ) {
+			$value = $this->model->slug();
+		}
 
 		if ( ! $value && $this->model ) {
 			$value = $this->model[ $attribute ] ?? null;

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -218,4 +218,30 @@ class Term extends Model implements Core_Object, Updatable {
 	public function delete( bool $force = false ) {
 		\wp_delete_term( $this->id(), $this->taxonomy() );
 	}
+
+	/**
+	 * Get the registerable route for the model. By default this is set relative
+	 * the object's archive route with the object's slug.
+	 *
+	 *     /object_name/object_slug/
+	 *
+	 * @return string|null
+	 */
+	public static function get_route(): ?string {
+		$route_structure = static::get_archive_route() . '/{' . static::get_object_name() . '}/';
+
+		/**
+		 * Filter the route structure for a term handled through the entity router.
+		 *
+		 * @param string $route_structure Route structure.
+		 * @param string $object_name Taxonomy name.
+		 * @param string $object_class Model class name.
+		 */
+		return (string) apply_filters(
+			'mantle_entity_router_term_route',
+			$route_structure,
+			static::get_object_name(),
+			get_called_class()
+		);
+	}
 }

--- a/src/mantle/framework/class-application.php
+++ b/src/mantle/framework/class-application.php
@@ -344,19 +344,20 @@ class Application extends Container implements Application_Contract {
 	 */
 	protected function register_core_aliases() {
 		$core_aliases = [
-			'app'         => [ static::class, \Mantle\Contracts\Application::class ],
-			'config'      => [ \Mantle\Config\Repository::class, \Mantle\Contracts\Config\Repository::class ],
-			'events'      => [ \Mantle\Events\Dispatcher::class, \Mantle\Contracts\Events\Dispatcher::class ],
-			'files'       => [ \Mantle\Filesystem\Filesystem::class ],
-			'filesystem'  => [ \Mantle\Filesystem\Filesystem_Manager::class, \Mantle\Contracts\Filesystem\Filesystem_Manager::class ],
-			'log'         => [ \Mantle\Log\Log_Manager::class, \Psr\Log\LoggerInterface::class ],
-			'queue'       => [ \Mantle\Queue\Queue_Manager::class, \Mantle\Contracts\Queue\Queue_Manager::class ],
-			'redirect'    => [ \Mantle\Http\Routing\Redirector::class ],
-			'request'     => [ \Mantle\Http\Request::class, \Symfony\Component\HttpFoundation\Request::class ],
-			'router'      => [ \Mantle\Http\Routing\Router::class, \Mantle\Contracts\Http\Routing\Router::class ],
-			'url'         => [ \Mantle\Http\Routing\Url_Generator::class, \Mantle\Contracts\Http\Routing\Url_Generator::class ],
-			'view.loader' => [ \Mantle\Http\View\View_Finder::class, \Mantle\Contracts\Http\View\View_Finder::class ],
-			'view'        => [ \Mantle\Http\View\Factory::class, \Mantle\Contracts\Http\View\Factory::class ],
+			'app'           => [ static::class, \Mantle\Contracts\Application::class ],
+			'config'        => [ \Mantle\Config\Repository::class, \Mantle\Contracts\Config\Repository::class ],
+			'events'        => [ \Mantle\Events\Dispatcher::class, \Mantle\Contracts\Events\Dispatcher::class ],
+			'files'         => [ \Mantle\Filesystem\Filesystem::class ],
+			'filesystem'    => [ \Mantle\Filesystem\Filesystem_Manager::class, \Mantle\Contracts\Filesystem\Filesystem_Manager::class ],
+			'log'           => [ \Mantle\Log\Log_Manager::class, \Psr\Log\LoggerInterface::class ],
+			'queue'         => [ \Mantle\Queue\Queue_Manager::class, \Mantle\Contracts\Queue\Queue_Manager::class ],
+			'redirect'      => [ \Mantle\Http\Routing\Redirector::class ],
+			'request'       => [ \Mantle\Http\Request::class, \Symfony\Component\HttpFoundation\Request::class ],
+			'router'        => [ \Mantle\Http\Routing\Router::class, \Mantle\Contracts\Http\Routing\Router::class ],
+			'router.entity' => [ \Mantle\Http\Routing\Entity_Router::class, \Mantle\Contracts\Http\Routing\Entity_Router::class ],
+			'url'           => [ \Mantle\Http\Routing\Url_Generator::class, \Mantle\Contracts\Http\Routing\Url_Generator::class ],
+			'view.loader'   => [ \Mantle\Http\View\View_Finder::class, \Mantle\Contracts\Http\View\View_Finder::class ],
+			'view'          => [ \Mantle\Http\View\Factory::class, \Mantle\Contracts\Http\View\Factory::class ],
 		];
 
 		foreach ( $core_aliases as $key => $aliases ) {

--- a/src/mantle/framework/providers/class-routing-service-provider.php
+++ b/src/mantle/framework/providers/class-routing-service-provider.php
@@ -8,6 +8,7 @@
 namespace Mantle\Framework\Providers;
 
 use Mantle\Contracts\Http\Routing\Response_Factory as Response_Factory_Contract;
+use Mantle\Http\Routing\Entity_Router;
 use Mantle\Http\Routing\Redirector;
 use Mantle\Http\Routing\Response_Factory;
 use Mantle\Http\Routing\Router;
@@ -41,6 +42,13 @@ class Routing_Service_Provider extends Service_Provider {
 			function( $app ) {
 				return new Router( $app['events'], $app );
 			}
+		);
+
+		$this->app->singleton(
+			'router.entity',
+			function( $app ) {
+				return new Entity_Router( $app );
+			},
 		);
 	}
 

--- a/src/mantle/http/routing/class-entity-router.php
+++ b/src/mantle/http/routing/class-entity-router.php
@@ -187,7 +187,7 @@ class Entity_Router implements Entity_Router_Contract {
 		// Singular endpoint.
 		$single_route = $entity::get_route();
 
-		if ( $single_route ) {
+		if ( $single_route && method_exists( $controller, 'show' ) ) {
 			$router
 				->get( trailingslashit( $single_route ), [ $controller, 'show' ] )
 				->addOptions(
@@ -200,9 +200,19 @@ class Entity_Router implements Entity_Router_Contract {
 
 		$archive_route = $entity::get_archive_route();
 
-		if ( $archive_route ) {
+		if ( $archive_route && method_exists( $controller, 'index' ) ) {
 			$router
 				->get( trailingslashit( $archive_route ), [ $controller, 'index' ] )
+				->addOptions(
+					[
+						'entity_router' => 'index',
+						'entity'        => $entity,
+					]
+				);
+
+			// Add a paginated endpoint for the archive.
+			$router
+				->get( trailingslashit( $archive_route ) . 'page/{page}/', [ $controller, 'index' ] )
 				->addOptions(
 					[
 						'entity_router' => 'index',

--- a/src/mantle/http/routing/class-implicit-route-binding.php
+++ b/src/mantle/http/routing/class-implicit-route-binding.php
@@ -30,8 +30,7 @@ class Implicit_Route_Binding {
 	 * @throws Model_Not_Found_Exception Thrown on missing model.
 	 */
 	public static function resolve_for_route( Container $container, Request $request ) {
-		$route = $request->get_route();
-
+		$route      = $request->get_route();
 		$parameters = $request->get_route_parameters()->all();
 
 		foreach ( $route->get_signature_parameters( Url_Routable::class ) as $parameter ) {

--- a/src/mantle/http/routing/class-router.php
+++ b/src/mantle/http/routing/class-router.php
@@ -532,7 +532,7 @@ class Router implements Router_Contract {
 	 * @return void
 	 */
 	public function model( string $model, string $controller ): void {
-		Entity_Router::add( $this, $model, $controller );
+		$this->container->make( Entity_Router::class )->add( $this, $model, $controller );
 	}
 
 	/**

--- a/src/mantle/http/routing/events/class-bindings-substituted.php
+++ b/src/mantle/http/routing/events/class-bindings-substituted.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Bindings_Substituted class file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Http\Routing\Events;
+
+use Mantle\Http\Request;
+
+/**
+ * Event for when bindings are substituted for a request.
+ */
+class Bindings_Substituted {
+	/**
+	 * Request instance.
+	 *
+	 * @var Request
+	 */
+	public $request;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Request $request Request instance.
+	 */
+	public function __construct( Request $request ) {
+		$this->request = $request;
+	}
+}

--- a/src/mantle/http/routing/middleware/class-substitute-bindings.php
+++ b/src/mantle/http/routing/middleware/class-substitute-bindings.php
@@ -10,6 +10,9 @@ namespace Mantle\Http\Routing\Middleware;
 use Closure;
 use Mantle\Contracts\Http\Routing\Router;
 use Mantle\Http\Request;
+use Mantle\Http\Routing\Events\Bindings_Substituted;
+
+use function Mantle\Framework\Helpers\event;
 
 /**
  * Substitute parameters for the route with dynamically binded models.
@@ -41,6 +44,8 @@ class Substitute_Bindings {
 	public function handle( Request $request, Closure $next ) {
 		$this->router->substitute_bindings( $request );
 		$this->router->substitute_implicit_bindings( $request );
+
+		event( new Bindings_Substituted( $request ) );
 
 		return $next( $request );
 	}

--- a/src/mantle/testing/concerns/trait-create-application.php
+++ b/src/mantle/testing/concerns/trait-create-application.php
@@ -64,6 +64,7 @@ trait Create_Application {
 	protected function get_application_config(): array {
 		return [
 			'app'        => [
+				'debug'     => true,
 				'providers' => [
 					\Mantle\Framework\Providers\Model_Service_Provider::class,
 					\Mantle\Framework\Providers\Queue_Service_Provider::class,

--- a/tests/http/routing/test-post-model-routing.php
+++ b/tests/http/routing/test-post-model-routing.php
@@ -33,7 +33,11 @@ class Test_Post_Model_Routing extends Framework_Test_Case {
 			]
 		);
 
-		$this->get( $post )->assertSee( $post->slug() );
+		$this
+			->get( $post )
+			->assertSee( $post->slug() )
+			->assertQueriedObject( get_post( $post->id() ) )
+			->assertQueryTrue( 'is_singular', 'is_single' );
 	}
 
 	public function test_custom_post_type() {

--- a/tests/http/routing/test-post-model-routing.php
+++ b/tests/http/routing/test-post-model-routing.php
@@ -7,6 +7,8 @@ use Mantle\Database\Model\Post;
 use Mantle\Database\Model\Registration\Register_Post_Type;
 use Mantle\Facade\Route;
 use Mantle\Http\Controller;
+use Mantle\Http\Routing\Middleware\Substitute_Bindings;
+use Mantle\Http\Routing\Middleware\Wrap_Template;
 use Mantle\Testing\Framework_Test_Case;
 
 class Test_Post_Model_Routing extends Framework_Test_Case {
@@ -20,7 +22,9 @@ class Test_Post_Model_Routing extends Framework_Test_Case {
 	public function test_post_type() {
 		Testable_Post_Model::boot_if_not_booted();
 
-		Route::model( Testable_Post_Model::class, Testable_Post_Model_Controller::class );
+		Route::middleware( [ Substitute_Bindings::class, Wrap_Template::class ] )->group( function () {
+			Route::model( Testable_Post_Model::class, Testable_Post_Model_Controller::class );
+		} );
 
 		$post = Testable_Post_Model::create(
 			[
@@ -29,10 +33,7 @@ class Test_Post_Model_Routing extends Framework_Test_Case {
 			]
 		);
 
-		$permalink = get_permalink( $post->ID );
-		$this->assertEquals( home_url( '/blog/' . $post->slug() ), $permalink );
-
-		$this->get( $permalink )->assertContent( $post->slug() );
+		$this->get( $post )->assertSee( $post->slug() );
 	}
 
 	public function test_custom_post_type() {
@@ -68,18 +69,12 @@ class Test_Post_Model_Routing extends Framework_Test_Case {
 }
 
 class Testable_Post_Model extends Post {
-	use Custom_Post_Permalink;
-
 	public static $object_name = 'post';
-
-	public static function get_route(): ?string {
-		return '/blog/{slug}';
-	}
 }
 
 class Testable_Post_Model_Controller extends Controller {
-	public function show( $slug ) {
-		return $slug;
+	public function show( Testable_Post_Model $post ) {
+		return $post->slug();
 	}
 }
 


### PR DESCRIPTION
Allows an entity route to properly setup the global post object and template tags (`is_singular`, `is_archive`, etc.)

<img width="463" alt="Screen Shot 2021-10-26 at 4 05 22 PM" src="https://user-images.githubusercontent.com/346399/138952757-4e271277-32e3-4c6a-82b5-648d6c8ca5b6.png">

Fixes #144 #154