### PR TITLE
Improve reporting of stray HTTP requests

### DIFF
--- a/src/mantle/testing/concerns/trait-interacts-with-requests.php
+++ b/src/mantle/testing/concerns/trait-interacts-with-requests.php
@@ -315,6 +315,10 @@ trait Interacts_With_Requests {
 	 * @return void
 	 */
 	protected function report_stray_requests(): void {
+		if ( ! isset( $this->recorded_actual_requests ) || $this->recorded_actual_requests->is_empty() ) {
+			return;
+		}
+
 		$this->recorded_actual_requests->map(
 			fn ( $method, $index ) => Utils::info(
 				"An HTTP request was made in <span class='font-bold'>{$method}</span> to <span class='font-bold'>{$this->recorded_requests[ $index ]->url()}</span> but no faked response was found.",

--- a/tests/scheduling/test-frequency.php
+++ b/tests/scheduling/test-frequency.php
@@ -14,6 +14,8 @@ class Test_Frequency extends Framework_Test_Case {
 	protected $event;
 
 	protected function setUp(): void {
+		parent::setUp();
+
 		$this->event = new Event(
 			'php foo'
 		);


### PR DESCRIPTION
<img width="1733" alt="Screenshot 2023-03-30 at 1 13 33 PM" src="https://user-images.githubusercontent.com/346399/228913858-f7dfe622-429a-47cd-aa07-8945db35c824.png">

Improve the reporting of stray HTTP requests. Previously stray requests were logged and reported when they were made. This works well for isolated unit tests but when a request was made on a page (when the output buffer is used), the log fell on silent ears. We'll now alert on tear down that a stray request was made.