### PR TITLE
Middleware for testing factories

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [7.4, 8.0]
+        php: [8.0]
         wordpress: ["latest"]
         multisite: [true, false]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "alleyinteractive/wp-asset-manager": "^1.0",
         "alleyinteractive/wp-caper": "^1.0",

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -50,7 +50,7 @@ return static function ( ContainerConfigurator $container_config ): void {
 		[
 			ComposerJsonSection::REQUIRE     => [
 				'alleyinteractive/composer-wordpress-autoloader' => '^1.0',
-				'php'                                            => '^7.4|^8.0',
+				'php'                                            => '^8.0',
 			],
 			ComposerJsonSection::REQUIRE_DEV => [
 				'alleyinteractive/alley-coding-standards' => '^0.3',

--- a/src/mantle/assets/composer.json
+++ b/src/mantle/assets/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Asset Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "alleyinteractive/wp-asset-manager": "^1.0",
         "mantle-framework/contracts": "^0.7",

--- a/src/mantle/auth/composer.json
+++ b/src/mantle/auth/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Auth Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/http": "^0.7",
         "symfony/http-kernel": "^5.3"

--- a/src/mantle/cache/composer.json
+++ b/src/mantle/cache/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Cache Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7",
         "mantle-framework/support": "^0.7",

--- a/src/mantle/config/composer.json
+++ b/src/mantle/config/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Config Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7",
         "mantle-framework/support": "^0.7"

--- a/src/mantle/console/composer.json
+++ b/src/mantle/console/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Console Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7",
         "mantle-framework/support": "^0.7",

--- a/src/mantle/container/composer.json
+++ b/src/mantle/container/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Container Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7",
         "psr/container": "^1.1.1 || ^2.0.1"

--- a/src/mantle/contracts/composer.json
+++ b/src/mantle/contracts/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Contracts Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "psr/container": "^1.1.1 || ^2.0.1"
     },

--- a/src/mantle/database/composer.json
+++ b/src/mantle/database/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Database Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "alleyinteractive/wp-filter-side-effects": "^1.0",
         "mantle-framework/contracts": "^0.7",

--- a/src/mantle/events/composer.json
+++ b/src/mantle/events/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Events Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/container": "^0.7",
         "mantle-framework/contracts": "^0.7",

--- a/src/mantle/facade/composer.json
+++ b/src/mantle/facade/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Facade Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7"
     },

--- a/src/mantle/faker/composer.json
+++ b/src/mantle/faker/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Faker Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "fakerphp/faker": "^1.16"
     },

--- a/src/mantle/filesystem/composer.json
+++ b/src/mantle/filesystem/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Filesystem Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "league/flysystem": "^1.1",
         "league/flysystem-cached-adapter": "^1.1",

--- a/src/mantle/http-client/composer.json
+++ b/src/mantle/http-client/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Http Client Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/wp-concurrent-remote-requests": "^1.0.0",
         "mantle-framework/support": "^0.7"
     },

--- a/src/mantle/http/composer.json
+++ b/src/mantle/http/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Http Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "illuminate/view": "^8.6",
         "mantle-framework/contracts": "^0.7",
         "mantle-framework/filesystem": "^0.7",

--- a/src/mantle/log/composer.json
+++ b/src/mantle/log/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Log Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7",
         "mantle-framework/support": "^0.7",

--- a/src/mantle/query-monitor/composer.json
+++ b/src/mantle/query-monitor/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Query Monitor Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7",
         "mantle-framework/database": "^0.7",

--- a/src/mantle/queue/composer.json
+++ b/src/mantle/queue/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Queue Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "laravel/serializable-closure": "^1.2",
         "mantle-framework/console": "^0.7",

--- a/src/mantle/rest-api/composer.json
+++ b/src/mantle/rest-api/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework REST API Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7"
     },

--- a/src/mantle/scheduling/composer.json
+++ b/src/mantle/scheduling/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Scheduling Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "dragonmantank/cron-expression": "^3.1",
         "guzzlehttp/guzzle": "^6.3.1 || ^7.3",

--- a/src/mantle/support/class-pipeline.php
+++ b/src/mantle/support/class-pipeline.php
@@ -10,6 +10,7 @@ namespace Mantle\Support;
 use Closure;
 use Mantle\Contracts\Container;
 use Mantle\Contracts\Pipeline as PipelineContract;
+use Mantle\Support\Traits\Makeable;
 use RuntimeException;
 use Throwable;
 
