### PR TITLE
Create new Testkit cases: Integration and Unit Test

### DIFF
--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -90,7 +90,7 @@ abstract class Test_Case extends BaseTestCase {
 
 		if ( ! empty( static::$test_uses ) ) {
 
-			self::get_test_case_traits()
+			static::get_test_case_traits()
 				->each(
 					function( $trait ) {
 						$method = strtolower( class_basename( $trait ) ) . '_set_up_before_class';

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -146,7 +146,7 @@ abstract class Test_Case extends BaseTestCase {
 		static::clean_up_global_scope();
 
 		// Boot traits on the test case.
-		self::get_test_case_traits()
+		static::get_test_case_traits()
 			->each(
 				function( $trait ) {
 					$method = strtolower( class_basename( $trait ) ) . '_set_up';

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -88,7 +88,7 @@ abstract class Test_Case extends BaseTestCase {
 			static::refresh_database_pre_setup_before_class();
 		}
 
-		if( ! empty( static::$test_uses ) ) {
+		if ( ! empty( static::$test_uses ) ) {
 
 			self::get_test_case_traits()
 				->each(
@@ -96,7 +96,7 @@ abstract class Test_Case extends BaseTestCase {
 						$method = strtolower( class_basename( $trait ) ) . '_set_up_before_class';
 
 						if ( method_exists( static::class, $method ) ) {
-							call_user_func([ static::class, $method ]);
+							call_user_func( [ static::class, $method ] );
 						}
 					}
 				);

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -171,7 +171,7 @@ abstract class Test_Case extends BaseTestCase {
 		// phpcs:disable WordPress.WP.GlobalVariablesOverride,WordPress.NamingConventions.PrefixAllGlobals
 		global $wp_query, $wp;
 
-		self::get_test_case_traits()
+		static::get_test_case_traits()
 			// Tearing down requires performing priority traits in opposite order.
 			->reverse()
 			->each(

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -88,6 +88,20 @@ abstract class Test_Case extends BaseTestCase {
 			static::refresh_database_pre_setup_before_class();
 		}
 
+		if( ! empty( static::$test_uses ) ) {
+
+			self::get_test_case_traits()
+				->each(
+					function( $trait ) {
+						$method = strtolower( class_basename( $trait ) ) . '_set_up_before_class';
+
+						if ( method_exists( static::class, $method ) ) {
+							call_user_func([ static::class, $method ]);
+						}
+					}
+				);
+		}
+
 		parent::setUpBeforeClass();
 
 		if ( isset( static::$test_uses[ Refresh_Database::class ] ) ) {
@@ -132,7 +146,7 @@ abstract class Test_Case extends BaseTestCase {
 		static::clean_up_global_scope();
 
 		// Boot traits on the test case.
-		$this->get_test_case_traits()
+		self::get_test_case_traits()
 			->each(
 				function( $trait ) {
 					$method = strtolower( class_basename( $trait ) ) . '_set_up';
@@ -157,7 +171,7 @@ abstract class Test_Case extends BaseTestCase {
 		// phpcs:disable WordPress.WP.GlobalVariablesOverride,WordPress.NamingConventions.PrefixAllGlobals
 		global $wp_query, $wp;
 
-		$this->get_test_case_traits()
+		self::get_test_case_traits()
 			// Tearing down requires performing priority traits in opposite order.
 			->reverse()
 			->each(
@@ -217,7 +231,7 @@ abstract class Test_Case extends BaseTestCase {
 	 *
 	 * @return Collection
 	 */
-	protected function get_test_case_traits(): Collection {
+	protected static function get_test_case_traits(): Collection {
 		// Boot traits on the test case.
 		$traits = array_values( class_uses_recursive( static::class ) );
 

--- a/src/mantle/testkit/class-integration-test-case.php
+++ b/src/mantle/testkit/class-integration-test-case.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Integration_Test_Case class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testkit;
+
+use Mantle\Testkit\Concerns\Installs_WordPress;
+use Mantle\Testkit\Test_Case as Testing_Test_Case;
+
+/**
+ * Testkit Integration Test Case
+ *
+ * For use in integration tests. Will install WordPress during Test Class
+ * set up process.
+ */
+abstract class Test_Case extends Testing_Test_Case {
+	use Installs_WordPress;
+}

--- a/src/mantle/testkit/class-integration-test-case.php
+++ b/src/mantle/testkit/class-integration-test-case.php
@@ -16,6 +16,6 @@ use Mantle\Testkit\Test_Case as Testing_Test_Case;
  * For use in integration tests. Will install WordPress during Test Class
  * set up process.
  */
-abstract class Test_Case extends Testing_Test_Case {
+abstract class Integration_Test_Case extends Testing_Test_Case {
 	use Installs_WordPress;
 }

--- a/src/mantle/testkit/class-unit-test-case.php
+++ b/src/mantle/testkit/class-unit-test-case.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Unit_Test_Case class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testkit;
+
+use PHPUnit\Framework\TestCase as Testing_Test_Case;
+
+/**
+ * Unit Test Case.
+ *
+ * Sets some required defaults for us, such as not preserving global state,
+ * and running each class in a separate process. This is required to not
+ * have global state mixed with Integration test global state.
+ */
+abstract class Unit_Test_Case extends Testing_Test_Case {
+	/**
+	 * We want to run our unit tests in isolation, allowing us to separate them
+	 * from the WordPress installation cluttered global state.
+	 *
+	 * @param array ...$args The array of arguments passed to the class.
+	 */
+	public function __construct( ...$args ) {
+		parent::__construct( ...$args );
+
+		// Discard all of the WordPress global state.
+		$this->setPreserveGlobalState( false );
+
+		// Load a new process to allow us to redefine functions.
+		$this->setRunClassInSeparateProcess( true );
+	}
+}

--- a/src/mantle/testkit/concerns/trait-installs-wordpress.php
+++ b/src/mantle/testkit/concerns/trait-installs-wordpress.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Installs_WordPress trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testkit\Concerns;
+
+/**
+ * Concern for handling WordPress installation outside of the bootstrap.
+ */
+trait Installs_WordPress {
+	/**
+	 * Manages installing WordPress.
+	 *
+	 * This is useful for installing WordPress in integration tests, while leaving the bootstrap
+	 * free of this overhead during unit tests. To perform actions after WordPress is installed, you
+	 * simply need to define a function `mantle_after_wordpress_install` in your bootstrap file.
+	 */
+	public static function installs_wordpress_set_up_before_class(): void {
+		static $installed = false;
+
+		if( true === $installed ) {
+			return;
+		}
+
+		$callback = function_exists( 'mantle_after_wordpress_install' ) ? 'mantle_after_wordpress_install' : null;
+
+		\Mantle\Testing\install( $callback );
+
+		$installed = true;
+	}
+}

--- a/src/mantle/testkit/concerns/trait-installs-wordpress.php
+++ b/src/mantle/testkit/concerns/trait-installs-wordpress.php
@@ -21,7 +21,7 @@ trait Installs_WordPress {
 	public static function installs_wordpress_set_up_before_class(): void {
 		static $installed = false;
 
-		if( true === $installed ) {
+		if ( true === $installed ) {
 			return;
 		}
 

--- a/tests/testkit/concerns/trait-example-overload.php
+++ b/tests/testkit/concerns/trait-example-overload.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Example_Overload trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Tests\Testkit\Concerns;
+
+/**
+ * Validates that method overloading is working as expected.
+ */
+trait Example_Overload {
+
+	/**
+	 * @var array<string> Contains the names of the methods that have been overloaded.
+	 */
+	protected static array $overloaded_methods = [];
+
+	/**
+	 * This method should be run during the setUpBeforeClass method of
+	 * the Test_Case.
+	 */
+	public static function example_overload_set_up_before_class(): void {
+		static::$overloaded_methods[] = 'setUpBeforeClass';
+	}
+}

--- a/tests/testkit/fixtures/global-functions.php
+++ b/tests/testkit/fixtures/global-functions.php
@@ -11,7 +11,7 @@
 function mantle_after_wordpress_install( bool $increment = true ): int {
 	static $called = 0;
 
-	if( true === $increment ) {
+	if ( true === $increment ) {
 		$called++;
 	}
 

--- a/tests/testkit/fixtures/global-functions.php
+++ b/tests/testkit/fixtures/global-functions.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This function intentionally defined in the global scope
+ * to be used by \Mantle\Testkit\Concerns\Installs_WordPress
+ * as a callback.
+ *
+ * @return int
+ */
+function mantle_after_wordpress_install(): int {
+	static $called = 0;
+
+	$called++;
+	return $called;
+}

--- a/tests/testkit/fixtures/global-functions.php
+++ b/tests/testkit/fixtures/global-functions.php
@@ -5,11 +5,15 @@
  * to be used by \Mantle\Testkit\Concerns\Installs_WordPress
  * as a callback.
  *
+ * @param bool $increment Defines if the counter should increment or not. Defaults to true.
  * @return int
  */
-function mantle_after_wordpress_install(): int {
+function mantle_after_wordpress_install( bool $increment = true ): int {
 	static $called = 0;
 
-	$called++;
+	if( true === $increment ) {
+		$called++;
+	}
+
 	return $called;
 }

--- a/tests/testkit/test-testkit-install-wordpress.php
+++ b/tests/testkit/test-testkit-install-wordpress.php
@@ -11,9 +11,9 @@ class Test_Testkit_Install_WordPress extends Test_Case {
 	use Installs_WordPress;
 
 	public function test_mantle_is_installed_from_trait() {
-		$called = \mantle_after_wordpress_install();
+		$called = \mantle_after_wordpress_install( false );
 
-		$this->assertEquals( 2, $called );
+		$this->assertEquals( 1, $called );
 	}
 
 }

--- a/tests/testkit/test-testkit-install-wordpress.php
+++ b/tests/testkit/test-testkit-install-wordpress.php
@@ -1,0 +1,19 @@
+<?php
+namespace Mantle\Tests\Testkit;
+
+use Mantle\Testkit\Concerns\Installs_WordPress;
+use Mantle\Testkit\Test_Case;
+
+// Required for callback.
+require_once __DIR__ . '/fixtures/global-functions.php';
+
+class Test_Testkit_Install_WordPress extends Test_Case {
+	use Installs_WordPress;
+
+	public function test_mantle_is_installed_from_trait() {
+		$called = \mantle_after_wordpress_install();
+
+		$this->assertEquals( 2, $called );
+	}
+
+}

--- a/tests/testkit/test-testkit-test-case.php
+++ b/tests/testkit/test-testkit-test-case.php
@@ -1,9 +1,12 @@
 <?php
 namespace Mantle\Tests\Testkit;
 
+use Mantle\Tests\Testkit\Concerns\Example_Overload;
 use Mantle\Testkit\Test_Case;
 
 class Test_Testkit_Test_Case extends Test_Case {
+	use Example_Overload;
+
 	public function test_create_application() {
 		$this->assertInstanceOf( \Mantle\Contracts\Application::class, $this->create_application() );
 	}
@@ -11,5 +14,13 @@ class Test_Testkit_Test_Case extends Test_Case {
 	public function test_make_request() {
 		$this->get( '/' )->assertOk();
 		$this->get( '/unknown/' )->assertNotFound();
+	}
+
+	/**
+	 * Verifies that trait methods for {$trait}_setUpBeforeClass are called.
+	 */
+	public function test_trait_setup_process() {
+		$this->assertNotEmpty( static::$overloaded_methods );
+		$this->assertContains( 'setUpBeforeClass', static::$overloaded_methods );
 	}
 }


### PR DESCRIPTION
This PR creates two new Testkit Test Case classes: `Integration_Test_Case` and `Unit_Test_Case`.

# Integration_Test_Case
This test case executes `\Mantle\Testing\install` on `setUpBeforeClass` once, bringing WordPress into the global scope. To allow us to continue to perform actions after install, the trait `Installs_WordPress` looks for an optional globally scoped method `mantle_after_wordpress_install` which, if found, will be used as the callback to `\Mantle\Testing\install`.

# Unit_Test_Case
This test case bypass Mantle entirely, extending directly from `PHPUnit\Framework\TestCase` and forcing `PreserveGlobalState` to false, and `RunClassInSeparateProcess` to true. This allows us to isolate our unit test's global scope from our Integration tests, which allows us to run them in tandem, without concerns of getting fatal errors around `PHP Fatal error: Cannot redeclare function`.

# Other changes
To make the above work, there were some changes to `\Mantle\Testing\Test_Case`:
* `get_test_case_traits` was converted to a static method.
* `setUpBeforeClass` now looks for the existance of a method `trait_name_set_up_before_class` for each loaded trait, and calls it statically, immediately prior to `parent::setUpBeforeClass`.