### PR TITLE
Using alleyinteractive/wordpress-autoloader for autoloading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,9 +75,6 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Validate Composer
-        run: composer validate --strict
-
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,9 @@ jobs:
           tools: composer:v2
           coverage: none
 
+      - name: Validate Composer
+        run: composer validate --strict
+
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "alleyinteractive/composer-wordpress-autoloader": "dev-test-exception",
         "alleyinteractive/wp-asset-manager": "^0.1",
         "dragonmantank/cron-expression": "^3.1",
         "fakerphp/faker": "^1.16",
@@ -21,7 +22,7 @@
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.53",
         "nette/php-generator": "^3.6",
-        "psr/container": "^1.1.1|^2.0.1",
+        "psr/container": "^1.1.1 || ^2.0.1",
         "symfony/finder": "^5.3",
         "symfony/http-foundation": "^5.3",
         "symfony/http-kernel": "^5.3",
@@ -36,9 +37,13 @@
         "alleyinteractive/alley-coding-standards": "^0.3.0",
         "mockery/mockery": "^1.3",
         "nunomaduro/collision": "^5.0",
-        "phpunit/phpunit": "^8.5.8|^9.3.3"
+        "phpunit/phpunit": "^8.5.8 || ^9.3.3"
     },
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "alleyinteractive/composer-wordpress-autoloader": true
+        },
         "apcu-autoloader": true,
         "optimize-autoloader": true,
         "sort-packages": true
@@ -49,12 +54,25 @@
             "src/mantle/testing/autoload.php",
             "src/mantle/framework/helpers.php",
             "src/mantle/framework/helpers/helpers.php"
-        ]
+        ],
+        "wordpress": {
+          "Mantle\\": "src/mantle/"
+        }
+    },
+    "autoload-dev": {
+      "wordpress": {
+        "Mantle\\Tests\\": "tests/"
+      }
     },
     "scripts": {
+        "lint": "@phpcs",
+        "phpcbf": "phpcbf --standard=./phpcs.xml .",
         "phpcs": "phpcs --standard=./phpcs.xml .",
         "phpcs-modified": "./bin/phpcs-modified-files.sh",
-        "phpcbf": "phpcbf --standard=./phpcs.xml .",
-        "phpunit": "phpunit"
+        "phpunit": "phpunit",
+        "test": [
+            "@phpcs",
+            "@phpunit"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "alleyinteractive/composer-wordpress-autoloader": "dev-test-exception",
+        "alleyinteractive/composer-wordpress-autoloader": "^0.2",
         "alleyinteractive/wp-asset-manager": "^0.1",
         "dragonmantank/cron-expression": "^3.1",
         "fakerphp/faker": "^1.16",

--- a/composer.json
+++ b/composer.json
@@ -54,14 +54,16 @@
             "src/mantle/testing/autoload.php",
             "src/mantle/framework/helpers.php",
             "src/mantle/framework/helpers/helpers.php"
-        ],
-        "wordpress": {
-          "Mantle\\": "src/mantle/"
-        }
+        ]
     },
-    "autoload-dev": {
-      "wordpress": {
-        "Mantle\\Tests\\": "tests/"
+    "extra": {
+      "wordpress-autoloader": {
+        "autoload": {
+          "Mantle\\": "src/mantle/"
+        },
+        "autoload-dev": {
+          "Mantle\\Tests\\": "tests/"
+        }
       }
     },
     "scripts": {

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -19,6 +19,11 @@ namespace Mantle;
  * @return \Closure Function for spl_autoload_register().
  */
 function generate_wp_autoloader( string $namespace, string $root_path ): callable {
+	trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		'Mantle\generate_wp_autoloader() is deprecated. Use alleyinteractive/wordpress-autoloader instead.',
+		E_USER_DEPRECATED,
+	);
+
 	return \Alley_Interactive\Autoloader\Autoloader::generate(
 		$namespace,
 		$root_path,

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -10,66 +10,17 @@ namespace Mantle;
 /**
  * Generate an autoloader for the WordPress file naming conventions.
  *
+ * @deprecated Use https://github.com/alleyinteractive/wordpress-autoloader or
+ * https://github.com/alleyinteractive/composer-wordpress-autoloader instead,
+ * will be removed shortly.
+ *
  * @param string $namespace Namespace to autoload.
  * @param string $root_path Path in which to look for files.
  * @return \Closure Function for spl_autoload_register().
  */
 function generate_wp_autoloader( string $namespace, string $root_path ): callable {
-	// Ensure consistent root.
-	$root_path = \rtrim( $root_path, \DIRECTORY_SEPARATOR ) . \DIRECTORY_SEPARATOR;
-
-	return function ( $classname ) use ( $namespace, $root_path ) {
-		// Ignore if the base namespace doesn't match.
-		if ( 0 !== \strpos( $classname, $namespace ) ) {
-			return;
-		}
-
-		// Remove the namespace.
-		$classname = \preg_replace( '#^' . \preg_quote( $namespace, '#' ) . '#', '', $classname );
-		$classname = \ltrim( $classname, '\\' );
-
-		// Convert to segments.
-		$classname = \strtolower( $classname );
-		$classname = \str_replace( [ '\\', '_' ], [ '/', '-' ], $classname );
-		$classes   = \explode( '/', $classname );
-
-		// Retrieve the class name (last item).
-		$class = \array_pop( $classes );
-
-		// Build the base path.
-		$base_path = \implode( '/', $classes );
-
-		// Support multiple locations since the class could be a class, trait or interface.
-		$paths = [
-			'%1$s/class-%2$s.php',
-			'%1$s/trait-%2$s.php',
-			'%1$s/interface-%2$s.php',
-		];
-
-		/*
-		 * Attempt to find the file by looping through the various paths.
-		 *
-		 * Autoloading a class will also cause a trait or interface with the
-		 * same fully qualified name to be autoloaded, as it's impossible to
-		 * tell which was requested.
-		 */
-		foreach ( $paths as $path ) {
-			$path = $root_path . \sprintf( $path, $base_path, $class );
-
-			if ( \file_exists( $path ) ) {
-				// Path is defined by this file and validated.
-				require_once $path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
-				return;
-			}
-		}
-	};
-}
-
-// Generate the autoloader for the Framework.
-try {
-	spl_autoload_register(
-		generate_wp_autoloader( __NAMESPACE__, __DIR__ . '/mantle' )
+	return \Alley_Interactive\Autoloader\Autoloader::generate(
+		$namespace,
+		$root_path,
 	);
-} catch ( \Exception $e ) {
-	\wp_die( $e->getMessage() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,16 +7,10 @@
 
 namespace Mantle\Tests;
 
-use function Mantle\generate_wp_autoloader;
+require_once __DIR__ . '/../vendor/wordpress-autoload.php';
 
 defined( 'MULTISITE' ) || define( 'MULTISITE', true );
 define( 'MANTLE_PHPUNIT_INCLUDES_PATH', __DIR__ . '/includes' );
 define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
-
-// Add an autoloader for the fixtures in the '/tests/' folder.
-spl_autoload_register( generate_wp_autoloader(
-	__NAMESPACE__,
-	__DIR__,
-) );
 
 \Mantle\Testing\install();


### PR DESCRIPTION
- https://github.com/alleyinteractive/wordpress-autoloader
- https://github.com/alleyinteractive/composer-wordpress-autoloader

- [x] Track the 0.1.1 release of alleyinteractive/composer-wordpress-autoloader after https://github.com/alleyinteractive/composer-wordpress-autoloader/pull/2 is merged.