### PR TITLE
Ensure tests have a permalink structure by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,11 +27,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        can_fail: [false]
+        multisite: ["0", "1"]
         php: [7.4, 8.0]
         wp_version: ["latest"]
-        can_fail: [false]
 
-    name: ${{ matrix.php }} @ ${{ matrix.wp_version }}
+    name: ${{ matrix.php }} @ ${{ matrix.wp_version }} (Multisite ${{ matrix.multisite }})
 
     env:
       CACHEDIR: /tmp
@@ -40,6 +41,7 @@ jobs:
       WP_DB_HOST: 127.0.0.1
       WP_DB_USER: root
       WP_DB_PASSWORD: '""'
+      WP_MULTISITE: ${{ matrix.multisite }}
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         php: [7.4, 8.0]
         wp_version: ["latest"]
 
-    name: ${{ matrix.php }} @ ${{ matrix.wp_version }} (Multisite ${{ matrix.multisite }})
+    name: Unit Test ${{ matrix.php }} @ ${{ matrix.wp_version }} (Multisite ${{ matrix.multisite }})
 
     env:
       CACHEDIR: /tmp

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -132,6 +132,10 @@ abstract class Test_Case extends BaseTestCase {
 	protected function setUp(): void {
 		set_time_limit( 0 );
 
+		// Set the default permalink structure on each test before setUp() to allow
+		// the tests to override it.
+		$this->set_permalink_structure( Utils::DEFAULT_PERMALINK_STRUCTURE );
+
 		parent::setUp();
 
 		if ( ! $this->app ) {

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -44,6 +44,13 @@ class Utils {
 	public const DEFAULT_DB_HOST = 'localhost';
 
 	/**
+	 * Default permalink structure.
+	 *
+	 * @var string
+	 */
+	public const DEFAULT_PERMALINK_STRUCTURE = '/%year%/%monthnum%/%day%/%postname%/';
+
+	/**
 	 * Get the output from a given callable.
 	 *
 	 * @param callable $callable Callable to execute.
@@ -177,7 +184,7 @@ class Utils {
 	 * @since 4.2.0
 	 */
 	public static function set_default_permalink_structure_for_tests() {
-		update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
+		update_option( 'permalink_structure', static::DEFAULT_PERMALINK_STRUCTURE );
 	}
 
 	/**

--- a/src/mantle/testing/concerns/trait-multisite-test.php
+++ b/src/mantle/testing/concerns/trait-multisite-test.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Multisite_Test trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Concerns;
+
+/**
+ * Trait to ensure the request is made in multisite mode and skipped otherwise.
+ */
+trait Multisite_Test {
+	/**
+	 * Setup the trait.
+	 */
+	public function multisite_test_set_up() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite.' );
+		}
+	}
+}

--- a/src/mantle/testing/install-wordpress.php
+++ b/src/mantle/testing/install-wordpress.php
@@ -55,7 +55,6 @@ wp_install( WP_TESTS_TITLE, 'admin', WP_TESTS_EMAIL, true, null, 'password' );
 if ( ! is_multisite() ) {
 	delete_option( 'permalink_structure' );
 }
-remove_action( 'populate_options', [ Utils::class, 'set_default_permalink_structure_for_tests' ] );
 
 if ( $multisite ) {
 	echo '... Installing network...' . PHP_EOL;
@@ -66,8 +65,18 @@ if ( $multisite ) {
 	$subdomain_install = false;
 
 	install_network();
-	populate_network( 1, WP_TESTS_DOMAIN, WP_TESTS_EMAIL, $title, '/', $subdomain_install );
-	$wp_rewrite->set_permalink_structure( '' );
+
+	$populate = populate_network( 1, WP_TESTS_DOMAIN, WP_TESTS_EMAIL, $title, '/', $subdomain_install );
+
+	if ( is_wp_error( $populate ) ) {
+		echo 'Error populating network: ' . $populate->get_error_message() . PHP_EOL;
+		exit( 1 );
+	}
+
+	$wp_rewrite->set_permalink_structure( Utils::DEFAULT_PERMALINK_STRUCTURE );
+	$wp_rewrite->flush_rules();
 }
+
+remove_action( 'populate_options', [ Utils::class, 'set_default_permalink_structure_for_tests' ] );
 
 echo "... Done!\n";

--- a/src/mantle/testing/install-wordpress.php
+++ b/src/mantle/testing/install-wordpress.php
@@ -55,6 +55,7 @@ wp_install( WP_TESTS_TITLE, 'admin', WP_TESTS_EMAIL, true, null, 'password' );
 if ( ! is_multisite() ) {
 	delete_option( 'permalink_structure' );
 }
+remove_action( 'populate_options', [ Utils::class, 'set_default_permalink_structure_for_tests' ] );
 
 if ( $multisite ) {
 	echo '... Installing network...' . PHP_EOL;
@@ -72,12 +73,8 @@ if ( $multisite ) {
 		echo 'Error populating network: ' . $populate->get_error_message() . PHP_EOL;
 		exit( 1 );
 	}
+
+	$wp_rewrite->set_permalink_structure( '' );
 }
-
-// Set the default permalink structure.
-$wp_rewrite->set_permalink_structure( Utils::DEFAULT_PERMALINK_STRUCTURE );
-$wp_rewrite->flush_rules();
-
-remove_action( 'populate_options', [ Utils::class, 'set_default_permalink_structure_for_tests' ] );
 
 echo "... Done!\n";

--- a/src/mantle/testing/install-wordpress.php
+++ b/src/mantle/testing/install-wordpress.php
@@ -72,10 +72,11 @@ if ( $multisite ) {
 		echo 'Error populating network: ' . $populate->get_error_message() . PHP_EOL;
 		exit( 1 );
 	}
-
-	$wp_rewrite->set_permalink_structure( Utils::DEFAULT_PERMALINK_STRUCTURE );
-	$wp_rewrite->flush_rules();
 }
+
+// Set the default permalink structure.
+$wp_rewrite->set_permalink_structure( Utils::DEFAULT_PERMALINK_STRUCTURE );
+$wp_rewrite->flush_rules();
 
 remove_action( 'populate_options', [ Utils::class, 'set_default_permalink_structure_for_tests' ] );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,6 @@
 
 namespace Mantle\Tests;
 
-defined( 'MULTISITE' ) || define( 'MULTISITE', true );
 define( 'MANTLE_PHPUNIT_INCLUDES_PATH', __DIR__ . '/includes' );
 define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 

--- a/tests/database/model/test-site-object.php
+++ b/tests/database/model/test-site-object.php
@@ -2,10 +2,13 @@
 namespace Mantle\Tests\Database\Model;
 
 use Mantle\Database\Model\Site;
+use Mantle\Testing\Concerns\Multisite_Test;
 use Mantle\Testing\Framework_Test_Case;
 
 
 class Test_Site_Object extends Framework_Test_Case {
+	use Multisite_Test;
+
 	public function test_site_attributes() {
 		$site_id = static::factory()->blog->create();
 		$site    = Site::find( $site_id );

--- a/tests/testing/test-factory.php
+++ b/tests/testing/test-factory.php
@@ -87,10 +87,20 @@ class Test_Factory extends Framework_Test_Case {
 	}
 
 	public function test_blog_factory() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite.' );
+			return;
+		}
+
 		$this->shim_test( \WP_Site::class, 'blog' );
 	}
 
 	public function test_network_factory() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite.' );
+			return;
+		}
+
 		$this->shim_test( \WP_Network::class, 'network' );
 	}
 

