### PR TITLE
Ensure WP_MULTISITE can be passed properly

### DIFF
--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -126,13 +126,11 @@ if ( ! $installing_wp && '1' !== getenv( 'WP_TESTS_SKIP_INSTALL' ) ) {
 	}
 }
 
-if ( $multisite ) {
-	if ( ! $installing_wp ) {
-		echo 'Running as multisite...' . PHP_EOL;
-		defined( 'MULTISITE' ) or define( 'MULTISITE', true );
-		defined( 'SUBDOMAIN_INSTALL' ) or define( 'SUBDOMAIN_INSTALL', false );
-		$GLOBALS['base'] = '/';
-	}
+if ( $multisite && ! $installing_wp ) {
+	echo 'Running as multisite...' . PHP_EOL;
+	defined( 'MULTISITE' ) or define( 'MULTISITE', true );
+	defined( 'SUBDOMAIN_INSTALL' ) or define( 'SUBDOMAIN_INSTALL', false );
+	$GLOBALS['base'] = '/';
 } elseif ( ! $installing_wp ) {
 	echo "Running as single site...\nℹ️  To run multisite, pass WP_MULTISITE=1 or set the WP_TESTS_MULTISITE=1 constant.\n";
 }

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -127,10 +127,10 @@ if ( ! $installing_wp && '1' !== getenv( 'WP_TESTS_SKIP_INSTALL' ) ) {
 if ( $multisite ) {
 	if ( ! $installing_wp ) {
 		echo 'Running as multisite...' . PHP_EOL;
+		defined( 'MULTISITE' ) or define( 'MULTISITE', true );
+		defined( 'SUBDOMAIN_INSTALL' ) or define( 'SUBDOMAIN_INSTALL', false );
+		$GLOBALS['base'] = '/';
 	}
-	defined( 'MULTISITE' ) or define( 'MULTISITE', true );
-	defined( 'SUBDOMAIN_INSTALL' ) or define( 'SUBDOMAIN_INSTALL', false );
-	$GLOBALS['base'] = '/';
 } elseif ( ! $installing_wp ) {
 	echo "Running as single site...\nℹ️  To run multisite, pass WP_MULTISITE=1 or set the WP_TESTS_MULTISITE=1 constant.\n";
 }

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -118,7 +118,9 @@ $installing_wp        = defined( 'WP_INSTALLING' ) && WP_INSTALLING;
 
 if ( ! $installing_wp && '1' !== getenv( 'WP_TESTS_SKIP_INSTALL' ) ) {
 	$resp = system( WP_PHP_BINARY . ' ' . escapeshellarg( __DIR__ . '/install-wordpress.php' ) . ' ' . $multisite, $retval );
-	if ( 0 !== $retval ) {
+
+	// Verify the return code and that 'Done!' is included in the output.
+	if ( 0 !== $retval || empty( $resp ) || false === strpos( $resp, 'Done!' ) ) {
 		echo "🚨 Error installing WordPress!\nResponse from installation script:\n\n$resp\n";
 		exit( $retval );
 	}

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -132,7 +132,7 @@ if ( $multisite ) {
 	defined( 'SUBDOMAIN_INSTALL' ) or define( 'SUBDOMAIN_INSTALL', false );
 	$GLOBALS['base'] = '/';
 } elseif ( ! $installing_wp ) {
-	echo 'Running as single site... To run multisite, pass WP_TESTS_MULTISITE=1' . PHP_EOL;
+	echo "Running as single site...\nℹ️  To run multisite, pass WP_MULTISITE=1 or set the WP_TESTS_MULTISITE=1 constant.\n";
 }
 unset( $multisite );
 


### PR DESCRIPTION
* Only set the `MULTISITE` constant for non-install requests. During the test lifecycle, the `wordpress-bootstrap.php` file loads `install-wordpress.php` via shell. `install-wordpress.php` then loads `wordpress-bootstrap.php` again which had set `MULTISITE` to true. With `MULTISITE` set, `ms-settings.php` was then loaded which caused a fatal error during installation. This constant should not be set during the internal installation of WordPress. This would be one difference Mantle has from core.
* WordPress was not being installed properly but was silently failing. A fix was put in place to check for a proper installation.
* Updated the message to reflect passing WP_MULTISITE=1 or defining WP_TESTS_MULTISITE=1 as a constant.