### PR TITLE
Make wp_insert_post return WP_Error

### DIFF
--- a/src/mantle/queue/providers/wordpress/class-provider.php
+++ b/src/mantle/queue/providers/wordpress/class-provider.php
@@ -122,7 +122,8 @@ class Provider implements Provider_Contract {
 				'meta_input'  => [
 					'_mantle_queue' => $job,
 				],
-			]
+			],
+			true
 		);
 
 		if ( is_wp_error( $insert ) ) {


### PR DESCRIPTION
as it is tested with `is_wp_error`
https://developer.wordpress.org/reference/functions/wp_insert_post/

Please consider using PHPStan.
