### PR TITLE
Define Post Model Terms Fluently

### DIFF
--- a/src/mantle/database/model/class-model.php
+++ b/src/mantle/database/model/class-model.php
@@ -19,6 +19,7 @@ use Mantle\Support\Str;
 
 use function Mantle\Support\Helpers\class_basename;
 use function Mantle\Support\Helpers\class_uses_recursive;
+use function Mantle\Support\Helpers\tap;
 
 /**
  * Database Model
@@ -167,6 +168,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		$this->exists = true;
 		$this->set_raw_attributes( $instance->get_raw_attributes() );
 		return $this;
+	}
+
+	/**
+	 * Create an instance of a model from another.
+	 *
+	 * @param Model $instance Instance to clone.
+	 * @return static
+	 */
+	public static function instance( Model $instance ) {
+		return tap(
+			( new static() )->set_raw_attributes( $instance->get_raw_attributes() ),
+			fn ( Model $model ) => $model->exists = true,
+		);
 	}
 
 	/**

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -7,8 +7,9 @@
 
 namespace Mantle\Database\Model;
 
+use Carbon\Carbon;
+use DateTime;
 use Mantle\Contracts;
-use Mantle\Contracts\Events\Dispatcher;
 use Mantle\Database\Query\Builder;
 use Mantle\Database\Query\Post_Query_Builder;
 use Mantle\Support\Helpers;
@@ -190,6 +191,29 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 		}
 
 		return null;
+	}
+
+	/**
+	 * Publish a post.
+	 */
+	public function publish() : bool {
+		return $this->save( [ 'status' => 'publish' ] );
+	}
+
+	/**
+	 * Schedule a post for publication.
+	 *
+	 * @param string|DateTime $date Date to schedule the post for.
+	 * @return bool
+	 */
+	public function schedule( $date ) : bool {
+		if ( $date instanceof DateTime ) {
+			$date = $date->format( 'Y-m-d H:i:s' );
+		} else {
+			$date = Carbon::parse( $date )->format( 'Y-m-d H:i:s' );
+		}
+
+		return $this->save( [ 'status' => 'future', 'date' => $date ] );
 	}
 
 	/**

--- a/src/mantle/database/model/meta/class-model-meta-proxy.php
+++ b/src/mantle/database/model/meta/class-model-meta-proxy.php
@@ -53,4 +53,13 @@ class Model_Meta_Proxy {
 	public function __set( string $key, $value ) {
 		$this->model->queue_meta_attribute( $key, $value );
 	}
+
+	/**
+	 * Delete model meta.
+	 *
+	 * @param string $key Meta key.
+	 */
+	public function __unset( string $key ) {
+		$this->model->delete_meta( $key );
+	}
 }

--- a/src/mantle/database/model/term/class-model-term-proxy.php
+++ b/src/mantle/database/model/term/class-model-term-proxy.php
@@ -8,10 +8,14 @@
 namespace Mantle\Database\Model\Term;
 
 use Mantle\Database\Model\Post;
