### PR TITLE
Add a with_image() helper to create an attachment with a real image

### DIFF
--- a/src/mantle/testing/factory/class-attachment-factory.php
+++ b/src/mantle/testing/factory/class-attachment-factory.php
@@ -119,7 +119,7 @@ class Attachment_Factory extends Post_Factory {
 	 *
 	 * @return int|\WP_Error The attachment ID on success. The value 0 or WP_Error on failure.
 	 */
-	public function create_upload_object( $file, $parent = 0 ) {
+	public function create_upload_object( $file, $parent = 0 ): int|\WP_Error {
 		return $this->with_image( $file, $parent )->create();
 	}
 

--- a/src/mantle/testing/factory/class-attachment-factory.php
+++ b/src/mantle/testing/factory/class-attachment-factory.php
@@ -7,9 +7,12 @@
 
 namespace Mantle\Testing\Factory;
 
+use Closure;
 use Faker\Generator;
 use Mantle\Database\Model\Attachment;
+use Mantle\Database\Model\Model;
 use Mantle\Database\Model\Post;
+use WP_Post;
 
 use function Mantle\Support\Helpers\get_post_object;
 
@@ -48,7 +51,69 @@ class Attachment_Factory extends Post_Factory {
 	}
 
 	/**
+	 * Create an attachment object with an underlying image file.
+	 *
+	 * @param string $file   The file name to create attachment object from.
+	 * @param int    $parent The parent post ID.
+	 * @param int    $width  The width of the image.
+	 * @param int    $height The height of the image.
+	 * @return static
+	 */
+	public function with_image( string $file = null, int $parent = 0, int $width = 640, int $height = 480 ): static {
+		if ( ! $file ) {
+			$file = $this->faker->image( sys_get_temp_dir(), $width, $height );
+		}
+
+		return $this->with_middleware(
+			function ( array $args, Closure $next ) use ( $file, $parent ) {
+				if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+					require_once ABSPATH . 'wp-admin/includes/image.php';
+				}
+
+				$contents = file_get_contents( $file ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+				$upload   = wp_upload_bits( wp_basename( $file ), null, $contents );
+
+				$type = '';
+				if ( ! empty( $upload['type'] ) ) {
+					$type = $upload['type'];
+				} else {
+					$mime = wp_check_filetype( $upload['file'] );
+					if ( $mime ) {
+						$type = $mime['type'];
+					}
+				}
+
+				$args = array_merge(
+					$args,
+					[
+						'file'           => $file,
+						'post_title'     => wp_basename( $upload['file'] ),
+						'post_content'   => '',
+						'post_type'      => 'attachment',
+						'post_parent'    => $parent,
+						'post_mime_type' => $type,
+						'guid'           => $upload['url'],
+					],
+				);
+
+				// Create the underlying attachment.
+				$attachment = $next( $args );
+
+				$id = $attachment instanceof Model ? $attachment->id() : $attachment;
+				dd($id, $attachment);
+
+				update_attached_file( $id, $upload['file'] );
+				wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $upload['file'] ) );
+
+				return $attachment;
+			}
+		);
+	}
+
+	/**
 	 * Saves an attachment.
+	 *
+	 * @deprecated Use the `with_image()` method instead.
 	 *
 	 * @param string $file   The file name to create attachment object for.
 	 * @param int    $parent ID of the post to attach the file to.
@@ -56,48 +121,18 @@ class Attachment_Factory extends Post_Factory {
 	 * @return int|\WP_Error The attachment ID on success. The value 0 or WP_Error on failure.
 	 */
 	public function create_upload_object( $file, $parent = 0 ) {
-		if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/image.php';
-		}
-
-		$contents = file_get_contents( $file ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
-		$upload   = wp_upload_bits( wp_basename( $file ), null, $contents );
-
-		$type = '';
-		if ( ! empty( $upload['type'] ) ) {
-			$type = $upload['type'];
-		} else {
-			$mime = wp_check_filetype( $upload['file'] );
-			if ( $mime ) {
-				$type = $mime['type'];
-			}
-		}
-
-		$attachment = [
-			'post_title'     => wp_basename( $upload['file'] ),
-			'post_content'   => '',
-			'post_type'      => 'attachment',
-			'post_parent'    => $parent,
-			'post_mime_type' => $type,
-			'guid'           => $upload['url'],
-		];
-
-		// Save the data.
-		$id = wp_insert_attachment( $attachment, $upload['file'], $parent );
-		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $upload['file'] ) );
-
-		return $id;
+		return $this->with_image( $file, $parent )->create();
 	}
 
 	/**
 	 * Retrieves an object by ID.
 	 *
 	 * @param int $object_id The object ID.
-	 * @return \WP_Post|null
+	 * @return Attachment|WP_Post|int|null
 	 */
-	public function get_object_by_id( int $object_id ): ?\WP_Post {
+	public function get_object_by_id( int $object_id ): Attachment|WP_Post|int|null {
 		return $this->as_models
-			? Post::find( $object_id )
+			? Attachment::find( $object_id )
 			: get_post_object( $object_id );
 	}
 }

--- a/src/mantle/testing/factory/class-attachment-factory.php
+++ b/src/mantle/testing/factory/class-attachment-factory.php
@@ -100,7 +100,6 @@ class Attachment_Factory extends Post_Factory {
 				$attachment = $next( $args );
 
 				$id = $attachment instanceof Model ? $attachment->id() : $attachment;
-				dd($id, $attachment);
 
 				update_attached_file( $id, $upload['file'] );
 				wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $upload['file'] ) );

--- a/tests/testing/test-factory.php
+++ b/tests/testing/test-factory.php
@@ -204,6 +204,12 @@ class Test_Factory extends Framework_Test_Case {
 		$this->assertEquals( '_test_meta_value', get_post_meta( $post->ID, '_test_meta_key', true ) );
 	}
 
+	public function test_attachment_with_image() {
+		$attachment = static::factory()->attachment->with_image()->create();
+
+		$this->assertNotEmpty( wp_get_attachment_image_url( $attachment ) );
+	}
+
 	protected function shim_test( string $class_name, string $property ) {
 		$this->assertInstanceOf( $class_name, static::factory()->$property->create_and_get() );
 


### PR DESCRIPTION
Introduces the following to make attachment generation with an actual image file easier:

```php
static::factory()->attachment->with_image()->create()
```