### PR TITLE
Fix Asset_Manager bug on asset()

### DIFF
--- a/src/mantle/framework/helpers.php
+++ b/src/mantle/framework/helpers.php
@@ -16,7 +16,7 @@ use Mantle\Support\Environment;
 use Mantle\Framework\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Mantle\Assets\Mix;
-use Mantle\Contracts\Assets\Asset_Manager;
+use Mantle\Assets\Asset_Manager;
 
 if ( ! function_exists( 'app' ) ) {
 	/**


### PR DESCRIPTION
When using the `asset()` helper I received a fatal error:

```
Mantle \ Container \ Binding_Resolution_Exception
Target [Mantle\Contracts\Assets\Asset_Manager] is not instantiable.
```

After a little testing, I found that by using the actual Asset_Manager class over the Asset_Manager contract here, I was able to get the helper to work. I'm not sure if this is the correct approach, but I figured it could start a conversation at least.