### PR TITLE
Update testkit to include URL Generator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 /.phpcs export-ignore
 /phpcs.xml export-ignore
 /phpunit.xml export-ignore
-/bin export-ignore
 /tests export-ignore
 
 #

--- a/src/mantle/http/routing/class-url-generator.php
+++ b/src/mantle/http/routing/class-url-generator.php
@@ -52,12 +52,12 @@ class Url_Generator extends UrlGenerator implements Generator_Contract {
 	/**
 	 * Constructor.
 	 *
-	 * @param string          $root_url Root URL.
-	 * @param RouteCollection $routes Route collection.
-	 * @param Request         $request Request object.
-	 * @param LoggerInterface $logger Logger instance.
+	 * @param string               $root_url Root URL.
+	 * @param RouteCollection      $routes Route collection.
+	 * @param Request              $request Request object.
+	 * @param LoggerInterface|null $logger Logger instance.
 	 */
-	public function __construct( string $root_url, RouteCollection $routes, Request $request, LoggerInterface $logger ) {
+	public function __construct( string $root_url, RouteCollection $routes, Request $request, LoggerInterface $logger = null ) {
 		$this->root_url = $root_url;
 		$this->routes   = $routes;
 		$this->logger   = $logger;
@@ -140,7 +140,7 @@ class Url_Generator extends UrlGenerator implements Generator_Contract {
 
 		return $this->format(
 			$root,
-			'/' . trim( $path . '/' . $tail, '/' )
+			'/' . trailingslashit( trim( $path, '/' ) ),
 		) . $query;
 	}
 
@@ -222,7 +222,7 @@ class Url_Generator extends UrlGenerator implements Generator_Contract {
 	 */
 	public function format( $root, $path ) {
 		$path = '/' . trim( $path, '/' );
-		return trim( $root . $path, '/' );
+		return trailingslashit( trim( $root . $path, '/' ) );
 	}
 
 	/**

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -61,7 +61,7 @@ abstract class Test_Case extends BaseTestCase {
 	/**
 	 * Application instance.
 	 *
-	 * @var \Mantle\Framework\Application
+	 * @var \Mantle\Contracts\Container|\Mantle\Container\Container
 	 */
 	protected $app;
 

--- a/src/mantle/testing/class-test-response.php
+++ b/src/mantle/testing/class-test-response.php
@@ -21,6 +21,13 @@ class Test_Response {
 	use Macroable;
 
 	/**
+	 * Application instance.
+	 *
+	 * @var \Mantle\Contracts\Container|\Mantle\Container\Container
+	 */
+	protected $app;
+
+	/**
 	 * Response headers.
 	 *
 	 * @var array
@@ -66,6 +73,17 @@ class Test_Response {
 		$this->set_content( $content )
 			->set_status_code( $status )
 			->set_headers( $headers );
+	}
+
+	/**
+	 * Set the container instance.
+	 *
+	 * @param \Mantle\Contracts\Container|\Mantle\Container\Container $app Application instance.
+	 * @return static
+	 */
+	public function set_app( $app ) {
+		$this->app = $app;
+		return $this;
 	}
 
 	/**
@@ -296,8 +314,8 @@ class Test_Response {
 	 */
 	public function assertLocation( $uri ) {
 		PHPUnit::assertEquals(
-			app( 'url' )->to( $uri ),
-			app( 'url' )->to( $this->get_header( 'location' ) ),
+			$this->app['url']->to( $uri ),
+			$this->app['url']->to( $this->get_header( 'location' ) ),
 		);
 
 		return $this;

--- a/src/mantle/testing/concerns/trait-makes-http-requests.php
+++ b/src/mantle/testing/concerns/trait-makes-http-requests.php
@@ -346,6 +346,8 @@ trait Makes_Http_Requests {
 			$response = new Test_Response( $response_content, $response_status ?? 200, $response_headers );
 		}
 
+		$response->set_app( $this->app );
+
 		remove_filter( 'exit_on_http_head', '__return_false', 9999 );
 		remove_filter( 'wp_using_themes', '__return_true', 9999 );
 

--- a/src/mantle/testkit/concerns/trait-create-application.php
+++ b/src/mantle/testkit/concerns/trait-create-application.php
@@ -10,8 +10,11 @@ namespace Mantle\Testkit\Concerns;
 use Mantle\Testkit\Application;
 use Mantle\Config\Repository;
 use Mantle\Contracts\Exceptions\Handler as Handler_Contract;
+use Mantle\Http\Request;
+use Mantle\Http\Routing\Url_Generator;
 use Mantle\Support\Collection;
 use Mantle\Testkit\Exception_Handler;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * Concern for creating the application instance.
@@ -53,6 +56,15 @@ trait Create_Application {
 		foreach ( $this->override_application_bindings( $app ) as $original => $replacement ) {
 			$app->bind( $original, $replacement );
 		}
+
+		$app->singleton_if(
+			'url',
+			fn ( $app ) => new Url_Generator(
+				$app->get_root_url(),
+				new RouteCollection(),
+				$app['request'] ?? new Request(),
+			),
+		);
 	}
 
 	/**

--- a/tests/testing/concerns/test-makes-http-requests.php
+++ b/tests/testing/concerns/test-makes-http-requests.php
@@ -126,12 +126,12 @@ class Test_Makes_Http_Requests extends Framework_Test_Case {
 	public function test_redirect_response() {
 		$this->app['router']->get(
 			'/route-to-redirect/',
-			fn () => redirect()->to( '/redirected', 302, [ 'Other-Header' => '123' ] ),
+			fn () => redirect()->to( '/redirected/', 302, [ 'Other-Header' => '123' ] ),
 		);
 
 		$this->get( '/route-to-redirect/' )
-			->assertHeader( 'location', home_url( '/redirected' ) )
-			->assertHeader( 'Location', home_url( '/redirected' ) )
+			->assertHeader( 'location', home_url( '/redirected/' ) )
+			->assertHeader( 'Location', home_url( '/redirected/' ) )
 			->assertRedirect( '/redirected' )
 			->assertHeader( 'Other-Header', '123' );
 	}

--- a/tests/testkit/test-testkit-test-case.php
+++ b/tests/testkit/test-testkit-test-case.php
@@ -16,6 +16,12 @@ class Test_Testkit_Test_Case extends Test_Case {
 		$this->get( '/unknown/' )->assertNotFound();
 	}
 
+	public function test_url_generator() {
+		$this->assertNotEmpty( $this->app['url'] );
+		$this->assertEquals( home_url( '/example/' ), $this->app['url']->to( home_url( '/example/' ) ) );
+		$this->assertEquals( home_url( '/example/' ), $this->app['url']->to( '/example/' ) );
+	}
+
 	/**
 	 * Verifies that trait methods for {$trait}_setUpBeforeClass are called.
 	 */


### PR DESCRIPTION
Allow Testkit to properly call `assertLocation()`. Previously it was calling `app()` which does not exist outside of the framework.