### PR TITLE
Allow attributes to register hooks

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4]
+        php: [8.0]
 
     name: Coding Standards
 

--- a/src/mantle/support/attributes/class-action.php
+++ b/src/mantle/support/attributes/class-action.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Action class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Support\Attributes;
+
+use Attribute;
+
+/**
+ * Hook Action Attribute
+ *
+ * Used to hook a method to an WordPress action at a specific priority.
+ */
+#[Attribute]
+class Action {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $action Action name.
+	 * @param int    $priority Priority, defaults to 10.
+	 */
+	public function __construct( public string $action, public int $priority = 10 ) {}
+}

--- a/src/mantle/support/class-service-provider.php
+++ b/src/mantle/support/class-service-provider.php
@@ -104,7 +104,7 @@ abstract class Service_Provider implements LoggerAwareInterface {
 	 */
 	protected function boot_attribute_hooks() {
 		// Abandon if we're not running PHP 8.
-		if ( phpversion() < '8.0.0' ) {
+		if ( version_compare( phpversion(), '8.0.0', '<' ) ) {
 			return;
 		}
 

--- a/tests/support/test-service-provider.php
+++ b/tests/support/test-service-provider.php
@@ -5,6 +5,7 @@ use Mantle\Framework\Application;
 use Mantle\Console\Command;
 use Mantle\Contracts\Providers as ProviderContracts;
 use Mantle\Support\Service_Provider;
+use Mantle\Support\Attributes\Action;
 use Mockery as m;
 
 class Test_Service_Provider extends \Mockery\Adapter\Phpunit\MockeryTestCase {
@@ -70,6 +71,22 @@ class Test_Service_Provider extends \Mockery\Adapter\Phpunit\MockeryTestCase {
 
 		$this->assertEquals( 15, $value );
 	}
+
+	public function test_hook_attribute() {
+		// Abandon if we're not running PHP 8.
+		if ( phpversion() < '8.0.0' ) {
+			$this->markTestSkipped( 'Requires PHP 8.0.0 or greater.' );
+			return;
+		}
+
+		$app = m::mock( Application::class )->makePartial();
+		$app->register( Provider_Test_Hook::class );
+		$app->boot();
+
+		do_action( 'testable-attribute-hook' );
+
+		$this->assertTrue( $_SERVER['__custom_hook_fired'] ?? false );
+	}
 }
 
 class Provider_Test_Hook extends Service_Provider {
@@ -79,5 +96,14 @@ class Provider_Test_Hook extends Service_Provider {
 
 	public function on_custom_filter( $value ) {
 		return $value + 10;
+	}
+
+	#[Action('testable-attribute-hook', 20)]
+	public function handle_custom_hook() {
+		$_SERVER['__custom_hook_fired'] = true;
+	}
+
+	public function handle_customn_filter( $value ) {
+		return $value + 100;
 	}
 }

--- a/tests/support/test-service-provider.php
+++ b/tests/support/test-service-provider.php
@@ -74,7 +74,7 @@ class Test_Service_Provider extends \Mockery\Adapter\Phpunit\MockeryTestCase {
 
 	public function test_hook_attribute() {
 		// Abandon if we're not running PHP 8.
-		if ( phpversion() < '8.0.0' ) {
+		if ( version_compare( phpversion(), '8.0.0', '<' ) ) {
 			$this->markTestSkipped( 'Requires PHP 8.0.0 or greater.' );
 			return;
 		}

--- a/tests/support/test-service-provider.php
+++ b/tests/support/test-service-provider.php
@@ -103,7 +103,7 @@ class Provider_Test_Hook extends Service_Provider {
 		$_SERVER['__custom_hook_fired'] = true;
 	}
 
-	public function handle_customn_filter( $value ) {
+	public function handle_custom_filter( $value ) {
 		return $value + 100;
 	}
 }


### PR DESCRIPTION
```php
use Mantle\Support\Attributes\Action;

class My_Provider extends Service_Provider {
	#[Action('my-hook', 20)]
	public function handle_custom_hook() {
		// Do some cool stuff!
	}
}
```