+use Mantle\Database\Model\Term;
 use RuntimeException;
 
 /**
  * Allow term to be retrieve as an attribute on the object.
+ *
+ * @property Term[] $category Categories for the model.
+ * @property Term[] $post_tag Tags for the model.
  */
 class Model_Term_Proxy {
 	/**
@@ -34,7 +38,7 @@ class Model_Term_Proxy {
 	 * Retrieve model terms by taxonomy.
 	 *
 	 * @param string $taxonomy Taxonomy name.
-	 * @return mixed
+	 * @return Term[]
 	 */
 	public function __get( string $taxonomy ) {
 		$queued_value = $this->model->get_queued_term_attribute( $taxonomy );
@@ -49,11 +53,11 @@ class Model_Term_Proxy {
 	/**
 	 * Set model term.
 	 *
-	 * @param string $taxonomy Taxonomy name..
-	 * @param mixed  $value Terms.
+	 * @param string                  $taxonomy Taxonomy name..
+	 * @param Term[]|\WP_Term[]|int[] $values Terms.
 	 */
-	public function __set( string $taxonomy, $value ) {
-		$this->model->queue_term_attribute( $taxonomy, $value );
+	public function __set( string $taxonomy, $values ) {
+		$this->model->queue_term_attribute( $taxonomy, $values );
 	}
 
 	/**

--- a/src/mantle/database/model/term/class-model-term-proxy.php
+++ b/src/mantle/database/model/term/class-model-term-proxy.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Model_Term_Proxy class file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Database\Model\Term;
+
+use Mantle\Database\Model\Post;
+use RuntimeException;
+
+/**
+ * Allow term to be retrieve as an attribute on the object.
+ */
+class Model_Term_Proxy {
+	/**
+	 * Model to retrieve meta from.
+	 *
+	 * @var Post
+	 */
+	protected Post $model;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Post $model Model to reference.
+	 */
+	public function __construct( Post $model ) {
+		$this->model = $model;
+	}
+
+	/**
+	 * Retrieve model terms by taxonomy.
+	 *
+	 * @param string $taxonomy Taxonomy name.
+	 * @return mixed
+	 */
+	public function __get( string $taxonomy ) {
+		$queued_value = $this->model->get_queued_term_attribute( $taxonomy );
+
+		if ( null !== $queued_value ) {
+			return $queued_value;
+		}
+
+		return $this->model->get_terms( $taxonomy );
+	}
+
+	/**
+	 * Set model term.
+	 *
+	 * @param string $taxonomy Taxonomy name..
+	 * @param mixed  $value Meta value.
+	 */
+	public function __set( string $taxonomy, $value ) {
+		$this->model->queue_term_attribute( $taxonomy, $value );
+	}
+
+	/**
+	 * Delete model terms.
+	 *
+	 * @throws RuntimeException Thrown on usage.
+	 * @param string $key Taxonomy key.
+	 */
+	public function __unset( string $key ) {
+		throw new RuntimeException( 'Deleting model terms by attribute is not supported.' );
+	}
+}

--- a/src/mantle/database/model/term/class-model-term-proxy.php
+++ b/src/mantle/database/model/term/class-model-term-proxy.php
@@ -15,7 +15,7 @@ use RuntimeException;
  */
 class Model_Term_Proxy {
 	/**
-	 * Model to retrieve meta from.
+	 * Model to retrieve term from.
 	 *
 	 * @var Post
 	 */
@@ -50,7 +50,7 @@ class Model_Term_Proxy {
 	 * Set model term.
 	 *
 	 * @param string $taxonomy Taxonomy name..
-	 * @param mixed  $value Meta value.
+	 * @param mixed  $value Terms.
 	 */
 	public function __set( string $taxonomy, $value ) {
 		$this->model->queue_term_attribute( $taxonomy, $value );

--- a/src/mantle/database/model/term/trait-model-term.php
+++ b/src/mantle/database/model/term/trait-model-term.php
@@ -190,7 +190,7 @@ trait Model_Term {
 	 * @throws Model_Exception Thrown if the $taxonomy cannot be inferred from $terms.
 	 */
 	public function remove_terms( $terms, string $taxonomy = null ) {
-		$terms = collect( is_array( $terms ) ? $terms : [ $terms ] )
+		$terms = collect( Arr::wrap( $terms ) )
 			->map(
 				function ( $term ) use ( &$taxonomy ) {
 					if ( $term instanceof Term ) {

--- a/src/mantle/database/model/term/trait-model-term.php
+++ b/src/mantle/database/model/term/trait-model-term.php
@@ -21,23 +21,23 @@ use function Mantle\Support\Helpers\collect;
  */
 trait Model_Term {
 	/**
-	 * Meta queued for saving.
+	 * Terms queued for saving.
 	 *
 	 * @var array
 	 */
 	protected $queued_terms = [];
 
 	/**
-	 * Retrieve the meta 'attribute'.
+	 * Retrieve the terms 'attribute'.
 	 *
-	 * @return Model_Meta_Proxy
+	 * @return Model_Term_Proxy
 	 */
 	public function get_terms_attribute() {
 		return new Model_Term_Proxy( $this );
 	}
 
 	/**
-	 * Allow setting meta through an array via an attribute mutator.
+	 * Allow setting terms through an array via an attribute mutator.
 	 *
 	 * @param array $values Term values to set.
 	 * @throws Model_Exception Thrown on invalid value being set.
@@ -73,7 +73,7 @@ trait Model_Term {
 	}
 
 	/**
-	 * Store queued model meta.
+	 * Store queued model terms.
 	 */
 	protected function store_queued_terms() {
 		foreach ( $this->queued_terms as $taxonomy => $values ) {

--- a/src/mantle/database/model/term/trait-model-term.php
+++ b/src/mantle/database/model/term/trait-model-term.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Model_Term class file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Database\Model\Term;
+
+use Mantle\Database\Model\Model_Exception;
+use Mantle\Database\Model\Term;
+use Mantle\Support\Arr;
+use WP_Term;
+
+use function Mantle\Support\Helpers\collect;
+
+/**
+ * Interface for interfacing with a model's terms.
+ *
+ * @property Model_Term_Proxy $terms Terms proxy instance.
+ */
+trait Model_Term {
+	/**
+	 * Meta queued for saving.
+	 *
+	 * @var array
+	 */
+	protected $queued_terms = [];
+
+	/**
+	 * Retrieve the meta 'attribute'.
+	 *
+	 * @return Model_Meta_Proxy
+	 */
+	public function get_terms_attribute() {
+		return new Model_Term_Proxy( $this );
+	}
+
+	/**
+	 * Allow setting meta through an array via an attribute mutator.
+	 *
+	 * @param array $values Term values to set.
+	 * @throws Model_Exception Thrown on invalid value being set.
+	 */
+	public function set_terms_attribute( $values ) {
+		if ( ! is_array( $values ) ) {
+			throw new Model_Exception( 'Attribute value passed to terms is not an array.' );
+		}
+
+		$this->queued_terms = $values;
+	}
+
+	/**
+	 * Get a queued term attribute.
+	 *
+	 * @param string $key Taxonomy key.
+	 * @return mixed|null Terms or null.
+	 */
+	public function get_queued_term_attribute( string $key ) {
+		return ( $this->queued_terms[ $key ] ?? [] )[0] ?? null;
+	}
+
+	/**
+	 * Queue a term for saving
+	 * Allows terms to be set before a post is saved.
+	 *
+	 * @param string $taxonomy Taxonomy name.
+	 * @param mixed  $value Terms.
+	 * @return void
+	 */
+	public function queue_term_attribute( string $taxonomy, $value ): void {
+		$this->queued_terms[ $taxonomy ] = $value;
+	}
+
+	/**
+	 * Store queued model meta.
+	 */
+	protected function store_queued_terms() {
+		foreach ( $this->queued_terms as $taxonomy => $values ) {
+			$this->set_terms( $values, $taxonomy );
+		}
+
+		$this->queued_terms = [];
+	}
+
+	/**
+	 * Get term(s) associated with a post.
+	 *
+	 * @param string $taxonomy Taxonomy name.
+	 * @return Term[]
+	 */
+	public function get_terms( string $taxonomy ): array {
+		$terms = \get_the_terms( $this->id(), $taxonomy );
+
+		if ( empty( $terms ) || \is_wp_error( $terms ) ) {
+			return [];
+		}
+
+		return array_map(
+			fn ( WP_Term $term ) => Term::new_from_existing( (array) $term ),
+			(array) $terms,
+		);
+	}
+
+	/**
+	 * Set the term(s) associated with a post.
+	 *
+	 * @param mixed  $terms Accepts an array of or a single instance of terms.
+	 * @param string $taxonomy Taxonomy name, optional.
+	 * @param bool   $append Append to the object's terms, defaults to false.
+	 * @return static
+	 *
+	 * @throws Model_Exception Thrown if the $taxonomy cannot be inferred from $terms.
+	 * @throws Model_Exception Thrown if error saving the post's terms.
+	 */
+	public function set_terms( $terms, string $taxonomy = null, bool $append = false ) {
+		$terms = collect( Arr::wrap( $terms ) )
+			->map(
+				function ( $term ) use ( &$taxonomy ) {
+					if ( $term instanceof Term ) {
+						if ( empty( $taxonomy ) ) {
+							$taxonomy = $term->taxonomy();
+						}
+
+						return $term->id();
+					}
+
+					if ( $term instanceof \WP_Term ) {
+						if ( empty( $taxonomy ) ) {
+							$taxonomy = $term->taxonomy;
+						}
+
+						return $term->term_id;
+					}
+
+					return $term;
+				}
+			)
+			->filter()
+			->all();
+
+		if ( empty( $taxonomy ) ) {
+			throw new Model_Exception( 'Term taxonomy not able to be inferred.' );
+		}
+
+		$update = \wp_set_object_terms( $this->id(), $terms, $taxonomy, $append );
+
+		if ( \is_wp_error( $update ) ) {
+			throw new Model_Exception( "Error setting model terms: [{$update->get_error_message()}]" );
+		}
+
+		return $this;
+	}
+
+
+	/**
+	 * Remove terms from a post.
+	 *
+	 * @param mixed  $terms Accepts an array of or a single instance of terms.
+	 * @param string $taxonomy Taxonomy name, optional.
+	 * @return static
+	 *
+	 * @throws Model_Exception Thrown if the $taxonomy cannot be inferred from $terms.
+	 */
+	public function remove_terms( $terms, string $taxonomy = null ) {
+		$terms = collect( is_array( $terms ) ? $terms : [ $terms ] )
+			->map(
+				function ( $term ) use ( &$taxonomy ) {
+					if ( $term instanceof Term ) {
+						if ( empty( $taxonomy ) ) {
+							$taxonomy = $term->taxonomy();
+						}
+
+						return $term->id();
+					}
+
+					if ( $term instanceof \WP_Term ) {
+						if ( empty( $taxonomy ) ) {
+							$taxonomy = $term->taxonomy;
+						}
+
+						return $term->term_id;
+					}
+
+					return $term;
+				}
+			)
+			->filter()
+			->all();
+
+		if ( empty( $taxonomy ) ) {
+			throw new Model_Exception( 'Term taxonomy not able to be inferred.' );
+		}
+
+		\wp_remove_object_terms( $this->id(), $terms, $taxonomy );
+
+		return $this;
+	}
+}

--- a/src/mantle/database/model/term/trait-model-term.php
+++ b/src/mantle/database/model/term/trait-model-term.php
@@ -17,7 +17,7 @@ use function Mantle\Support\Helpers\collect;
 /**
  * Interface for interfacing with a model's terms.
  *
- * @property Model_Term_Proxy $terms Terms proxy instance.
+ * @property Model_Term_Proxy $terms Proxy to manage terms for the model.
  */
 trait Model_Term {
 	/**

--- a/src/mantle/testing/concerns/trait-assertions.php
+++ b/src/mantle/testing/concerns/trait-assertions.php
@@ -15,6 +15,9 @@ use Mantle\Database\Model\User;
 use Mantle\Testing\Constraints\ArraySubset;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Util\InvalidArgumentHelper;
+use WP_Term;
+
+use function Mantle\Support\Helpers\get_term_object;
 
 /**
  * Assorted Test_Cast assertions.
@@ -367,5 +370,73 @@ trait Assertions {
 		);
 
 		PHPUnit::assertEmpty( $users );
+	}
+
+	/**
+	 * Get a term object from a flexible argument.
+	 *
+	 * @param Term|\WP_Term|int $argument Term object, term ID, or term slug.
+	 * @return WP_Term|null
+	 */
+	protected function get_term_from_argument( $argument ): ?WP_Term {
+		if ( $argument instanceof Term ) {
+			return $argument->core_object();
+		}
+
+		if ( is_int( $argument ) ) {
+			return get_term_object( $argument );
+		}
+
+		if ( $argument instanceof WP_Term ) {
+			return $argument;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Assert that a post has a specific term.
+	 *
+	 * `assertPostNotHasTerm()` is the inverse of this method.
+	 *
+	 * @param Post|\WP_Post|int $post Post to check.
+	 * @param Term|\WP_Term|int $term Term to check.
+	 * @return void
+	 */
+	public function assertPostHasTerm( $post, $term ) {
+		if ( $post instanceof Post ) {
+			$post = $post->id();
+		}
+
+		$term = $this->get_term_from_argument( $term );
+
+		if ( $term ) {
+			PHPUnit::assertTrue( \has_term( $term->term_id, $term->taxonomy, $post ) );
+		} else {
+			PHPUnit::fail( 'Term not found to assert against' );
+		}
+	}
+
+	/**
+	 * Assert that a post doesn't have a specific term.
+	 *
+	 * `assertPostHasTerm()` is the inverse of this method.
+	 *
+	 * @param Post|\WP_Post|int $post Post to check.
+	 * @param Term|\WP_Term|int $term Term to check.
+	 * @return void
+	 */
+	public function assertPostNotHasTerm( $post, $term ) {
+		if ( $post instanceof Post ) {
+			$post = $post->id();
+		}
+
+		$term = $this->get_term_from_argument( $term );
+
+		if ( $term ) {
+			PHPUnit::assertFalse( \has_term( $term->term_id, $term->taxonomy, $post ) );
+		} else {
+			PHPUnit::fail( 'Term not found to assert against' );
+		}
 	}
 }

--- a/src/mantle/testing/concerns/trait-assertions.php
+++ b/src/mantle/testing/concerns/trait-assertions.php
@@ -410,11 +410,8 @@ trait Assertions {
 
 		$term = $this->get_term_from_argument( $term );
 
-		if ( $term ) {
-			PHPUnit::assertTrue( \has_term( $term->term_id, $term->taxonomy, $post ) );
-		} else {
-			PHPUnit::fail( 'Term not found to assert against' );
-		}
+		PHPUnit::assertInstanceOf( \WP_Term::class, $term, 'Term not found to assert against' );
+		PHPUnit::assertTrue( \has_term( $term->term_id, $term->taxonomy, $post ) );
 	}
 
 	/**
@@ -435,8 +432,6 @@ trait Assertions {
 
 		if ( $term ) {
 			PHPUnit::assertFalse( \has_term( $term->term_id, $term->taxonomy, $post ) );
-		} else {
-			PHPUnit::fail( 'Term not found to assert against' );
 		}
 	}
 

--- a/src/mantle/testing/concerns/trait-assertions.php
+++ b/src/mantle/testing/concerns/trait-assertions.php
@@ -439,4 +439,14 @@ trait Assertions {
 			PHPUnit::fail( 'Term not found to assert against' );
 		}
 	}
+
+	/**
+	 * Alias of `assertPostNotHasTerm()`.
+	 *
+	 * @param Post|\WP_Post|int $post Post to check.
+	 * @param Term|\WP_Term|int $term Term to check.
+	 */
+	public function assertPostsDoesNotHaveTerm( $post, $term ) {
+		$this->assertPostNotHasTerm( $post, $term );
+	}
 }

--- a/src/mantle/testing/factory/class-attachment-factory.php
+++ b/src/mantle/testing/factory/class-attachment-factory.php
@@ -99,6 +99,8 @@ class Attachment_Factory extends Post_Factory {
 	 * @return \WP_Post|null
 	 */
 	public function get_object_by_id( int $object_id ): ?\WP_Post {
-		return get_post_object( $object_id );
+		return $this->as_models
+			? Post::find( $object_id )
+			: get_post_object( $object_id );
 	}
 }

--- a/src/mantle/testing/factory/class-factory.php
+++ b/src/mantle/testing/factory/class-factory.php
@@ -7,12 +7,22 @@
 
 namespace Mantle\Testing\Factory;
 
+use Mantle\Contracts\Database\Core_Object;
+
 use function Mantle\Support\Helpers\collect;
+use function Mantle\Support\Helpers\tap;
 
 /**
  * Base Factory
  */
 abstract class Factory {
+	/**
+	 * Flag to return the factory as a model.
+	 *
+	 * @var bool
+	 */
+	protected bool $as_models = false;
+
 	/**
 	 * Creates an object.
 	 *
@@ -28,6 +38,30 @@ abstract class Factory {
 	 * @return mixed
 	 */
 	abstract public function get_object_by_id( int $object_id );
+
+	/**
+	 * Generate models from the factory.
+	 *
+	 * @return static
+	 */
+	public function as_models() {
+		return tap(
+			clone $this,
+			fn ( $factory ) => $factory->as_models = true,
+		);
+	}
+
+	/**
+	 * Generate core WordPress objects from the factory.
+	 *
+	 * @return static
+	 */
+	public function as_objects() {
+		return tap(
+			clone $this,
+			fn ( $factory ) => $factory->as_models = false,
+		);
+	}
 
 	/**
 	 * Creates multiple objects.
@@ -52,7 +86,7 @@ abstract class Factory {
 	 * Creates an object and returns its object.
 	 *
 	 * @param array $args Optional. The arguments for the object to create. Default is empty array.
-	 * @return mixed The created object.
+	 * @return mixed|Core_Object The created object.
 	 */
 	public function create_and_get( $args = [] ) {
 		$object_id = $this->create( $args );

--- a/src/mantle/testing/factory/class-post-factory.php
+++ b/src/mantle/testing/factory/class-post-factory.php
@@ -136,6 +136,8 @@ class Post_Factory extends Factory {
 	 * @return \WP_Post|null
 	 */
 	public function get_object_by_id( int $object_id ) {
-		return get_post_object( $object_id );
+		return $this->as_models
+			? Post::find( $object_id )
+			: get_post_object( $object_id );
 	}
 }

--- a/src/mantle/testing/factory/class-term-factory.php
+++ b/src/mantle/testing/factory/class-term-factory.php
@@ -67,6 +67,12 @@ class Term_Factory extends Factory {
 	 * @return \WP_Term|null
 	 */
 	public function get_object_by_id( int $object_id ) {
-		return get_term_object( $object_id );
+		$term = get_term_object( $object_id );
+
+		if ( $term && $this->as_models ) {
+			return Term::new_from_existing( (array) $term );
+		}
+
+		return $term;
 	}
 }

--- a/tests/database/model/test-post-object.php
+++ b/tests/database/model/test-post-object.php
@@ -5,6 +5,7 @@ use Mantle\Contracts\Database\Registrable;
 use Mantle\Database\Model\Model_Exception;
 use Mantle\Database\Model\Post;
 use Mantle\Database\Model\Registration\Register_Post_Type;
+use Mantle\Database\Model\Term;
 use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testing\Framework_Test_Case;
 
@@ -278,6 +279,33 @@ class Test_Post_Object extends Framework_Test_Case {
 		$object->save();
 		$this->assertEquals( 'Updated meta value', $object->get_meta( 'meta_key' ) );
 		$this->assertEquals( 'Updated meta value', $object->meta->meta_key );
+	}
+
+	public function test_terms_attribute() {
+		$post = static::factory()->post->as_models()->create_and_get();
+		$category = static::factory()->category->create_and_get();
+
+		// Save the term to the post.
+		$post->terms->category = [ $category ];
+		$post->save();
+
+		$this->assertEquals(
+			$category->term_id,
+			get_the_category( $post->id() )[0]->term_id,
+		);
+
+		$this->assertInstanceOf( Term::class, $post->terms->category[0] );
+
+		$this->assertEquals(
+			$category->term_id,
+			$post->terms->category[0]->id(),
+		);
+
+		// Remove the term.
+		$post->terms->category = [];
+		$post->save();
+
+		$this->assertEmpty( get_the_category( $post->id() ) );
 	}
 
 	public function test_get_all() {

--- a/tests/database/model/test-post-object.php
+++ b/tests/database/model/test-post-object.php
@@ -305,6 +305,18 @@ class Test_Post_Object extends Framework_Test_Case {
 		$post->save();
 
 		$this->assertEmpty( get_the_category( $post->id() ) );
+
+		// Create a post using terms attribute.
+		$new_post = static::factory()->post->as_models()->create_and_get( [
+			'terms' => [
+				'category' => [ $category ],
+			],
+		] );
+
+		$this->assertEquals(
+			$category->term_id,
+			get_the_category( $new_post->id() )[0]->term_id,
+		);
 	}
 
 	public function test_get_all() {

--- a/tests/database/model/test-post-object.php
+++ b/tests/database/model/test-post-object.php
@@ -288,11 +288,7 @@ class Test_Post_Object extends Framework_Test_Case {
 		$post->terms->category = [ $category ];
 		$post->save();
 
-		$this->assertEquals(
-			$category->term_id,
-			get_the_category( $post->id() )[0]->term_id,
-		);
-
+		$this->assertPostHasTerm( $post, $category );
 		$this->assertInstanceOf( Term::class, $post->terms->category[0] );
 
 		$this->assertEquals(
@@ -305,6 +301,10 @@ class Test_Post_Object extends Framework_Test_Case {
 		$post->save();
 
 		$this->assertEmpty( get_the_category( $post->id() ) );
+	}
+
+	public function test_terms_attribute_create() {
+		$category = static::factory()->category->create_and_get();
 
 		// Create a post using terms attribute.
 		$new_post = static::factory()->post->as_models()->create_and_get( [
@@ -313,10 +313,34 @@ class Test_Post_Object extends Framework_Test_Case {
 			],
 		] );
 
-		$this->assertEquals(
-			$category->term_id,
-			get_the_category( $new_post->id() )[0]->term_id,
-		);
+		$this->assertPostHasTerm( $new_post, $category );
+	}
+
+	public function test_terms_attribute_create_without_taxonomy() {
+		$category_a = static::factory()->category->create_and_get();
+		$category_b = static::factory()->category->create_and_get();
+
+		// Create a post using terms attribute without specifying a taxonomy.
+		$new_post = static::factory()->post->as_models()->create_and_get( [
+			'terms' => [ $category_a, $category_b ],
+		] );
+
+		$this->assertCount( 2, get_the_category( $new_post->id() ) );
+		$this->assertPostHasTerm( $new_post, $category_a );
+		$this->assertPostHasTerm( $new_post, $category_b );
+	}
+
+	public function test_terms_attribute_create_without_taxonomy_multiple() {
+		$category = static::factory()->category->create_and_get();
+		$tag      = static::factory()->tag->create_and_get();
+
+		// Create a post using terms attribute without specifying a taxonomy.
+		$new_post = static::factory()->post->as_models()->create_and_get( [
+			'terms' => [ $category, $tag ],
+		] );
+
+		$this->assertPostHasTerm( $new_post, $category );
+		$this->assertPostHasTerm( $new_post, $tag );
 	}
 
 	public function test_get_all() {

--- a/tests/database/model/test-post-object.php
+++ b/tests/database/model/test-post-object.php
@@ -9,7 +9,6 @@ use Mantle\Database\Model\Term;
 use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testing\Framework_Test_Case;
 
-
 class Test_Post_Object extends Framework_Test_Case {
 	use Refresh_Database;
 

--- a/tests/testing/test-factory.php
+++ b/tests/testing/test-factory.php
@@ -2,6 +2,8 @@
 namespace Mantle\Testing;
 
 use Carbon\Carbon;
+use Mantle\Database\Model\Post;
+use Mantle\Database\Model\Term;
 
 use function Mantle\Support\Helpers\collect;
 
@@ -97,6 +99,14 @@ class Test_Factory extends Framework_Test_Case {
 
 	public function test_comment_factory() {
 		$this->shim_test( \WP_Comment::class, 'comment' );
+	}
+
+	public function test_as_models() {
+		$post = static::factory()->post->as_models()->create_and_get();
+		$term = static::factory()->term->as_models()->create_and_get();
+
+		$this->assertInstanceOf( Post::class, $post );
+		$this->assertInstanceOf( Term::class, $term );
 	}
 
 	protected function shim_test( string $class_name, string $property ) {


### PR DESCRIPTION
Extends #276
Docs https://github.com/alleyinteractive/mantle-docs/pull/21/files

Allows post models to add/set/delete/update terms using a fluent format.


The `Post` model support interacting with terms through relationships or through the model directly. The model supports multiple methods to make setting terms on a post simple:

```php
$category = Category::whereName( 'Example Category' )->first();

// Save the category to a post.
$post = new Post( [ 'title' => 'Example Post' ] );

// Also supports an array of IDs or WP_Term objects.
$post->terms->category = [ $category ];

$post->save();

// Read the tags from a post.
$post->terms->post_tag // Term[]
```

Terms can also be set when creating a post (specifying the taxonomy is optional):

```php
$post = new Post( [
	'title' => 'Example Title',
	'terms' => [ $category ],
] );

$post = new Post( [
	'title' => 'Example Title',
	'terms' => [
		'category' => [ $category ],
		'post_tag' => [ $tag ],
	],
] );
```