### PR TITLE
Compatibility layer for Refresh_Database and Installs_Wordpress

### DIFF
--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -236,13 +236,7 @@ abstract class Test_Case extends BaseTestCase {
 		// Boot traits on the test case.
 		$traits = array_values( class_uses_recursive( static::class ) );
 
-		$priority_traits = [
-			// This order is deliberate.
-			Refresh_Database::class,
-			WordPress_Authentication::class,
-			Admin_Screen::class,
-			Network_Admin_Screen::class,
-		];
+		$priority_traits = static::get_priority_traits();
 
 		// Combine the priority and non-priority traits.
 		return collect()
@@ -250,7 +244,21 @@ abstract class Test_Case extends BaseTestCase {
 			->merge( array_diff( $traits, $priority_traits ) )
 			->unique();
 	}
-
+	
+	/**
+	 * Get an array of priority traits.
+	 * 
+	 * @return array
+	 */
+	protected static function get_priority_traits(): array {
+		return [
+			// This order is deliberate.
+			Refresh_Database::class,
+			WordPress_Authentication::class,
+			Admin_Screen::class,
+			Network_Admin_Screen::class,
+		];
+	}
 	/**
 	 * Register the traits that this test case uses.
 	 */

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -84,10 +84,7 @@ abstract class Test_Case extends BaseTestCase {
 	 */
 	public static function setUpBeforeClass(): void {
 		static::register_traits();
-		if ( isset( static::$test_uses[ Refresh_Database::class ] ) ) {
-			static::refresh_database_pre_setup_before_class();
-		}
-
+		
 		if ( ! empty( static::$test_uses ) ) {
 
 			static::get_test_case_traits()

--- a/src/mantle/testing/concerns/trait-refresh-database.php
+++ b/src/mantle/testing/concerns/trait-refresh-database.php
@@ -14,7 +14,7 @@ trait Refresh_Database {
 	/**
 	 * Routines to run before setupBeforeClass.
 	 */
-	public static function refresh_database_pre_setup_before_class() {
+	public static function refresh_database_setup_before_class() {
 		global $wpdb;
 
 		$wpdb->suppress_errors = false;

--- a/src/mantle/testkit/class-test-case.php
+++ b/src/mantle/testkit/class-test-case.php
@@ -20,6 +20,11 @@ use Mantle\Testing\Test_Case as Testing_Test_Case;
 abstract class Test_Case extends Testing_Test_Case {
 	use Create_Application;
 	
+	/**
+	 * Add Testkit specific traits to Priority list.
+	 *
+	 * @return array
+	 */
 	protected static function get_priority_traits(): array {
 		$parent_priorities = parent::get_priority_traits();
 		

--- a/src/mantle/testkit/class-test-case.php
+++ b/src/mantle/testkit/class-test-case.php
@@ -8,6 +8,7 @@
 namespace Mantle\Testkit;
 
 use Mantle\Testkit\Concerns\Create_Application;
+use Mantle\Testkit\Concerns\Installs_Wordpress;
 use Mantle\Testing\Test_Case as Testing_Test_Case;
 
 /**
@@ -18,4 +19,14 @@ use Mantle\Testing\Test_Case as Testing_Test_Case;
  */
 abstract class Test_Case extends Testing_Test_Case {
 	use Create_Application;
+	
+	protected static function get_priority_traits(): array {
+		$parent_priorities = parent::get_priority_traits();
+		
+		$priorities = [
+			Installs_Wordpress::class,
+		];
+		
+		return array_merge( $priorities, $parent_priorities );
+	}
 }


### PR DESCRIPTION
Currently if you happen to run a test that relies on both `Installs_Wordpress` and `Refresh_Database` too soon, you uncover errors due to no `$wpdb` existing.

This PR attempts to fix that by:

* converting `Refresh_Database` to use the `setup_before_class` hook
* creating a new `get_priority_traits` static method to return the array of prioritized traits
* overloading this method in the Testkit Test Case to add `Installs_Wordpress` above `Refresh_Database` ensuring that Wordpress will always be installed prior to the initial attempt to refresh the database.