### PR TITLE
Fix Faker deprecation warnings about accessing methods as parameters

### DIFF
--- a/src/mantle/testing/factory/class-blog-factory.php
+++ b/src/mantle/testing/factory/class-blog-factory.php
@@ -44,8 +44,8 @@ class Blog_Factory extends Factory {
 			array_merge(
 				[
 					'domain'     => $current_site->domain,
-					'path'       => $base . $this->faker->slug,
-					'title'      => $this->faker->text,
+					'path'       => $base . $this->faker->slug(),
+					'title'      => $this->faker->text(),
 					'network_id' => $current_site->id,
 				],
 				$args

--- a/src/mantle/testing/factory/class-comment-factory.php
+++ b/src/mantle/testing/factory/class-comment-factory.php
@@ -48,10 +48,10 @@ class Comment_Factory extends Factory {
 	public function create( $args = [] ) {
 		$args = array_merge(
 			[
-				'comment_author'     => $this->faker->name,
-				'comment_author_url' => $this->faker->url,
+				'comment_author'     => $this->faker->name(),
+				'comment_author_url' => $this->faker->url(),
 				'comment_approved'   => 1,
-				'comment_content'    => $this->faker->sentence,
+				'comment_content'    => $this->faker->sentence(),
 			],
 			$args
 		);

--- a/src/mantle/testing/factory/class-network-factory.php
+++ b/src/mantle/testing/factory/class-network-factory.php
@@ -41,16 +41,16 @@ class Network_Factory extends Factory {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
 		if ( ! isset( $args['user'] ) ) {
-			$email = $this->faker->email;
+			$email = $this->faker->email();
 		} else {
 			$email = get_userdata( $args['user'] )->user_email;
 		}
 
 		$args = array_merge(
 			[
-				'domain' => $this->faker->domainName,
-				'title'  => $this->faker->words,
-				'path'   => $this->faker->slug,
+				'domain' => $this->faker->domainName(),
+				'title'  => $this->faker->words(),
+				'path'   => $this->faker->slug(),
 			],
 			$args
 		);

--- a/src/mantle/testing/factory/class-user-factory.php
+++ b/src/mantle/testing/factory/class-user-factory.php
@@ -42,8 +42,8 @@ class User_Factory extends Factory {
 		return User::create(
 			array_merge(
 				[
-					'user_email' => $this->faker->email,
-					'user_login' => $this->faker->userName,
+					'user_email' => $this->faker->email(),
+					'user_login' => $this->faker->userName(),
 					'user_pass'  => 'password',
 				],
 				$args


### PR DESCRIPTION
During some testing it became apparent that in certain configurations, Faker was throwing a deprecation warning which was causing some tests to fail.

This PR updates Mantle's use of Faker to avoid those deprecation warnings.

* Specific Faker line in question: https://github.com/FakerPHP/Faker/blob/acef8f29bfd88bb046a5fe2a08693977aa9501bd/src/Faker/Generator.php#L950