### PR TITLE
Use the existing WP_CORE_DIR if one exists

### DIFF
--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -7,6 +7,7 @@
 
 namespace Mantle\Testing;
 
+use Mantle\Support\Str;
 use Mantle\Testing\Doubles\Spy_REST_Server;
 use function Termwind\render;
 
@@ -203,7 +204,7 @@ class Utils {
 		global $table_prefix;
 
 		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
-		defined( 'ABSPATH' ) || define( 'ABSPATH', ensure_trailingslash( preg_replace( '#/wp-content/.*$#', '/', __DIR__ ) ) );
+		defined( 'ABSPATH' ) || define( 'ABSPATH', Str::trailing_slash( preg_replace( '#/wp-content/.*$#', '/', __DIR__ ) ) );
 		defined( 'WP_DEBUG' ) || define( 'WP_DEBUG', true );
 
 		defined( 'DB_NAME' ) || define( 'DB_NAME', static::DEFAULT_DB_NAME );

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -47,13 +47,13 @@ if ( defined( 'WP_TESTS_CONFIG_FILE_PATH' ) && ! empty( WP_TESTS_CONFIG_FILE_PAT
 		/**
 		 * Install WordPress automatically in the /tmp/wordpress folder.
 		 *
-		 * Retrieves the latest installation command from Mantle's GitHub and runs it
-		 * to install WordPress to a temporary folder (/tmp/wordpress by default).
-		 * This unlocks the ability to run `composer run phpunit` both locally and in
-		 * CI tests.
+		 * Retrieves the latest installation command from Mantle's GitHub and runs
+		 * it to install WordPress to a temporary folder (WP_CORE_DIR if set falling
+		 * back to /tmp/wordpress). This unlocks the ability to run `composer run
+		 * phpunit` both locally and in CI tests.
 		 */
 
-		defined( 'WP_TESTS_INSTALL_PATH' ) || define( 'WP_TESTS_INSTALL_PATH', '/tmp/wordpress' );
+		defined( 'WP_TESTS_INSTALL_PATH' ) || define( 'WP_TESTS_INSTALL_PATH', getenv( 'WP_CORE_DIR' ) ?: '/tmp/wordpress' );
 
 		$config_file_path = WP_TESTS_INSTALL_PATH . '/wp-tests-config.php';
 

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -36,27 +36,36 @@ global $wpdb,
 if ( defined( 'WP_TESTS_CONFIG_FILE_PATH' ) && ! empty( WP_TESTS_CONFIG_FILE_PATH ) && is_readable( WP_TESTS_CONFIG_FILE_PATH ) ) {
 	$config_file_path = WP_TESTS_CONFIG_FILE_PATH;
 } elseif ( false === strpos( __DIR__, '/wp-content/' ) ) {
-	/**
-	 * Install WordPress automatically in the /tmp/wordpress folder.
-	 *
-	 * Retrieves the latest installation command from Mantle's GitHub and runs it
-	 * to install WordPress to a temporary folder (/tmp/wordpress by default).
-	 * This unlocks the ability to run `composer run phpunit` both locally and in
-	 * CI tests.
-	 */
+	// Check if WP_CORE_DIR is defined and points to a valid installation.
+	if ( getenv( 'WP_CORE_DIR' ) && ! defined( 'WP_TESTS_INSTALL_PATH' ) && is_readable( getenv( 'WP_CORE_DIR' ) . '/wp-load.php' ) ) {
+		define( 'WP_TESTS_INSTALL_PATH', getenv( 'WP_CORE_DIR' ) );
 
-	defined( 'WP_TESTS_INSTALL_PATH' ) || define( 'WP_TESTS_INSTALL_PATH', '/tmp/wordpress' );
+		Utils::info( 'Using the WP_CORE_DIR environment variable: ' . WP_TESTS_INSTALL_PATH );
 
-	$config_file_path = WP_TESTS_INSTALL_PATH . '/wp-tests-config.php';
+		$config_file_path = WP_TESTS_INSTALL_PATH . '/wp-tests-config.php';
+	} else {
+		/**
+		 * Install WordPress automatically in the /tmp/wordpress folder.
+		 *
+		 * Retrieves the latest installation command from Mantle's GitHub and runs it
+		 * to install WordPress to a temporary folder (/tmp/wordpress by default).
+		 * This unlocks the ability to run `composer run phpunit` both locally and in
+		 * CI tests.
+		 */
 
-	// Install WordPress if we're not in the sub-process that installs WordPress.
-	if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
-		Utils::info(
-			'WordPress installation not found, installing in temporary directory: <em>' . WP_TESTS_INSTALL_PATH . '</em>'
-		);
+		defined( 'WP_TESTS_INSTALL_PATH' ) || define( 'WP_TESTS_INSTALL_PATH', '/tmp/wordpress' );
 
-		// Download the latest installation command from GitHub and install WordPress.
-		Utils::install_wordpress( WP_TESTS_INSTALL_PATH );
+		$config_file_path = WP_TESTS_INSTALL_PATH . '/wp-tests-config.php';
+
+		// Install WordPress if we're not in the sub-process that installs WordPress.
+		if ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) {
+			Utils::info(
+				'WordPress installation not found, installing in temporary directory: <em>' . WP_TESTS_INSTALL_PATH . '</em>'
+			);
+
+			// Download the latest installation command from GitHub and install WordPress.
+			Utils::install_wordpress( WP_TESTS_INSTALL_PATH );
+		}
 	}
 } else {
 	// The project is being loaded from inside a WordPress installation.


### PR DESCRIPTION
Fixes a conflict @kevinfodness noted where Broadway already has `WP_CORE_DIR` defined. If the variable is defined and the site isn't running in an existing WordPress installation it will use that variable's setting to store where WordPress should be installed for testing.