### PR TITLE
Adding alleyinteractive/wp-filter-side-effects to mantle-framework/database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v0.6.1 - 2022-09-20
+
+- Adding alleyinteractive/wp-filter-side-effects to mantle-framework/database
+
 ## v0.6.0 - 2022-09-16
 
 - Ensure tests have a permalink structure by default.

--- a/src/mantle/database/composer.json
+++ b/src/mantle/database/composer.json
@@ -5,6 +5,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
+        "alleyinteractive/wp-filter-side-effects": "^1.0",
         "mantle-framework/contracts": "^0.6",
         "mantle-framework/support": "^0.6",
         "psr/container": "^1.1.1 || ^2.0.1",


### PR DESCRIPTION
- Adding alleyinteractive/wp-filter-side-effects to mantle-framework/database
- CHANGELOG

Fixes an error with an undefined function:

```
Error: Call to undefined function Alley\WP\add_filter_side_effect()

/home/runner/work/archiveless/archiveless/vendor/mantle-framework/database/model/events/trait-post-events.php:30
/home/runner/work/archiveless/archiveless/vendor/mantle-framework/database/model/events/trait-post-events.php:21
/home/runner/work/archiveless/archiveless/vendor/mantle-framework/database/model/class-model.php:263
/home/runner/work/archiveless/archiveless/vendor/mantle-framework/database/model/class-model.php:233
/home/runner/work/archiveless/archiveless/vendor/mantle-framework/database/model/class-model.php:92
/home/runner/work/archiveless/archiveless/vendor/mantle-framework/database/model/class-post.php:78
/home/runner/work/archiveless/archiveless/vendor/mantle-framework/database/model/class-model.php:551
/home/runner/work/archiveless/archiveless/vendor/mantle-framework/testing/factory/class-post-factory.php:59
/home/runner/work/archiveless/archiveless/tests/test-general.php:52
```