### PR TITLE
Assert Json Structure and other testing improvements

### DIFF
--- a/src/mantle/http/class-response.php
+++ b/src/mantle/http/class-response.php
@@ -50,7 +50,7 @@ class Response extends HttpFoundationResponse {
 	 *
 	 * @throws InvalidArgumentException When the HTTP status code is not valid.
 	 */
-	public function setContent( mixed $content ): static {
+	public function setContent( $content ) {
 		$this->original = $content;
 
 		// If the content is "JSONable" we will set the appropriate header and convert
@@ -78,7 +78,7 @@ class Response extends HttpFoundationResponse {
 	 * @param  Arrayable|Jsonable|ArrayObject|JsonSerializable|array|mixed $content
 	 * @return bool
 	 */
-	protected function should_be_json( mixed $content ): bool {
+	protected function should_be_json( $content ): bool {
 		return $content instanceof Arrayable ||
 			$content instanceof Jsonable ||
 			$content instanceof ArrayObject ||

--- a/src/mantle/http/class-response.php
+++ b/src/mantle/http/class-response.php
@@ -11,6 +11,7 @@ use ArrayObject;
 use InvalidArgumentException;
 use JsonSerializable;
 use Mantle\Contracts\Support\Arrayable;
+use Mantle\Contracts\Support\Htmlable;
 use Mantle\Contracts\Support\Jsonable;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -64,9 +65,10 @@ class Response extends HttpFoundationResponse {
 			if ( false === $content ) {
 				throw new InvalidArgumentException( json_last_error_msg() );
 			}
+		} elseif ( $content instanceof Htmlable ) {
+			$content = $content->to_html();
 		}
 
-		// todo: include Renderable/Htmlable interfaces.
 		parent::setContent( $content );
 
 		return $this;

--- a/src/mantle/http/class-response.php
+++ b/src/mantle/http/class-response.php
@@ -7,9 +7,98 @@
 
 namespace Mantle\Http;
 
+use ArrayObject;
+use InvalidArgumentException;
+use JsonSerializable;
+use Mantle\Contracts\Support\Arrayable;
+use Mantle\Contracts\Support\Jsonable;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 /**
  * HTTP Response
  */
-class Response extends HttpFoundationResponse { }
+class Response extends HttpFoundationResponse {
+	/**
+	 * The original content of the response.
+	 *
+	 * @var mixed
+	 */
+	public $original;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param mixed                 $content Response content.
+	 * @param int                   $status  Response status code.
+	 * @param array<string, string> $headers Response headers.
+	 *
+	 * @throws InvalidArgumentException When the HTTP status code is not valid.
+	 */
+	public function __construct( mixed $content = '', int $status = 200, array $headers = [] ) {
+		$this->headers = new ResponseHeaderBag( $headers );
+		$this->setContent( $content );
+		$this->setStatusCode( $status );
+		$this->setProtocolVersion( '1.0' );
+	}
+
+	/**
+	 * Set the content on the response.
+	 *
+	 * @param  mixed $content
+	 * @return $this
+	 *
+	 * @throws InvalidArgumentException When the HTTP status code is not valid.
+	 */
+	public function setContent( mixed $content ): static {
+		$this->original = $content;
+
+		// If the content is "JSONable" we will set the appropriate header and convert
+		// the content to JSON. This is useful when returning something like models
+		// from routes that will be automatically transformed to their JSON form.
+		if ( $this->should_be_json( $content ) ) {
+			$this->headers->set( 'Content-Type', 'application/json' );
+
+			$content = $this->morph_to_json( $content );
+
+			if ( false === $content ) {
+				throw new InvalidArgumentException( json_last_error_msg() );
+			}
+		}
+
+		// todo: include Renderable/Htmlable interfaces.
+		parent::setContent( $content );
+
+		return $this;
+	}
+
+	/**
+	 * Determine if the given content should be turned into JSON.
+	 *
+	 * @param  Arrayable|Jsonable|ArrayObject|JsonSerializable|array|mixed $content
+	 * @return bool
+	 */
+	protected function should_be_json( mixed $content ): bool {
+		return $content instanceof Arrayable ||
+			$content instanceof Jsonable ||
+			$content instanceof ArrayObject ||
+			$content instanceof JsonSerializable ||
+			is_array( $content );
+	}
+
+	/**
+	 * Morph the given content into JSON.
+	 *
+	 * @param  Arrayable|Jsonable|ArrayObject|JsonSerializable|array|mixed $content
+	 * @return string
+	 */
+	protected function morph_to_json( mixed $content ) {
+		if ( $content instanceof Jsonable ) {
+			return $content->to_json();
+		} elseif ( $content instanceof Arrayable ) {
+			return json_encode( $content->to_array() ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+		}
+
+		return json_encode( $content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+	}
+}

--- a/src/mantle/http/class-response.php
+++ b/src/mantle/http/class-response.php
@@ -35,7 +35,7 @@ class Response extends HttpFoundationResponse {
 	 *
 	 * @throws InvalidArgumentException When the HTTP status code is not valid.
 	 */
-	public function __construct( mixed $content = '', int $status = 200, array $headers = [] ) {
+	public function __construct( $content = '', int $status = 200, array $headers = [] ) {
 		$this->headers = new ResponseHeaderBag( $headers );
 		$this->setContent( $content );
 		$this->setStatusCode( $status );

--- a/src/mantle/http/class-response.php
+++ b/src/mantle/http/class-response.php
@@ -92,7 +92,7 @@ class Response extends HttpFoundationResponse {
 	 * @param  Arrayable|Jsonable|ArrayObject|JsonSerializable|array|mixed $content
 	 * @return string
 	 */
-	protected function morph_to_json( mixed $content ) {
+	protected function morph_to_json( $content ) {
 		if ( $content instanceof Jsonable ) {
 			return $content->to_json();
 		} elseif ( $content instanceof Arrayable ) {

--- a/src/mantle/testing/class-assertable-json-string.php
+++ b/src/mantle/testing/class-assertable-json-string.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Assertable_Json_String class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing;
+
+use ArrayAccess;
+use Countable;
+use JsonSerializable;
+use Mantle\Contracts\Support\Jsonable;
+use Mantle\Support\Arr;
+use Mantle\Support\Str;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+use function Mantle\Support\Helpers\data_get;
+
+/**
+ * Assertions that can be made against a JSON string.
+ */
+class Assertable_Json_String implements ArrayAccess, Countable {
+	/**
+	 * The original encoded JSON.
+	 *
+	 * @var string|array|Jsonable|JsonSerializable
+	 */
+	public $json;
+
+	/**
+	 * The decoded JSON contents.
+	 *
+	 * @var array|null
+	 */
+	protected ?array $decoded;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string|array|Jsonable|JsonSerializable $jsonable
+	 */
+	public function __construct( $jsonable ) {
+		$this->json = $jsonable;
+
+		if ( $jsonable instanceof JsonSerializable ) {
+			$this->decoded = $jsonable->jsonSerialize();
+		} elseif ( $jsonable instanceof Jsonable ) {
+			$this->decoded = json_decode( $jsonable->to_json(), true );
+		} else {
+			$this->decoded = json_decode( $jsonable, true );
+		}
+
+		if ( is_null( $this->decoded ) || false === $this->decoded ) {
+			PHPUnit::fail( 'Invalid JSON was returned from the route.' );
+		}
+	}
+
+	/**
+	 * Validate and return the decoded response JSON.
+	 *
+	 * @param string|null $key Key to retrieve, optional.
+	 * @return mixed
+	 */
+	public function json( $key = null ) {
+		return data_get( $this->decoded, $key );
+	}
+
+	/**
+	 * Assert that the expected value and type exists at the given path in the response.
+	 *
+	 * @param  string $path
+	 * @param  mixed  $expect
+	 * @return $this
+	 */
+	public function assertJsonPath( $path, $expect ) {
+		PHPUnit::assertSame( $expect, $this->json( $path ) );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path exists in the response.
+	 *
+	 * @param string $path Path to check.
+	 */
+	public function assertJsonPathExists( string $path ) {
+		PHPUnit::assertNotNull( $this->json( $path ) );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path does not exist in the response.
+	 *
+	 * @param string $path Path to check.
+	 */
+	public function assertJsonPathMissing( string $path ) {
+		PHPUnit::assertNull( $this->json( $path ) );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that the response has the exact given JSON.
+	 *
+	 * @param  array $data
+	 * @return $this
+	 */
+	public function assertExactJson( array $data ) {
+		$actual = wp_json_encode(
+			Arr::sort_recursive(
+				(array) $this->json()
+			)
+		);
+
+		PHPUnit::assertEquals( wp_json_encode( Arr::sort_recursive( $data ) ), $actual );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that the response contains the given JSON fragment.
+	 *
+	 * @param  array $data Data to compare.
+	 * @return $this
+	 */
+	public function assertJsonFragment( array $data ) {
+		$actual = wp_json_encode(
+			Arr::sort_recursive(
+				(array) $this->json()
+			)
+		);
+
+		foreach ( Arr::sort_recursive( $data ) as $key => $value ) {
+			$expected = $this->json_search_strings( $key, $value );
+
+			PHPUnit::assertTrue(
+				Str::contains( $actual, $expected ),
+				'Unable to find JSON fragment: ' . PHP_EOL . PHP_EOL .
+					'[' . wp_json_encode( [ $key => $value ] ) . ']' . PHP_EOL . PHP_EOL .
+					'within' . PHP_EOL . PHP_EOL .
+					"[{$actual}]."
+			);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Assert that the response does not contain the given JSON fragment.
+	 *
+	 * @param  array $data Data to compare.
+	 * @param  bool  $exact Flag for exact match, defaults to false.
+	 * @return $this
+	 */
+	public function assertJsonMissing( array $data, $exact = false ) {
+		if ( $exact ) {
+			return $this->assertJsonMissingExact( $data );
+		}
+
+		$actual = wp_json_encode(
+			Arr::sort_recursive(
+				(array) $this->json()
+			)
+		);
+
+		foreach ( Arr::sort_recursive( $data ) as $key => $value ) {
+			$unexpected = $this->json_search_strings( $key, $value );
+
+			PHPUnit::assertFalse(
+				Str::contains( $actual, $unexpected ),
+				'Found unexpected JSON fragment: ' . PHP_EOL . PHP_EOL .
+					'[' . wp_json_encode( [ $key => $value ] ) . ']' . PHP_EOL . PHP_EOL .
+					'within' . PHP_EOL . PHP_EOL .
+					"[{$actual}]."
+			);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Assert that the response does not contain the exact JSON fragment.
+	 *
+	 * @param  array $data
+	 * @return $this
+	 */
+	public function assertJsonMissingExact( array $data ) {
+		$actual = wp_json_encode(
+			Arr::sort_recursive(
+				(array) $this->json()
+			)
+		);
+
+		foreach ( Arr::sort_recursive( $data ) as $key => $value ) {
+			$unexpected = $this->json_search_strings( $key, $value );
+
+			if ( ! Str::contains( $actual, $unexpected ) ) {
+				return $this;
+			}
+		}
+
+		PHPUnit::fail(
+			'Found unexpected JSON fragment: ' . PHP_EOL . PHP_EOL .
+			'[' . wp_json_encode( $data ) . ']' . PHP_EOL . PHP_EOL .
+			'within' . PHP_EOL . PHP_EOL .
+			"[{$actual}]."
+		);
+	}
+
+	/**
+	 * Get the strings we need to search for when examining the JSON.
+	 *
+	 * @param  string $key
+	 * @param  string $value
+	 * @return array
+	 */
+	protected function json_search_strings( $key, $value ) {
+		$needle = substr( wp_json_encode( [ $key => $value ] ), 1, -1 );
+
+		return [
+			$needle . ']',
+			$needle . '}',
+			$needle . ',',
+		];
+	}
+
+	/**
+	 * Assert that the response JSON has the expected count of items at the given key.
+	 *
+	 * @param  int         $count
+	 * @param  string|null $key
+	 * @return $this
+	 */
+	public function assertJsonCount( int $count, $key = null ) {
+		if ( ! is_null( $key ) ) {
+			PHPUnit::assertCount(
+				$count,
+				data_get( $this->json(), $key ),
+				"Failed to assert that the response count matched the expected {$count}"
+			);
+
+			return $this;
+		}
+
+		PHPUnit::assertCount(
+			$count,
+			$this->json(),
+			"Failed to assert that the response count matched the expected {$count}"
+		);
+
+		return $this;
+	}
+
+	/**
+	 * Get the total number of items in the underlying JSON array.
+	 *
+	 * @return int
+	 */
+	public function count(): int {
+		return count( $this->decoded );
+	}
+
+	/**
+	 * Determine whether an offset exists.
+	 *
+	 * @param  mixed  $offset
+	 * @return bool
+	 */
+	public function offsetExists( $offset ): bool {
+		return isset( $this->decoded[ $offset ] );
+	}
+
+	/**
+	 * Get the value at the given offset.
+	 *
+	 * @param  string  $offset
+	 * @return mixed
+	 */
+	public function offsetGet( $offset ): mixed {
+		return $this->decoded[ $offset ];
+	}
+
+	/**
+	 * Set the value at the given offset.
+	 *
+	 * @param  string  $offset
+	 * @param  mixed  $value
+	 * @return void
+	 */
+	public function offsetSet($offset, $value): void {
+		$this->decoded[ $offset ] = $value;
+	}
+
+	/**
+	 * Unset the value at the given offset.
+	 *
+	 * @param  string  $offset
+	 * @return void
+	 */
+	public function offsetUnset($offset): void {
+		unset( $this->decoded[ $offset ] );
+	}
+}

--- a/src/mantle/testing/class-assertable-json-string.php
+++ b/src/mantle/testing/class-assertable-json-string.php
@@ -73,7 +73,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * @param  mixed  $expect
 	 * @return $this
 	 */
-	public function assertJsonPath( $path, $expect ) {
+	public function assertPath( $path, $expect ) {
 		PHPUnit::assertSame( $expect, $this->json( $path ) );
 
 		return $this;
@@ -84,7 +84,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 *
 	 * @param string $path Path to check.
 	 */
-	public function assertJsonPathExists( string $path ) {
+	public function assertPathExists( string $path ) {
 		PHPUnit::assertNotNull( $this->json( $path ) );
 
 		return $this;
@@ -95,7 +95,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 *
 	 * @param string $path Path to check.
 	 */
-	public function assertJsonPathMissing( string $path ) {
+	public function assertPathMissing( string $path ) {
 		PHPUnit::assertNull( $this->json( $path ) );
 
 		return $this;
@@ -107,7 +107,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * @param  array $data
 	 * @return $this
 	 */
-	public function assertExactJson( array $data ) {
+	public function assertExact( array $data ) {
 		$actual = wp_json_encode(
 			Arr::sort_recursive(
 				(array) $this->json()
@@ -125,7 +125,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * @param  array $data Data to compare.
 	 * @return $this
 	 */
-	public function assertJsonFragment( array $data ) {
+	public function assertFragment( array $data ) {
 		$actual = wp_json_encode(
 			Arr::sort_recursive(
 				(array) $this->json()
@@ -154,9 +154,9 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * @param  bool  $exact Flag for exact match, defaults to false.
 	 * @return $this
 	 */
-	public function assertJsonMissing( array $data, $exact = false ) {
+	public function assertMissing( array $data, $exact = false ) {
 		if ( $exact ) {
-			return $this->assertJsonMissingExact( $data );
+			return $this->assertMissingExact( $data );
 		}
 
 		$actual = wp_json_encode(
@@ -186,7 +186,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * @param  array $data
 	 * @return $this
 	 */
-	public function assertJsonMissingExact( array $data ) {
+	public function assertMissingExact( array $data ) {
 		$actual = wp_json_encode(
 			Arr::sort_recursive(
 				(array) $this->json()
@@ -210,30 +210,13 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	}
 
 	/**
-	 * Get the strings we need to search for when examining the JSON.
-	 *
-	 * @param  string $key
-	 * @param  string $value
-	 * @return array
-	 */
-	protected function json_search_strings( $key, $value ) {
-		$needle = substr( wp_json_encode( [ $key => $value ] ), 1, -1 );
-
-		return [
-			$needle . ']',
-			$needle . '}',
-			$needle . ',',
-		];
-	}
-
-	/**
 	 * Assert that the response JSON has the expected count of items at the given key.
 	 *
 	 * @param  int         $count
 	 * @param  string|null $key
 	 * @return $this
 	 */
-	public function assertJsonCount( int $count, $key = null ) {
+	public function assertCount( int $count, $key = null ) {
 		if ( ! is_null( $key ) ) {
 			PHPUnit::assertCount(
 				$count,
@@ -251,6 +234,23 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 		);
 
 		return $this;
+	}
+
+	/**
+	 * Get the strings we need to search for when examining the JSON.
+	 *
+	 * @param  string $key
+	 * @param  string $value
+	 * @return array
+	 */
+	protected function json_search_strings( $key, $value ) {
+		$needle = substr( wp_json_encode( [ $key => $value ] ), 1, -1 );
+
+		return [
+			$needle . ']',
+			$needle . '}',
+			$needle . ',',
+		];
 	}
 
 	/**

--- a/src/mantle/testing/class-test-response.php
+++ b/src/mantle/testing/class-test-response.php
@@ -518,7 +518,7 @@ class Test_Response {
 	 * @return $this
 	 */
 	public function assertJsonPath( $path, $expect ) {
-		$this->decoded_json()->assertJsonPath( $path, $expect );
+		$this->decoded_json()->assertPath( $path, $expect );
 
 		return $this;
 	}
@@ -529,7 +529,7 @@ class Test_Response {
 	 * @param string $path Path to check.
 	 */
 	public function assertJsonPathExists( string $path ) {
-		$this->decoded_json()->assertJsonPathExists( $path );
+		$this->decoded_json()->assertPathExists( $path );
 
 		return $this;
 	}
@@ -540,7 +540,7 @@ class Test_Response {
 	 * @param string $path Path to check.
 	 */
 	public function assertJsonPathMissing( string $path ) {
-		$this->decoded_json()->assertJsonPathMissing( $path );
+		$this->decoded_json()->assertPathMissing( $path );
 
 		return $this;
 	}
@@ -552,7 +552,7 @@ class Test_Response {
 	 * @return $this
 	 */
 	public function assertExactJson( array $data ) {
-		$this->decoded_json()->assertExactJson( $data );
+		$this->decoded_json()->assertExact( $data );
 
 		return $this;
 	}
@@ -564,7 +564,7 @@ class Test_Response {
 	 * @return $this
 	 */
 	public function assertJsonFragment( array $data ) {
-		$this->decoded_json()->assertJsonFragment( $data );
+		$this->decoded_json()->assertFragment( $data );
 
 		return $this;
 	}
@@ -577,7 +577,7 @@ class Test_Response {
 	 * @return $this
 	 */
 	public function assertJsonMissing( array $data, $exact = false ) {
-		$this->decoded_json()->assertJsonMissing( $data, $exact );
+		$this->decoded_json()->assertMissing( $data, $exact );
 
 		return $this;
 	}
@@ -589,7 +589,7 @@ class Test_Response {
 	 * @return $this
 	 */
 	public function assertJsonMissingExact( array $data ) {
-		$this->decoded_json()->assertJsonMissingExact( $data );
+		$this->decoded_json()->assertMissingExact( $data );
 
 		return $this;
 	}
@@ -602,7 +602,7 @@ class Test_Response {
 	 * @return $this
 	 */
 	public function assertJsonCount( int $count, $key = null ) {
-		$this->decoded_json()->assertJsonCount( $count, $key );
+		$this->decoded_json()->assertCount( $count, $key );
 
 		return $this;
 	}

--- a/src/mantle/testing/class-test-response.php
+++ b/src/mantle/testing/class-test-response.php
@@ -10,6 +10,7 @@ namespace Mantle\Testing;
 use DOMDocument;
 use DOMXPath;
 use Exception;
+use Mantle\Http\Response;
 use Mantle\Support\Traits\Macroable;
 use PHPUnit\Framework\Assert as PHPUnit;
 
@@ -65,6 +66,16 @@ class Test_Response {
 		$this->set_content( $content )
 			->set_status_code( $status )
 			->set_headers( $headers );
+	}
+
+	/**
+	 * Create a response from a base response instance.
+	 *
+	 * @param Response $response Base response instance.
+	 * @return static
+	 */
+	public static function from_base_response( Response $response ) {
+		return new static( $response->getContent(), $response->getStatusCode(), $response->headers->all() );
 	}
 
 	/**
@@ -603,6 +614,30 @@ class Test_Response {
 	 */
 	public function assertJsonCount( int $count, $key = null ) {
 		$this->decoded_json()->assertCount( $count, $key );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that the response has the similar JSON as given.
+	 *
+	 * @param  array $data
+	 * @return $this
+	 */
+	public function assertJsonSimilar( array $data ) {
+		$this->decoded_json()->assertSimilar( $data );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that the response has a given JSON structure.
+	 *
+	 * @param  array|null $structure Structure to check.
+	 * @return $this
+	 */
+	public function assertJsonStructure( array $structure = null ) {
+		$this->decoded_json()->assertStructure( $structure );
 
 		return $this;
 	}

--- a/tests/testing/concerns/test-interacts-with-external-requests.php
+++ b/tests/testing/concerns/test-interacts-with-external-requests.php
@@ -10,7 +10,7 @@ use RuntimeException;
 /**
  * Test for Mocking WP HTTP API Requests.
  */
-class Test_Interacts_With_Requests extends Framework_Test_Case {
+class Test_Interacts_With_External_Requests extends Framework_Test_Case {
 	public function test_fake_request() {
 		$this->fake_request( 'https://testing.com/*' )
 			->with_response_code( 404 )
@@ -74,7 +74,8 @@ class Test_Interacts_With_Requests extends Framework_Test_Case {
 		$response = wp_remote_get( 'https://github.com/' );
 		$this->assertEquals( [ 1, 2, 3 ], json_decode( wp_remote_retrieve_body( $response ) ) );
 	}
-public function test_permanent_redirect_response() {
+
+	public function test_permanent_redirect_response() {
 		$this->fake_request()->with_redirect( 'https://wordpress.org/', 308 );
 
 		$response = wp_remote_get( 'https://drupal.org/' );
@@ -85,6 +86,7 @@ public function test_permanent_redirect_response() {
 
 		$this->assertEquals( 308, wp_remote_retrieve_response_code( $response ) );
 	}
+
 	public function test_redirect_response() {
 		$this->fake_request()->with_redirect( 'https://wordpress.org/' );
 

--- a/tests/testing/concerns/test-makes-http-requests.php
+++ b/tests/testing/concerns/test-makes-http-requests.php
@@ -175,31 +175,72 @@ class Test_Makes_Http_Requests extends Framework_Test_Case {
 class JsonSerializableMixedResourcesStub implements JsonSerializable {
 	public function jsonSerialize(): array {
 		return [
-			'foo' => 'bar',
-			'foobar' => [
+			'foo'          => 'bar',
+			'foobar'       => [
 				'foobar_foo' => 'foo',
 				'foobar_bar' => 'bar',
 			],
-			'0' => ['foo'],
-			'bars' => [
-				['bar' => 'foo 0', 'foo' => 'bar 0'],
-				['bar' => 'foo 1', 'foo' => 'bar 1'],
-				['bar' => 'foo 2', 'foo' => 'bar 2'],
+			'0'            => [ 'foo' ],
+			'bars'         => [
+				[
+					'bar' => 'foo 0',
+					'foo' => 'bar 0',
+				],
+				[
+					'bar' => 'foo 1',
+					'foo' => 'bar 1',
+				],
+				[
+					'bar' => 'foo 2',
+					'foo' => 'bar 2',
+				],
 			],
-			'baz' => [
-				['foo' => 'bar 0', 'bar' => ['foo' => 'bar 0', 'bar' => 'foo 0']],
-				['foo' => 'bar 1', 'bar' => ['foo' => 'bar 1', 'bar' => 'foo 1']],
+			'baz'          => [
+				[
+					'foo' => 'bar 0',
+					'bar' => [
+						'foo' => 'bar 0',
+						'bar' => 'foo 0',
+					],
+				],
+				[
+					'foo' => 'bar 1',
+					'bar' => [
+						'foo' => 'bar 1',
+						'bar' => 'foo 1',
+					],
+				],
 			],
-			'barfoo' => [
-				['bar' => ['bar' => 'foo 0']],
-				['bar' => ['bar' => 'foo 0', 'foo' => 'foo 0']],
-				['bar' => ['foo' => 'bar 0', 'bar' => 'foo 0', 'rab' => 'rab 0']],
+			'barfoo'       => [
+				[ 'bar' => [ 'bar' => 'foo 0' ] ],
+				[
+					'bar' => [
+						'bar' => 'foo 0',
+						'foo' => 'foo 0',
+					],
+				],
+				[
+					'bar' => [
+						'foo' => 'bar 0',
+						'bar' => 'foo 0',
+						'rab' => 'rab 0',
+					],
+				],
 			],
 			'numeric_keys' => [
-				2 => ['bar' => 'foo 0', 'foo' => 'bar 0'],
-				3 => ['bar' => 'foo 1', 'foo' => 'bar 1'],
-				4 => ['bar' => 'foo 2', 'foo' => 'bar 2'],
+				2 => [
+					'bar' => 'foo 0',
+					'foo' => 'bar 0',
+				],
+				3 => [
+					'bar' => 'foo 1',
+					'foo' => 'bar 1',
+				],
+				4 => [
+					'bar' => 'foo 2',
+					'foo' => 'bar 2',
+				],
 			],
 		];
-  }
+	}
 }

--- a/tests/testing/concerns/test-makes-http-requests.php
+++ b/tests/testing/concerns/test-makes-http-requests.php
@@ -117,7 +117,8 @@ class Test_Makes_Http_Requests extends Framework_Test_Case {
 
 	public function test_rest_api_route_error() {
 		$this->get( rest_url( '/an/unknown/route' ) )
-			->assertStatus( 404 );
+			->assertStatus( 404 )
+			->assertNotFound();
 	}
 
 	public function test_redirect_response() {

--- a/tests/testing/test-core-test-shim.php
+++ b/tests/testing/test-core-test-shim.php
@@ -1,5 +1,7 @@
 <?php
-namespace Mantle\Testing;
+namespace Mantle\Tests\Testing;
+
+use Mantle\Testing\Framework_Test_Case;
 
 class Test_Core_Test_Shim extends Framework_Test_Case {
 	public function test_go_to() {

--- a/tests/testing/test-factory.php
+++ b/tests/testing/test-factory.php
@@ -1,9 +1,10 @@
 <?php
-namespace Mantle\Testing;
+namespace Mantle\Tests\Testing;
 
 use Carbon\Carbon;
 use Mantle\Database\Model\Post;
 use Mantle\Database\Model\Term;
+use Mantle\Testing\Framework_Test_Case;
 
 use function Mantle\Support\Helpers\collect;
 


### PR DESCRIPTION
- Renaming to Test_Interacts_With_External_Requests to clarify the intent of the test
- Moving all JSON tests to `Assertable_Json_String` -- a broken out class for asserting against JSON. More tests will be added in the future to it!
- Adding assertJsonStructure method
- Wiring up the response to take a JsonSerializable straight
