### PR TITLE
Set default to string incase of missing location

### DIFF
--- a/src/mantle/testing/class-test-response.php
+++ b/src/mantle/testing/class-test-response.php
@@ -315,7 +315,7 @@ class Test_Response {
 	public function assertLocation( $uri ) {
 		PHPUnit::assertEquals(
 			$this->app['url']->to( $uri ),
-			$this->app['url']->to( $this->get_header( 'location' ) ),
+			$this->app['url']->to( $this->get_header( 'location', '' ) ),
 		);
 
 		return $this;


### PR DESCRIPTION
Sets a default value of an empty string on the `location` header in `assertLocation` to avoid the fatal error of passing null to `->to()`