### PR TITLE
Add support for using SQLite in tests (opt-in)

### DIFF
--- a/src/mantle/testing/class-installation-manager.php
+++ b/src/mantle/testing/class-installation-manager.php
@@ -120,6 +120,16 @@ class Installation_Manager {
 	}
 
 	/**
+	 * Alias for `theme()`.
+	 *
+	 * @param string $theme Theme name.
+	 * @return static
+	 */
+	public function with_theme( string $theme ) {
+		return $this->theme( $theme );
+	}
+
+	/**
 	 * Define the active plugins to be set after the installation is loaded.
 	 *
 	 * @param array<int, string> $plugins Plugin files.
@@ -127,6 +137,16 @@ class Installation_Manager {
 	 */
 	public function plugins( array $plugins ) {
 		return $this->loaded( fn () => update_option( 'active_plugins', $plugins ) );
+	}
+
+	/**
+	 * Alias for `plugins()`.
+	 *
+	 * @param array<int, string> $plugins Plugin files.
+	 * @return static
+	 */
+	public function with_plugins( array $plugins ) {
+		return $this->plugins( $plugins );
 	}
 
 	/**

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -275,16 +275,24 @@ class Utils {
 	 * not install the WordPress database.
 	 *
 	 * @param string $directory Directory to install WordPress in.
-	 * @param bool   $install_vip_mu_plugins Whether to install VIP MU plugins.
-	 * @param bool   $install_object_cache Whether to install the object cache drop-in.
+	 * @param bool   $install_vip_mu_plugins Whether to install VIP MU plugins, defaults to false.
+	 * @param bool   $install_object_cache Whether to install the object cache drop-in, defaults to false.
+	 * @param bool   $use_sqlite_db Whether to use SQLite for the database, defaults to false.
 	 */
-	public static function install_wordpress( string $directory, bool $install_vip_mu_plugins = false, bool $install_object_cache = false ) {
-		$branch = static::env( 'MANTLE_CI_BRANCH', 'HEAD' );
+	public static function install_wordpress(
+		string $directory,
+		bool $install_vip_mu_plugins = false,
+		bool $install_object_cache = false,
+		bool $use_sqlite_db = false,
+	): void {
+		// $branch = static::env( 'MANTLE_CI_BRANCH', 'HEAD' );
+		$branch = static::env( 'MANTLE_CI_BRANCH', 'sqlite-drop-in' );
 
 		$command = sprintf(
-			'export WP_CORE_DIR=%s WP_MULTISITE=%s INSTALL_WP_TEST_DEBUG=%s && curl -s %s | bash -s %s',
+			'export WP_CORE_DIR=%s WP_MULTISITE=%s WP_USE_SQLITE=%s INSTALL_WP_TEST_DEBUG=%s && curl -s %s | bash -s %s',
 			$directory,
 			static::shell_safe( static::env( 'WP_MULTISITE', '0' ) ),
+			static::shell_safe( $use_sqlite_db ),
 			static::shell_safe( static::is_debug_mode() ),
 			"https://raw.githubusercontent.com/alleyinteractive/mantle-ci/{$branch}/install-wp-tests.sh",
 			collect(

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -285,8 +285,7 @@ class Utils {
 		bool $install_object_cache = false,
 		bool $use_sqlite_db = false,
 	): void {
-		// $branch = static::env( 'MANTLE_CI_BRANCH', 'HEAD' );
-		$branch = static::env( 'MANTLE_CI_BRANCH', 'sqlite-drop-in' );
+		$branch = static::env( 'MANTLE_CI_BRANCH', 'HEAD' );
 
 		$command = sprintf(
 			'export WP_CORE_DIR=%s WP_MULTISITE=%s WP_USE_SQLITE=%s INSTALL_WP_TEST_DEBUG=%s && curl -s %s | bash -s %s',

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -68,6 +68,13 @@ trait Rsync_Installation {
 	protected bool $install_object_cache = false;
 
 	/**
+	 * Flag to use a SQLite db.php drop-in when rsyncing the codebase.
+	 *
+	 * @var boolean
+	 */
+	protected bool $use_sqlite_db = false;
+
+	/**
 	 * Exclusions to be used when rsyncing the codebase.
 	 *
 	 * @var string[]
@@ -198,6 +205,25 @@ trait Rsync_Installation {
 	}
 
 	/**
+	 * Install SQLite db.php drop-in into the codebase.
+	 *
+	 * This will only be applied if the codebase is being rsync-ed to a WordPress
+	 * installation.
+	 *
+	 * @param bool $install Install the SQLite db.php drop-in into the codebase.
+	 * @return static
+	 */
+	public function with_sqlite( bool $install = true ): static {
+		if ( ! $this->is_within_wordpress_install() ) {
+			return $this;
+		}
+
+		$this->use_sqlite_db = $install;
+
+		return $this;
+	}
+
+	/**
 	 * Maybe rsync the codebase as a plugin within WordPress.
 	 *
 	 * By default, the from path will be rsynced to `wp-content/plugins/{directory_name}`.
@@ -306,6 +332,7 @@ trait Rsync_Installation {
 				directory: $base_install_path,
 				install_vip_mu_plugins: $this->install_vip_mu_plugins,
 				install_object_cache: $this->install_object_cache,
+				use_sqlite_db: $this->use_sqlite_db,
 			);
 
 			Utils::success(

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -218,6 +218,8 @@ trait Rsync_Installation {
 			return $this;
 		}
 
+		$this->rsync_exclusions[] = 'db.php';
+
 		$this->use_sqlite_db = $install;
 
 		return $this;

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -214,7 +214,7 @@ trait Rsync_Installation {
 	 * @return static
 	 */
 	public function with_sqlite( bool $install = true ): static {
-		if ( ! $this->is_within_wordpress_install() ) {
+		if ( $this->is_within_wordpress_install() ) {
 			return $this;
 		}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,5 +15,4 @@ define( 'MANTLE_TESTING_DEBUG', true );
 \Mantle\Testing\manager()
 	->maybe_rsync_plugin()
 	->with_vip_mu_plugins()
-	->with_sqlite()
 	->install();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,4 +15,5 @@ define( 'MANTLE_TESTING_DEBUG', true );
 \Mantle\Testing\manager()
 	->maybe_rsync_plugin()
 	->with_vip_mu_plugins()
+	->with_sqlite()
 	->install();


### PR DESCRIPTION
Depends on https://github.com/alleyinteractive/mantle-ci/pull/11

Adds opt-in support for using SQLite in tests in place of MySQL. Uses the `db.php` drop-in from https://github.com/aaemnnosttv/wp-sqlite-db