--- a/tests/testing/test-permalink-structure.php
+++ b/tests/testing/test-permalink-structure.php
@@ -26,4 +26,46 @@ class Test_Permalink_Structure extends Framework_Test_Case {
 			->assertQueriedObject( $post )
 			->assertQueryTrue( 'is_single', 'is_singular' );
   }
+
+  public function test_custom_permalink_structure() {
+		$this->set_permalink_structure( '/blog/%year%/%postname%/' );
+
+		$this->assertEquals(
+			'/blog/%year%/%postname%/',
+			get_option( 'permalink_structure' ),
+		);
+
+    $post = static::factory()->post->create_and_get( [
+			'post_date' => '2018-01-01 00:00:00',
+			'post_name' => 'test-post-custom',
+		] );
+
+		$permalink = get_permalink( $post );
+
+		$this->assertEquals( home_url( '/blog/2018/test-post-custom/' ), $permalink );
+
+		// Ensure the permalink can be reached by the testing framework.
+		$this->get( $permalink )
+			->assertOk()
+			->assertQueriedObject( $post )
+			->assertQueryTrue( 'is_single', 'is_singular' );
+  }
+
+  public function test_no_permalinks() {
+		$this->set_permalink_structure( '' );
+
+		$this->assertEmpty( get_option( 'permalink_structure' ) );
+
+    $post_id = static::factory()->post->create();
+
+		$permalink = get_permalink( $post_id );
+
+		$this->assertEquals( home_url( '?p=' . $post_id ), $permalink );
+
+		// Ensure the permalink can be reached by the testing framework.
+		$this->get( $permalink )
+			->assertOk()
+			->assertQueriedObjectId( $post_id )
+			->assertQueryTrue( 'is_single', 'is_singular' );
+  }
 }

--- a/tests/testing/test-permalink-structure.php
+++ b/tests/testing/test-permalink-structure.php
@@ -1,0 +1,29 @@
+<?php
+namespace Mantle\Tests\Testing;
+
+use Mantle\Testing\Framework_Test_Case;
+use Mantle\Testing\Utils;
+
+class Test_Permalink_Structure extends Framework_Test_Case {
+  public function test_default_permalink_structure() {
+		$this->assertEquals(
+			Utils::DEFAULT_PERMALINK_STRUCTURE,
+			get_option( 'permalink_structure' ),
+		);
+
+    $post = static::factory()->post->create_and_get( [
+			'post_date' => '2018-01-01 00:00:00',
+			'post_name' => 'test-post',
+		] );
+
+		$permalink = get_permalink( $post );
+
+		$this->assertEquals( home_url( '/2018/01/01/test-post/' ), $permalink );
+
+		// Ensure the permalink can be reached by the testing framework.
+		$this->get( $permalink )
+			->assertOk()
+			->assertQueriedObject( $post )
+			->assertQueryTrue( 'is_single', 'is_singular' );
+  }
+}


### PR DESCRIPTION
- Ensure that tests can have a permalink structure by default.
- Ensure Mantle tests against single and multisite.