### PR TITLE
Update stubs to match WP doc standards

### DIFF
--- a/src/mantle/framework/console/generators/stubs/controller.stub
+++ b/src/mantle/framework/console/generators/stubs/controller.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package {{ namespace }}
  */
@@ -10,7 +10,7 @@ namespace App\Http\Controller;
 use Mantle\Http\Controller;
 
 /**
- * {{ class }} Controller
+ * {{ class }} Controller.
  */
 class {{ class }} extends Controller {
 	//

--- a/src/mantle/framework/console/generators/stubs/generator.stub
+++ b/src/mantle/framework/console/generators/stubs/generator.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }}_Make_Command class file.
+ * {{ class }}_Make_Command class file
  *
  * @package {{ namespace }}
  */
@@ -10,7 +10,7 @@ namespace App\Console\Generators;
 use Mantle\Framework\Console\Generators\Stub_Generator_Command;
 
 /**
- * {{ class }} Generator Command
+ * {{ class }} Generator Command.
  */
 class {{ class }}_Make_Command extends Stub_Generator_Command {
 	/**

--- a/src/mantle/framework/console/generators/stubs/job.stub
+++ b/src/mantle/framework/console/generators/stubs/job.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package Mantle
  */
@@ -13,7 +13,7 @@ use Mantle\Queue\Dispatchable;
 use Mantle\Queue\Queueable;
 
 /**
- * {{ class }}
+ * {{ class }} Job.
  */
 class {{ class }} implements Job, Can_Queue {
 	use Queueable, Dispatchable;

--- a/src/mantle/framework/console/generators/stubs/middleware.stub
+++ b/src/mantle/framework/console/generators/stubs/middleware.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package {{ namespace }}
  */
@@ -10,7 +10,7 @@ namespace App\Http\Middleware;
 use Closure;
 
 /**
- * {{ class }} Middleware
+ * {{ class }} Middleware.
  */
 class {{ class }} {
 	/**

--- a/src/mantle/framework/console/generators/stubs/model-post-registrable.stub
+++ b/src/mantle/framework/console/generators/stubs/model-post-registrable.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package {{ namespace }}
  */

--- a/src/mantle/framework/console/generators/stubs/model-post.stub
+++ b/src/mantle/framework/console/generators/stubs/model-post.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package {{ namespace }}
  */

--- a/src/mantle/framework/console/generators/stubs/model-term-registrable.stub
+++ b/src/mantle/framework/console/generators/stubs/model-term-registrable.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package {{ namespace }}
  */

--- a/src/mantle/framework/console/generators/stubs/model-term.stub
+++ b/src/mantle/framework/console/generators/stubs/model-term.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package {{ namespace }}
  */

--- a/src/mantle/framework/console/generators/stubs/provider.stub
+++ b/src/mantle/framework/console/generators/stubs/provider.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package {{ namespace }}
  */
@@ -10,7 +10,7 @@ namespace {{ namespace }};
 use Mantle\Support\Service_Provider;
 
 /**
- * {{ class }} Service Provider
+ * {{ class }} Service Provider.
  */
 class {{ class }} extends Service_Provider {
 

--- a/src/mantle/framework/console/generators/stubs/seeder.stub
+++ b/src/mantle/framework/console/generators/stubs/seeder.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} class file.
+ * {{ class }} class file
  *
  * @package {{ namespace }}
  */
@@ -11,7 +11,7 @@ use Mantle\Database\Seeder;
 use function Mantle\Framework\Helpers\factory;
 
 /**
- * {{ class }} Seeder
+ * {{ class }} Seeder.
  */
 class {{ class }} extends Seeder {
 	/**

--- a/src/mantle/framework/console/generators/stubs/stub.stub
+++ b/src/mantle/framework/console/generators/stubs/stub.stub
@@ -1,6 +1,6 @@
 <?php
 /**
- * {{ class }} file.
+ * {{ class }} file
  *
  * @package {{ namespace }}
  */

--- a/src/mantle/framework/console/generators/stubs/test.stub
+++ b/src/mantle/framework/console/generators/stubs/test.stub
@@ -10,7 +10,7 @@ namespace {{ namespace }};
 use App\Tests\Test_Case;
 
 /**
- * Base Test Case that each Test Case should extend.
+ * {{ class }} Test Case.
  */
 class Test_{{ class }} extends Test_Case {
   public function test_example() {


### PR DESCRIPTION
[File header summaries shouldn't have periods ](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#6-file-headers) and [class docblocks should](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#2-classes)