### PR TITLE
Add dd/dump commands to test response

### DIFF
--- a/src/mantle/testing/class-test-response.php
+++ b/src/mantle/testing/class-test-response.php
@@ -12,6 +12,7 @@ use DOMXPath;
 use Exception;
 use Mantle\Support\Arr;
 use Mantle\Support\Str;
+use Mantle\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 use function Mantle\Framework\Helpers\data_get;
@@ -20,6 +21,7 @@ use function Mantle\Framework\Helpers\data_get;
  * Faux "Response" class for unit testing.
  */
 class Test_Response {
+	use Macroable;
 
 	/**
 	 * Response headers.
@@ -753,5 +755,57 @@ class Test_Response {
 		PHPUnit::assertTrue( false === $nodes || 0 === $nodes->length );
 
 		return $this;
+	}
+
+	/**
+	 * Dump the contents of the response to the screen.
+	 *
+	 * @return static
+	 */
+	public function dump() {
+		$content = $this->get_content();
+
+		$json = json_decode( $content );
+
+		if ( json_last_error() === JSON_ERROR_NONE ) {
+			$content = $json;
+		}
+
+		dump( $content );
+
+		return $this;
+	}
+
+	/**
+	 * Dump the headers of the response to the screen.
+	 *
+	 * @return static
+	 */
+	public function dump_headers() {
+		dump( $this->headers );
+
+		return $this;
+	}
+
+	/**
+	 * Dump the content from the response and end the script.
+	 *
+	 * @return void
+	 */
+	public function dd() {
+		$this->dump();
+
+		exit( 1 );
+	}
+
+	/**
+	 * Dump the headers from the response and end the script.
+	 *
+	 * @return void
+	 */
+	public function dd_headers() {
+		$this->dump_headers();
+
+		exit( 1 );
 	}
 }


### PR DESCRIPTION
Add a method to dump/debug the response from the test response.

```php
class Example_Test {
	public function test_rest_api_route_error() {
		$this->get( rest_url( '/an/unknown/route' ) )
			->assertStatus( 404 )
			->dump_headers()
			->dd();
	}
}
```
<img width="585" alt="Screen Shot 2021-12-30 at 2 29 05 PM" src="https://user-images.githubusercontent.com/346399/147782496-26b97fce-c5f0-4945-856f-c53daed39df4.png">

