### PR TITLE
Enable PHP 8.1 Support

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,3 +11,5 @@ on:
 jobs:
   coding-standards:
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
+    with:
+      php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [8.0]
+        php: [8.0, 8.1]
         wordpress: ["latest"]
         multisite: [true, false]
     uses: alleyinteractive/.github/.github/workflows/php-tests.yml@main

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "voku/portable-ascii": "^1.4"
     },
     "require-dev": {
-        "alleyinteractive/alley-coding-standards": "^0.3 || ^0.4 || ^1.0",
+        "alleyinteractive/alley-coding-standards": "^1.0",
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^9.3.3",
         "symplify/monorepo-builder": "^10.1"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "laravel/serializable-closure": "^1.2",
         "league/flysystem": "^1.1",
         "league/flysystem-cached-adapter": "^1.1",
-        "monolog/monolog": "^2.7 || ^3.0",
+        "monolog/monolog": "^2.7",
         "nesbot/carbon": "^2.53",
         "nette/php-generator": "^3.6",
         "nunomaduro/termwind": "^1.14",

--- a/src/mantle/config/class-repository.php
+++ b/src/mantle/config/class-repository.php
@@ -93,7 +93,7 @@ class Repository implements ArrayAccess, Config_Contract {
 	 * @param mixed $offset Offset to retrieve.
 	 * @return mixed
 	 */
-	public function offsetGet( mixed $offset ) {
+	public function offsetGet( mixed $offset ): mixed {
 		return $this->get( $offset );
 	}
 

--- a/src/mantle/config/class-repository.php
+++ b/src/mantle/config/class-repository.php
@@ -83,7 +83,7 @@ class Repository implements ArrayAccess, Config_Contract {
 	 * @param mixed $offset Offset to retrieve.
 	 * @return bool
 	 */
-	public function offsetExists( $offset ): bool {
+	public function offsetExists( mixed $offset ): bool {
 		return $this->has( $offset );
 	}
 
@@ -93,7 +93,7 @@ class Repository implements ArrayAccess, Config_Contract {
 	 * @param mixed $offset Offset to retrieve.
 	 * @return mixed
 	 */
-	public function offsetGet( $offset ) {
+	public function offsetGet( mixed $offset ) {
 		return $this->get( $offset );
 	}
 
@@ -103,7 +103,7 @@ class Repository implements ArrayAccess, Config_Contract {
 	 * @param mixed $offset Offset to set.
 	 * @param mixed $value Value to set.
 	 */
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( mixed $offset, mixed $value ): void {
 		$this->set( $offset, $value );
 	}
 
@@ -112,7 +112,7 @@ class Repository implements ArrayAccess, Config_Contract {
 	 *
 	 * @param mixed $offset Offset to unset.
 	 */
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( mixed $offset ): void {
 		$this->set( $offset, null );
 	}
 }

--- a/src/mantle/container/class-container.php
+++ b/src/mantle/container/class-container.php
@@ -1159,8 +1159,8 @@ class Container implements ArrayAccess, Container_Contract {
 	 * @param  mixed $key
 	 * @return mixed
 	 */
-	public function offsetGet( mixed $key ) {
-			return $this->make( $key );
+	public function offsetGet( mixed $key ): mixed {
+		return $this->make( $key );
 	}
 
 	/**

--- a/src/mantle/database/factory/class-factory.php
+++ b/src/mantle/database/factory/class-factory.php
@@ -249,7 +249,7 @@ class Factory implements ArrayAccess {
 	 *
 	 * @return bool
 	 */
-	public function offsetExists( $offset ) {
+	public function offsetExists( mixed $offset ): bool {
 		return isset( $this->definitions[ $offset ] );
 	}
 
@@ -260,7 +260,7 @@ class Factory implements ArrayAccess {
 	 *
 	 * @return mixed
 	 */
-	public function offsetGet( $offset ) {
+	public function offsetGet( mixed $offset ): mixed {
 		return $this->make( $offset );
 	}
 
@@ -272,11 +272,8 @@ class Factory implements ArrayAccess {
 	 *
 	 * @return void
 	 */
-	public function offsetSet( $offset, $value ) {
-		$this->define(
-			$offset, // phpcs:ignore
-			$value
-		);
+	public function offsetSet( mixed $offset, mixed $value ): void {
+		$this->define( $offset, $value );
 	}
 
 	/**
@@ -286,7 +283,7 @@ class Factory implements ArrayAccess {
 	 *
 	 * @return void
 	 */
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( mixed $offset ): void {
 		unset( $this->definitions[ $offset ] );
 	}
 }

--- a/src/mantle/database/factory/class-factory.php
+++ b/src/mantle/database/factory/class-factory.php
@@ -245,8 +245,7 @@ class Factory implements ArrayAccess {
 	/**
 	 * Determine if the given offset exists.
 	 *
-	 * @param string $offset
-	 *
+	 * @param mixed $offset Offset to check on.
 	 * @return bool
 	 */
 	public function offsetExists( mixed $offset ): bool {
@@ -256,8 +255,7 @@ class Factory implements ArrayAccess {
 	/**
 	 * Get the value of the given offset.
 	 *
-	 * @param string $offset
-	 *
+	 * @param mixed $offset Offset to retrieve.
 	 * @return mixed
 	 */
 	public function offsetGet( mixed $offset ): mixed {
@@ -267,9 +265,8 @@ class Factory implements ArrayAccess {
 	/**
 	 * Set the given offset to the given value.
 	 *
-	 * @param string   $offset
-	 * @param callable $value
-	 *
+	 * @param mixed  $offset Offset to assign the value to.
+	 * @param mixed  $value Value to set.
 	 * @return void
 	 */
 	public function offsetSet( mixed $offset, mixed $value ): void {
@@ -279,8 +276,7 @@ class Factory implements ArrayAccess {
 	/**
 	 * Unset the value at the given offset.
 	 *
-	 * @param string $offset
-	 *
+	 * @param mixed $offset Offset to unset.
 	 * @return void
 	 */
 	public function offsetUnset( mixed $offset ): void {

--- a/src/mantle/database/model/class-model.php
+++ b/src/mantle/database/model/class-model.php
@@ -317,7 +317,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param string $offset Array offset.
 	 * @return bool
 	 */
-	public function offsetExists( $offset ): bool {
+	public function offsetExists( mixed $offset ): bool {
 		return null !== $this->get( $offset );
 	}
 
@@ -327,7 +327,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param string $offset Array offset.
 	 * @return mixed
 	 */
-	public function offsetGet( $offset ) {
+	public function offsetGet( mixed $offset ): mixed {
 		return $this->get( $offset );
 	}
 
@@ -337,8 +337,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 * @param string $offset Offset name.
 	 * @param mixed  $value Value to set.
 	 */
-	public function offsetSet( $offset, $value ) {
-		return $this->set( $offset, $value );
+	public function offsetSet( mixed $offset, mixed $value ): void {
+		$this->set( $offset, $value );
 	}
 
 	/**
@@ -346,7 +346,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	 *
 	 * @param string $offset Offset to unset.
 	 */
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( mixed $offset ): void {
 		$this->set( $offset, null );
 		unset( $this->relations[ $offset ] );
 	}

--- a/src/mantle/database/model/class-model.php
+++ b/src/mantle/database/model/class-model.php
@@ -314,7 +314,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	/**
 	 * Check if an offset exists.
 	 *
-	 * @param string $offset Array offset.
+	 * @param mixed $offset Array offset.
 	 * @return bool
 	 */
 	public function offsetExists( mixed $offset ): bool {
@@ -324,7 +324,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	/**
 	 * Get data by the offset.
 	 *
-	 * @param string $offset Array offset.
+	 * @param mixed $offset Array offset.
 	 * @return mixed
 	 */
 	public function offsetGet( mixed $offset ): mixed {
@@ -334,8 +334,8 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	/**
 	 * Set data by offset.
 	 *
-	 * @param string $offset Offset name.
-	 * @param mixed  $value Value to set.
+	 * @param mixed $offset Offset name.
+	 * @param mixed $value Value to set.
 	 */
 	public function offsetSet( mixed $offset, mixed $value ): void {
 		$this->set( $offset, $value );
@@ -344,7 +344,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	/**
 	 * Unset data by offset.
 	 *
-	 * @param string $offset Offset to unset.
+	 * @param mixed $offset Offset to unset.
 	 */
 	public function offsetUnset( mixed $offset ): void {
 		$this->set( $offset, null );

--- a/src/mantle/database/model/class-model.php
+++ b/src/mantle/database/model/class-model.php
@@ -576,9 +576,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 	/**
 	 * Convert the object into something JSON serializable.
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): mixed {
 		return $this->to_array();
 	}
 }

--- a/src/mantle/database/pagination/class-paginator.php
+++ b/src/mantle/database/pagination/class-paginator.php
@@ -488,9 +488,9 @@ class Paginator implements Arrayable, ArrayAccess, Countable, Jsonable, JsonSeri
 	/**
 	 * Convert the object into something JSON serializable.
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): mixed {
 		return $this->to_array();
 	}
 

--- a/src/mantle/database/pagination/class-paginator.php
+++ b/src/mantle/database/pagination/class-paginator.php
@@ -27,6 +27,13 @@ use Mantle\Support\Str;
  */
 class Paginator implements Arrayable, ArrayAccess, Countable, Jsonable, JsonSerializable, Htmlable, PaginatorContract {
 	/**
+	 * Query parameters to append.
+	 *
+	 * @var array<string, string>
+	 */
+	public $append = [];
+
+	/**
 	 * Current page number
 	 *
 	 * @var int
@@ -503,7 +510,7 @@ class Paginator implements Arrayable, ArrayAccess, Countable, Jsonable, JsonSeri
 	 * @param mixed $offset Array offset.
 	 * @return bool
 	 */
-	public function offsetExists( $offset ): bool {
+	public function offsetExists( mixed $offset ): bool {
 		return isset( $this->items[ $offset ] );
 	}
 
@@ -513,7 +520,7 @@ class Paginator implements Arrayable, ArrayAccess, Countable, Jsonable, JsonSeri
 	 * @param mixed $offset Offset to get.
 	 * @return mixed
 	 */
-	public function offsetGet( $offset ) {
+	public function offsetGet( mixed $offset ): mixed {
 		return $this->items[ $offset ];
 	}
 
@@ -524,7 +531,7 @@ class Paginator implements Arrayable, ArrayAccess, Countable, Jsonable, JsonSeri
 	 * @param mixed $value  Value to set.
 	 * @return void
 	 */
-	public function offsetSet( $offset, $value ): void {
+	public function offsetSet( mixed $offset, mixed $value ): void {
 		$this->items[ $offset ] = $value;
 	}
 
@@ -534,7 +541,7 @@ class Paginator implements Arrayable, ArrayAccess, Countable, Jsonable, JsonSeri
 	 * @param mixed $offset Offset to delete.
 	 * @return void
 	 */
-	public function offsetUnset( $offset ): void {
+	public function offsetUnset( mixed $offset ): void {
 		unset( $this->items[ $offset ] );
 	}
 

--- a/src/mantle/support/class-arr.php
+++ b/src/mantle/support/class-arr.php
@@ -606,7 +606,7 @@ class Arr {
 	 * @return string
 	 */
 	public static function query( $array ) {
-		return http_build_query( $array, null, '&', PHP_QUERY_RFC3986 );
+		return http_build_query( $array, '', '&', PHP_QUERY_RFC3986 );
 	}
 
 	/**

--- a/src/mantle/support/class-collection.php
+++ b/src/mantle/support/class-collection.php
@@ -1345,7 +1345,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 * @param    mixed $key
 	 * @return mixed
 	 */
-	public function offsetGet( $key ) {
+	public function offsetGet( mixed $key ): mixed {
 		return $this->items[ $key ];
 	}
 

--- a/src/mantle/support/class-collection.php
+++ b/src/mantle/support/class-collection.php
@@ -2,12 +2,10 @@
 /**
  * Collections class file.
  *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamComment, Squiz.Commenting.FunctionComment.MissingParamTag
+ *
  * @package Mantle
  */
-
-// phpcs:disable Squiz.Commenting.FunctionComment.MissingParamComment
-
-// phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
 
 namespace Mantle\Support;
 
@@ -94,10 +92,10 @@ class Collection implements ArrayAccess, Enumerable {
 	/**
 	 * Get a lazy collection for the items in this collection.
 	 *
-	 * @return \Mantle\Support\LazyCollection
+	 * @return void
 	 */
 	public function lazy() {
-		throw new \RuntimeException( 'Lazy collections are not supported at this time. ');
+		throw new \RuntimeException( 'Lazy collections are not supported at this time. ' ); // phpcs:ignore
 	}
 
 	/**

--- a/src/mantle/support/class-collection.php
+++ b/src/mantle/support/class-collection.php
@@ -17,6 +17,7 @@ use Mantle\Support\Traits\Enumerates_Values;
 use Mantle\Database\Model;
 use function Mantle\Support\Helpers\value;
 use stdClass;
+use Traversable;
 
 /**
  * Collection
@@ -96,7 +97,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 * @return \Mantle\Support\LazyCollection
 	 */
 	public function lazy() {
-		return new LazyCollection( $this->items );
+		throw new \RuntimeException( 'Lazy collections are not supported at this time. ');
 	}
 
 	/**
@@ -1091,7 +1092,7 @@ class Collection implements ArrayAccess, Enumerable {
 
 		$callback && is_callable( $callback )
 			? uasort( $items, $callback )
-			: asort( $items, $callback );
+			: asort( $items, $callback ?? SORT_REGULAR );
 
 		return new static( $items );
 	}
@@ -1296,7 +1297,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 *
 	 * @return \ArrayIterator
 	 */
-	public function getIterator() {
+	public function getIterator(): Traversable {
 		return new ArrayIterator( $this->items );
 	}
 
@@ -1305,7 +1306,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 *
 	 * @return int
 	 */
-	public function count() {
+	public function count(): int {
 		return count( $this->items );
 	}
 
@@ -1336,7 +1337,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 * @param    mixed $key
 	 * @return bool
 	 */
-	public function offsetExists( $key ) {
+	public function offsetExists( mixed $key ): bool {
 		return array_key_exists( $key, $this->items );
 	}
 
@@ -1357,7 +1358,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 * @param    mixed $value
 	 * @return void
 	 */
-	public function offsetSet( $key, $value ) {
+	public function offsetSet( mixed $key, mixed $value ): void {
 		if ( is_null( $key ) ) {
 			$this->items[] = $value;
 		} else {
@@ -1371,7 +1372,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 * @param    string $key
 	 * @return void
 	 */
-	public function offsetUnset( $key ) {
+	public function offsetUnset( $key ): void {
 		unset( $this->items[ $key ] );
 	}
 }

--- a/src/mantle/support/traits/trait-enumerates-values.php
+++ b/src/mantle/support/traits/trait-enumerates-values.php
@@ -772,9 +772,9 @@ trait Enumerates_Values {
 	/**
 	 * Convert the object into something JSON serializable.
 	 *
-	 * @return array
+	 * @return mixed
 	 */
-	public function jsonSerialize() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function jsonSerialize(): mixed { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return array_map(
 			function ( $value ) {
 				if ( $value instanceof JsonSerializable ) {

--- a/src/mantle/testing/class-assertable-json-string.php
+++ b/src/mantle/testing/class-assertable-json-string.php
@@ -321,7 +321,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * @param  mixed  $offset
 	 * @return bool
 	 */
-	public function offsetExists( $offset ): bool {
+	public function offsetExists( mixed $offset ): bool {
 		return isset( $this->decoded[ $offset ] );
 	}
 
@@ -342,7 +342,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * @param  mixed  $value
 	 * @return void
 	 */
-	public function offsetSet($offset, $value): void {
+	public function offsetSet( mixed $offset, mixed $value): void {
 		$this->decoded[ $offset ] = $value;
 	}
 
@@ -352,7 +352,7 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * @param  string  $offset
 	 * @return void
 	 */
-	public function offsetUnset($offset): void {
+	public function offsetUnset( mixed $offset ): void {
 		unset( $this->decoded[ $offset ] );
 	}
 }

--- a/tests/helpers/test-helpers-array.php
+++ b/tests/helpers/test-helpers-array.php
@@ -330,22 +330,22 @@ class SupportTestArrayAccess implements ArrayAccess
 		$this->attributes = $attributes;
 	}
 
-	public function offsetExists($offset)
+	public function offsetExists( mixed $offset ): bool
 	{
 		return array_key_exists($offset, $this->attributes);
 	}
 
-	public function offsetGet($offset)
+	public function offsetGet( mixed $offset ): mixed
 	{
 		return $this->attributes[$offset];
 	}
 
-	public function offsetSet($offset, $value)
+	public function offsetSet( mixed $offset, mixed $value ): void
 	{
 		$this->attributes[$offset] = $value;
 	}
 
-	public function offsetUnset($offset)
+	public function offsetUnset( mixed $offset ): void
 	{
 		unset($this->attributes[$offset]);
 	}

--- a/tests/support/test-collection.php
+++ b/tests/support/test-collection.php
@@ -4464,14 +4464,14 @@ class TestJsonableObject implements Jsonable {
 }
 
 class TestJsonSerializeObject implements JsonSerializable {
-	public function jsonSerialize()
+	public function jsonSerialize(): mixed
 	{
 		return ['foo' => 'bar'];
 	}
 }
 
 class TestJsonSerializeWithScalarValueObject implements JsonSerializable {
-	public function jsonSerialize()
+	public function jsonSerialize(): mixed
 	{
 		return 'foo';
 	}

--- a/tests/support/test-collection.php
+++ b/tests/support/test-collection.php
@@ -4428,22 +4428,22 @@ class TestArrayAccessImplementation implements ArrayAccess {
 		$this->arr = $arr;
 	}
 
-	public function offsetExists($offset)
+	public function offsetExists( mixed $offset ): bool
 	{
 		return isset($this->arr[$offset]);
 	}
 
-	public function offsetGet($offset)
+	public function offsetGet( mixed $offset ): mixed
 	{
 		return $this->arr[$offset];
 	}
 
-	public function offsetSet($offset, $value)
+	public function offsetSet( mixed $offset, mixed $value ): void
 	{
 		$this->arr[$offset] = $value;
 	}
 
-	public function offsetUnset($offset)
+	public function offsetUnset( mixed $offset ): void
 	{
 		unset($this->arr[$offset]);
 	}


### PR DESCRIPTION
Resolves #230

- [x] Fix deprecation changes for PHP 8.1
- [ ] Ensure all phpcs test pass for 8.1.

Currently, the latest stable version `wordpress/wpcs` (2.3) does not support PHP 8.1 (see https://github.com/WordPress/WordPress-Coding-Standards/issues/2035). We will need to make some upstream changes in https://github.com/alleyinteractive/alley-coding-standards to make it work.