@@ -17,6 +18,7 @@ use Throwable;
  * Middleware Pipeline
  */
 class Pipeline implements PipelineContract {
+	use Makeable;
 
 	/**
 	 * The container implementation.

--- a/src/mantle/support/composer.json
+++ b/src/mantle/support/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework Support Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7",
         "monolog/monolog": "^2.7",

--- a/src/mantle/testing/composer.json
+++ b/src/mantle/testing/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["testing", "mantle"],
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7",
         "mantle-framework/database": "^0.7",

--- a/src/mantle/testing/factory/class-attachment-factory.php
+++ b/src/mantle/testing/factory/class-attachment-factory.php
@@ -42,14 +42,9 @@ class Attachment_Factory extends Post_Factory {
 	 * @return int|null|
 	 */
 	public function create( array $args = [] ): ?int {
-		return Attachment::create(
-			array_merge(
-				[
-					'post_type' => 'attachment',
-				],
-				$args
-			)
-		)->id();
+		$args['post_type'] = 'attachment';
+
+		return $this->make( $args, Attachment::class )?->id();
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-blog-factory.php
+++ b/src/mantle/testing/factory/class-blog-factory.php
@@ -42,17 +42,18 @@ class Blog_Factory extends Factory {
 	 */
 	public function create( array $args = [] ) {
 		global $current_site, $base;
-		return Site::create(
-			array_merge(
-				[
-					'domain'     => $current_site->domain,
-					'path'       => $base . $this->faker->slug(),
-					'title'      => $this->faker->text(),
-					'network_id' => $current_site->id,
-				],
-				$args
-			)
-		)->id();
+
+		$args = array_merge(
+			[
+				'domain'     => $current_site->domain,
+				'path'       => $base . $this->faker->slug(),
+				'title'      => $this->faker->text(),
+				'network_id' => $current_site->id,
+			],
+			$args
+		);
+
+		return $this->make( $args, Site::class )?->id();
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-comment-factory.php
+++ b/src/mantle/testing/factory/class-comment-factory.php
@@ -58,7 +58,7 @@ class Comment_Factory extends Factory {
 			$args
 		);
 
-		return Comment::create( $args )->id();
+		return $this->make( $args, Comment::class )?->id();
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-factory.php
+++ b/src/mantle/testing/factory/class-factory.php
@@ -120,4 +120,20 @@ abstract class Factory {
 
 		return $this->get_object_by_id( $object_id );
 	}
+
+	/**
+	 * Pass arguments through the middleware and return a core object.
+	 *
+	 * @param array  $args  Arguments to pass through the middleware.
+	 * @param string $class Model class name.
+	 * @return TObject|Core_Object
+	 */
+	protected function make( array $args, string $class ) {
+		return Pipeline::make()
+			->send( $args )
+			->through( $this->middleware )
+			->then(
+				fn ( array $args ) => $class::create( $args )
+			);
+	}
 }

--- a/src/mantle/testing/factory/class-factory.php
+++ b/src/mantle/testing/factory/class-factory.php
@@ -8,6 +8,7 @@
 namespace Mantle\Testing\Factory;
 
 use Mantle\Contracts\Database\Core_Object;
+use Mantle\Support\Pipeline;
 
 use function Mantle\Support\Helpers\collect;
 use function Mantle\Support\Helpers\tap;
@@ -24,6 +25,13 @@ abstract class Factory {
 	 * @var bool
 	 */
 	protected bool $as_models = false;
+
+	/**
+	 * Array of pipes (middleware) to run through.
+	 *
+	 * @var array<callable>
+	 */
+	public array $middleware = [];
 
 	/**
 	 * Creates an object.
@@ -66,6 +74,21 @@ abstract class Factory {
 	}
 
 	/**
+	 * Create a new factory instance with middleware.
+	 *
+	 * @param array $middleware Middleware to run the factory through.
+	 * @return static
+	 */
+	public function with_middleware( $middleware ) {
+		return tap(
+			clone $this,
+			fn ( $factory ) => $factory->middleware = collect( $this->middleware )
+				->merge( $middleware )
+				->all(),
+		);
+	}
+
+	/**
 	 * Creates multiple objects.
 	 *
 	 * @param int   $count Amount of objects to create.
@@ -77,9 +100,7 @@ abstract class Factory {
 		return collect()
 			->pad( $count, null )
 			->map(
-				function() use ( $args ) {
-					return $this->create( $args );
-				}
+				fn() => $this->create( $args ),
 			)
 			->to_array();
 	}

--- a/src/mantle/testing/factory/class-post-factory.php
+++ b/src/mantle/testing/factory/class-post-factory.php
@@ -50,7 +50,7 @@ class Post_Factory extends Factory {
 	/**
 	 * Create a new factory instance to create posts with a set of terms.
 	 *
-	 * @param array<int, WP_Term|int|string>|WP_Term|int|string ...$terms Terms to assign to the post.
+	 * @param array<int, WP_Term|int|string>|WP_Term|int|string> ...$terms Terms to assign to the post.
 	 * @return static
 	 */
 	public function with_terms( ...$terms ) {

--- a/src/mantle/testing/factory/class-post-factory.php
+++ b/src/mantle/testing/factory/class-post-factory.php
@@ -11,7 +11,6 @@ use Carbon\Carbon;
 use Closure;
 use Faker\Generator;
 use Mantle\Database\Model\Post;
-use Mantle\Support\Pipeline;
 use WP_Post;
 
 use function Mantle\Support\Helpers\collect;
@@ -112,12 +111,7 @@ class Post_Factory extends Factory {
 			$args
 		);
 
-		return Pipeline::make()
-			->send( $args )
-			->through( $this->middleware )
-			->then(
-				fn ( array $args ) => Post::create( $args ),
-			)?->id();
+		return $this->make( $args, Post::class )?->id();
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-term-factory.php
+++ b/src/mantle/testing/factory/class-term-factory.php
@@ -59,7 +59,7 @@ class Term_Factory extends Factory {
 			$args
 		);
 
-		return Term::create( $args )->id();
+		return $this->make( $args, Term::class )?->id();
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-user-factory.php
+++ b/src/mantle/testing/factory/class-user-factory.php
@@ -9,6 +9,7 @@ namespace Mantle\Testing\Factory;
 
 use Faker\Generator;
 use Mantle\Database\Model\User;
+use Mantle\Support\Pipeline;
 
 use function Mantle\Support\Helpers\get_user_object;
 
@@ -41,16 +42,16 @@ class User_Factory extends Factory {
 	 * @return int|null
 	 */
 	public function create( array $args = [] ): ?int {
-		return User::create(
-			array_merge(
-				[
-					'user_email' => $this->faker->email(),
-					'user_login' => $this->faker->userName(),
-					'user_pass'  => 'password',
-				],
-				$args
-			)
-		)->id();
+		$args = array_merge(
+			[
+				'user_email' => $this->faker->email(),
+				'user_login' => $this->faker->userName(),
+				'user_pass'  => 'password',
+			],
+			$args
+		);
+
+		return $this->make( $args, User::class )?->id();
 	}
 
 	/**

--- a/src/mantle/testkit/composer.json
+++ b/src/mantle/testkit/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["testing", "mantle"],
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/config": "^0.7",
         "mantle-framework/container": "^0.7",

--- a/src/mantle/view/composer.json
+++ b/src/mantle/view/composer.json
@@ -3,7 +3,7 @@
     "description": "The Mantle Framework View Package",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
         "mantle-framework/contracts": "^0.7"
     },

--- a/tests/framework/events/test-discover-events.php
+++ b/tests/framework/events/test-discover-events.php
@@ -55,18 +55,11 @@ class Test_Discover_Events extends Framework_Test_Case {
 			'pre_get_posts' => [
 				[ Example_Listener::class . '@on_pre_get_posts_at_20', 20 ],
 			],
-			'attribute-event' => $is_php_8 ? [
+			'attribute-event' => [
 				[ Example_Listener::class . '@handle_attribute_string_callback', 10 ],
 				[ Example_Listener::class . '@handle_attribute_string_callback_priority', 20 ],
-			] : null,
+			],
 		];
-
-		// Filter out expected events for PHP 7.4.
-		if ( ! $is_php_8 ) {
-			$expected = collect( $expected )
-				->filter( fn ( $events ) => null !== $events )
-				->to_array();
-		}
 
 		$this->assertEquals( $expected, $events );
 	}


### PR DESCRIPTION
Allows for fluent creation of posts with terms/meta. Adds support for middleware when factory objects are being created.

```
static::factory()->post->with_terms( ... )->create();
```