### PR TITLE
Finish removing \Mantle\Support\LazyCollection

### DIFF
--- a/src/mantle/support/class-collection.php
+++ b/src/mantle/support/class-collection.php
@@ -91,15 +91,6 @@ class Collection implements ArrayAccess, Enumerable {
 	}
 
 	/**
-	 * Get a lazy collection for the items in this collection.
-	 *
-	 * @return \Mantle\Support\LazyCollection
-	 */
-	public function lazy() {
-		return new LazyCollection( $this->items );
-	}
-
-	/**
 	 * Get the average value of a given key.
 	 *
 	 * @param    callable|string|null $callback

--- a/tests/support/test-collection.php
+++ b/tests/support/test-collection.php
@@ -300,18 +300,6 @@ class Test_Collection extends Framework_Test_Case {
 		$this->assertEquals(['foo.array', 'bar.array'], $results);
 	}
 
-//	public function testLazyReturnsLazyCollection()
-//	{
-//		$data = new Collection([1, 2, 3, 4, 5]);
-//
-//		$lazy = $data->lazy();
-//
-//		$data->add(6);
-//
-//		$this->assertInstanceOf(LazyCollection::class, $lazy);
-//		$this->assertSame([1, 2, 3, 4, 5], $lazy->all());
-//	}
-
 	/**
 	 * @dataProvider collectionClassProvider
 	 */
@@ -4361,7 +4349,6 @@ class Test_Collection extends Framework_Test_Case {
 	{
 		return [
 			[Collection::class],
-			//[LazyCollection::class],
 		];
 	}
 }


### PR DESCRIPTION
This closes #370 

Finishes removing the old LazyCollection class from code to avoid potential errors.