### PR TITLE
Introduce application bootloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,7 @@
         "symfony/string": "^6.0",
         "symfony/var-dumper": "^6.0",
         "vlucas/phpdotenv": "^5.5",
-        "voku/portable-ascii": "^2.0",
-        "wp-coding-standards/wpcs": "dev-php-8-1 as 2.3.x-dev"
+        "voku/portable-ascii": "^2.0"
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0",
@@ -50,7 +49,8 @@
         "phpunit/phpunit": "^9.3.3",
         "predis/predis": "^2.0.2",
         "symplify/monorepo-builder": "^10.1",
-        "szepeviktor/phpstan-wordpress": "^1.2"
+        "szepeviktor/phpstan-wordpress": "^1.2",
+        "wp-coding-standards/wpcs": "dev-php-8-1 as 2.3.x-dev"
     },
     "replace": {
         "mantle-framework/assets": "self.version",

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Application Configuration
+ *
+ * @package Mantle
+ */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Application Debug Mode
+	|--------------------------------------------------------------------------
+	|
+	| Enable detailed error messages with stack traces will be shown on every error
+	| that occurs within your application. If disabled, a simple generic error page
+	| is shown.
+	|
+	*/
+	'debug'     => environment( 'APP_DEBUG', defined( 'WP_DEBUG' ) && WP_DEBUG ),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Service Providers
+	|--------------------------------------------------------------------------
+	|
+	| Providers listed here will be autoloaded for every request on the application.
+	|
+	 */
+	'providers' => [
+		// Framework Providers.
+		Mantle\Filesystem\Filesystem_Service_Provider::class,
+		Mantle\Database\Factory_Service_Provider::class,
+		Mantle\Framework\Providers\Error_Service_Provider::class,
+		Mantle\Database\Model_Service_Provider::class,
+		Mantle\Queue\Queue_Service_Provider::class,
+		Mantle\Query_Monitor\Query_Monitor_Service_Provider::class,
+		Mantle\New_Relic\New_Relic_Service_Provider::class,
+		Mantle\Database\Pagination\Paginator_Service_Provider::class,
+		Mantle\Cache\Cache_Service_Provider::class,
+
+		/*
+		|--------------------------------------------------------------------------
+		| Application Providers
+		|--------------------------------------------------------------------------
+		|
+		| These are the providers that power your application. The above ones are
+		| core to Mantle. The following are designed to be implemented and extended
+		| by your application.
+		|
+		*/
+		Mantle\Application\App_Service_Provider::class,
+		Mantle\Assets\Asset_Service_Provider::class,
+		Mantle\Events\Event_Service_Provider::class,
+		Mantle\Framework\Providers\Route_Service_Provider::class,
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Application Aliases
+	|--------------------------------------------------------------------------
+	|
+	| These are aliases that will be available to the entire application without
+	| the need use the proper namespace.
+	|
+	 */
+	'aliases'   => [
+		'App'     => Mantle\Facade\App::class,
+		'Cache'   => Mantle\Facade\Cache::class,
+		'Config'  => Mantle\Facade\Config::class,
+		'Event'   => Mantle\Facade\Event::class,
+		'Log'     => Mantle\Facade\Log::class,
+		'Queue'   => Mantle\Facade\Queue::class,
+		'Request' => Mantle\Facade\Request::class,
+		'Route'   => Mantle\Facade\Route::class,
+		'View'    => Mantle\Facade\View::class,
+		'Storage' => Mantle\Facade\Storage::class,
+	],
+
+	/*
+	|--------------------------------------------------------------------------
+	| Application Namespace
+	|--------------------------------------------------------------------------
+	|
+	| Used to provide a configurable namespace for class generation.
+	|
+	*/
+	'namespace' => environment( 'APP_NAMESPACE', 'App' ),
+];

--- a/config/assets.php
+++ b/config/assets.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Asset Configuration
+ *
+ * @package Mantle
+ */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Asset Folder
+	|--------------------------------------------------------------------------
+	|
+	| Specify the folder that built assets live in. This defaults to `build/` but
+	| can be customized to any other path.
+	|
+	*/
+	'path' => env( 'ASSET_BUILD_PATH', 'build' ),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Asset URL
+	|--------------------------------------------------------------------------
+	|
+	| This URL is used to properly generate the URL to built assets.
+	*/
+	'url'  => env(
+		'ASSET_BUILD_URL',
+		function_exists( 'plugin_dir_url' ) ? \plugin_dir_url( __DIR__ ) . 'build' : '', // todo: replace with a framework helper method.
+	),
+];

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Cache Configuration
+ *
+ * @package Mantle
+ */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Default Cache Store
+	|--------------------------------------------------------------------------
+	|
+	| Define the default cache store used. Supports "redis", "wordpress", and
+	| "array".
+	|
+	*/
+	'default' => environment( 'CACHE_DRIVER', 'wordpress' ),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Cache Stores
+	|--------------------------------------------------------------------------
+	|
+	| Cache stores can use supported drivers in any combination.
+	|
+	*/
+	'stores'  => [
+		'wordpress' => [
+			'driver' => 'wordpress',
+		],
+		'array'     => [
+			'driver' => 'array',
+		],
+		'redis'     => [
+			'driver'   => 'redis',
+			'host'     => environment( 'REDIS_HOST', '127.0.0.1' ),
+			'password' => environment( 'REDIS_PASSWORD', '' ),
+			'port'     => environment( 'REDIS_PORT', 6379 ),
+			'scheme'   => environment( 'REDIS_SCHEME', 'tcp' ),
+		],
+	],
+];

--- a/config/filesystem.php
+++ b/config/filesystem.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Filesystem Configuration
+ *
+ * @package Mantle
+ */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Default Filesystem Disk
+	|--------------------------------------------------------------------------
+	|
+	| Here you may specify the default filesystem disk that should be used
+	| by the framework. The "local" disk, as well as a variety of cloud
+	| based disks are available to your application. Just store away!
+	|
+	*/
+	'default' => environment( 'FILESYSTEM_DRIVER', 'local' ),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Filesystem Disks
+	|--------------------------------------------------------------------------
+	|
+	| Here you may configure as many filesystem "disks" as you wish, and you
+	| may even configure multiple disks of the same driver. Defaults have
+	| been setup for each driver as an example of the required options.
+	|
+	| Supported Drivers: "local", "ftp", "sftp", "s3"
+	|
+	*/
+	'disks'   => [
+		'local' => [
+			'driver' => 'local',
+		],
+
+		's3'    => [
+			'driver'                   => 's3',
+			'key'                      => environment( 'S3_KEY', '' ),
+			'secret'                   => environment( 'S3_SECRET', '' ),
+			'region'                   => environment( 'S3_REGION', 'us-east-2' ),
+			'bucket'                   => environment( 'S3_BUCKET', '' ),
+			'temporary_url_expiration' => environment( 'S3_TEMPORARY_URL_EXPIRATION', 3600 ),
+		],
+	],
+];

--- a/config/local/app.php
+++ b/config/local/app.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Application Configuration
+ *
+ * @package Mantle
+ */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Application Debug Mode
+	|--------------------------------------------------------------------------
+	|
+	| Enabled by default for local development.
+	|
+	*/
+	'debug' => true,
+];

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Logging Configuration
+ *
+ * @package Mantle
+ */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Default Log Channel
+	|--------------------------------------------------------------------------
+	|
+	| The default log channel that is used when calling the `Log` class.
+	|
+	*/
+	'default'  => environment( 'LOG_CHANNEL', 'stack' ),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Log Channel Configuration
+	|--------------------------------------------------------------------------
+	|
+	| Provides configuration for various log channels. Supported drivers are 'new_relic',
+	| 'ai_logger', 'slack', 'error_log', and 'custom'.
+	|
+	*/
+	'channels' => [
+		'stack'     => [
+			'driver'   => 'stack',
+			'channels' => [ 'error_log' ],
+		],
+
+		'error_log' => [
+			'driver' => 'error_log',
+			'level'  => 'error',
+		],
+
+		'new_relic' => [
+			'driver' => 'new_relic',
+			'level'  => 'error',
+		],
+
+		/**
+		 * Log to the Alley Logger Package
+		 *
+		 * @link https://github.com/alleyinteractive/logger/
+		 */
+		'logger'    => [
+			'driver' => 'ai_logger',
+			'level'  => 'info',
+		],
+
+		/**
+		 * Log to a Slack Webhook
+		 *
+		 * @link https://api.slack.com/messaging/webhooks#create_a_webhook
+		 */
+		'slack'     => [
+			'driver'   => 'slack',
+			'url'      => environment( 'SLACK_URL', '' ),
+			'username' => environment( 'SLACK_USERNAME', 'Mantle Log' ),
+			'emoji'    => ':boom:',
+			'level'    => 'critical',
+		],
+
+		/*
+		|--------------------------------------------------------------------------
+		| Custom Log Channel
+		|--------------------------------------------------------------------------
+		|
+		| Supports passing to a specific handler by class name or Monolog Handler
+		| instance via the 'handler' attribute.
+		|
+		*/
+		'custom'    => [
+			'driver'  => 'custom',
+			'handler' => 'Example\Class\Name',
+		],
+	],
+];

--- a/config/queue.php
+++ b/config/queue.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Queue Configuration
+ *
+ * @package Mantle
+ */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Queue Provider
+	|--------------------------------------------------------------------------
+	|
+	| Define the queue provider used in the application.
+	|
+	*/
+	'default'    => environment( 'QUEUE_CONNECTION', 'wordpress' ),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Queue Batch Size
+	|--------------------------------------------------------------------------
+	|
+	| The amount of items handled in one run of the queue.
+	|
+	*/
+	'batch_size' => environment( 'QUEUE_BATCH_SIZE', 5 ),
+
+	/*
+	|--------------------------------------------------------------------------
+	| Provider Configuration
+	|--------------------------------------------------------------------------
+	|
+	| Control the configuration for the queue providers.
+	|
+	*/
+	'wordpress'  => [
+		// Delay between queue runs in seconds.
+		'delay' => environment( 'QUEUE_DELAY', 0 ),
+	],
+];

--- a/config/view.php
+++ b/config/view.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * View Configuration
+ *
+ * @package Mantle
+ */
+
+return [
+
+	/*
+	|--------------------------------------------------------------------------
+	| Compiled View Path
+	|--------------------------------------------------------------------------
+	|
+	| This option determines where all the compiled Blade templates will be
+	| stored for your application.
+	*/
+
+	'compiled' => environment( 'VIEW_STORAGE_PATH', storage_path( 'framework/views' ) ),
+];

--- a/src/mantle/application/autoload.php
+++ b/src/mantle/application/autoload.php
@@ -79,6 +79,6 @@ if ( ! function_exists( 'storage_path' ) ) {
 	 * @return string
 	 */
 	function storage_path( string $path = '' ): string {
-			return app( 'path.storage' ) . ( $path ? DIRECTORY_SEPARATOR . $path : $path );
+		return app()->get_storage_path( $path );
 	}
 }

--- a/src/mantle/application/class-app-service-provider.php
+++ b/src/mantle/application/class-app-service-provider.php
@@ -16,7 +16,7 @@ use function Mantle\Support\Helpers\tap;
 /**
  * App Service Provider
  */
-abstract class App_Service_Provider extends Service_Provider {
+class App_Service_Provider extends Service_Provider {
 	/**
 	 * Application instance.
 	 *

--- a/src/mantle/application/class-application.php
+++ b/src/mantle/application/class-application.php
@@ -9,29 +9,25 @@ namespace Mantle\Application;
 
 use Mantle\Container\Container;
 use Mantle\Contracts\Application as Application_Contract;
+use Mantle\Contracts\Bootstrapable;
 use Mantle\Contracts\Container as Container_Contract;
 use Mantle\Contracts\Kernel as Kernel_Contract;
-use Mantle\Contracts\Support\Isolated_Service_Provider;
-use Mantle\Events\Event_Service_Provider;
 use Mantle\Framework\Manifest\Model_Manifest;
 use Mantle\Framework\Manifest\Package_Manifest;
-use Mantle\Framework\Providers\Console_Service_Provider;
-use Mantle\Framework\Providers\Routing_Service_Provider;
-use Mantle\Log\Log_Service_Provider;
-use Mantle\Support\Arr;
 use Mantle\Support\Environment;
-use Mantle\Support\Service_Provider;
-use Mantle\View\View_Service_Provider;
 use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-
-use function Mantle\Support\Helpers\collect;
 
 /**
  * Mantle Application
  */
 class Application extends Container implements Application_Contract {
+	use Concerns\Loads_Base_Configuration,
+		Concerns\Loads_Environment_Variables,
+		Concerns\Loads_Facades,
+		Concerns\Manages_Service_Providers;
+
 	/**
 	 * Base path of the application.
 	 *
@@ -49,93 +45,86 @@ class Application extends Container implements Application_Contract {
 	/**
 	 * Bootstrap path of the application.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
-	protected $bootstrap_path;
+	protected ?string $bootstrap_path = null;
 
 	/**
 	 * Storage path of the application.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
-	protected $storage_path;
+	protected ?string $storage_path = null;
 
 	/**
 	 * Root URL of the application.
 	 *
-	 * @var string
+	 * @var string|null
 	 */
-	protected $root_url;
+	protected ?string $root_url = null;
 
 	/**
 	 * Indicates if the application has been bootstrapped before.
 	 *
 	 * @var bool
 	 */
-	protected $has_been_bootstrapped = false;
+	protected bool $has_been_bootstrapped = false;
 
 	/**
 	 * Indicates if the application has "booted".
 	 *
 	 * @var bool
 	 */
-	protected $booted = false;
+	protected bool $booted = false;
 
 	/**
 	 * The array of booting callbacks.
 	 *
 	 * @var callable[]
 	 */
-	protected $booting_callbacks = [];
+	protected array $booting_callbacks = [];
 
 	/**
 	 * The array of booted callbacks.
 	 *
 	 * @var callable[]
 	 */
-	protected $booted_callbacks = [];
+	protected array $booted_callbacks = [];
 
 	/**
 	 * The array of terminating callbacks.
 	 *
 	 * @var callable[]
 	 */
-	protected $terminating_callbacks = [];
-
-	/**
-	 * All of the registered service providers.
-	 *
-	 * @var Service_Provider[]
-	 */
-	protected $service_providers = [];
+	protected array $terminating_callbacks = [];
 
 	/**
 	 * Environment file name.
 	 *
 	 * @var string
 	 */
-	protected $environment_file = '.env';
+	protected string $environment_file = '.env';
 
 	/**
 	 * The custom environment path defined by the developer.
 	 *
 	 * @var string
 	 */
-	protected $environment_path;
+	protected ?string $environment_path = null;
 
 	/**
 	 * Storage of the overridden environment name.
 	 *
 	 * @var string
 	 */
-	protected $environment;
+	protected ?string $environment;
 
 	/**
 	 * Indicates if the application is running in the console.
 	 *
 	 * @var bool
 	 */
-	protected $is_running_in_console;
+	protected ?bool $is_running_in_console = null;
 
 	/**
 	 * Constructor.
@@ -157,6 +146,7 @@ class Application extends Container implements Application_Contract {
 		$this->register_base_bindings();
 		$this->register_base_service_providers();
 		$this->register_core_aliases();
+		$this->register_base_services();
 	}
 
 	/**
@@ -182,7 +172,7 @@ class Application extends Container implements Application_Contract {
 	 * @return string
 	 */
 	public function get_base_path( string $path = '' ): string {
-		return $this->base_path . ( $path ? '/' . $path : '' );
+		return $this->base_path . ( $path ? DIRECTORY_SEPARATOR . $path : '' );
 	}
 
 	/**
@@ -218,7 +208,23 @@ class Application extends Container implements Application_Contract {
 	 * @return string
 	 */
 	public function get_bootstrap_path( string $path = '' ): string {
-		return ( $this->bootstrap_path ?: $this->base_path . DIRECTORY_SEPARATOR . 'bootstrap' ) . $path;
+		if ( $this->bootstrap_path ) {
+			return $path ? $this->bootstrap_path . DIRECTORY_SEPARATOR . $path : $this->bootstrap_path;
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filter the path to the bootstrap folder.
+			 *
+			 * @param string $cache_path Path to the bootstrap folder.
+			 * @param Application $app Application instance.
+			 */
+			$this->bootstrap_path = apply_filters( 'mantle_bootstrap_path', $this->get_base_path( 'bootstrap' ), $this );
+		} else {
+			$this->bootstrap_path = $this->get_base_path( 'bootstrap' );
+		}
+
+		return $this->bootstrap_path . DIRECTORY_SEPARATOR . $path;
 	}
 
 	/**
@@ -228,15 +234,35 @@ class Application extends Container implements Application_Contract {
 	 * @return string
 	 */
 	public function get_storage_path( string $path = '' ): string {
-		return ( $this->storage_path ?: $this->base_path . DIRECTORY_SEPARATOR . 'storage' ) . $path;
+		if ( $this->storage_path ) {
+			return $this->storage_path . DIRECTORY_SEPARATOR . $path;
+		}
+
+		if ( function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filter the path to the storage folder.
+			 *
+			 * @param string $cache_path Path to the cache folder.
+			 * @param Application $app Application instance.
+			 */
+			$this->storage_path = apply_filters( 'mantle_storage_path', $this->get_base_path( 'storage' ), $this );
+		} else {
+			$this->storage_path = $this->get_base_path( 'storage' );
+		}
+
+		return $this->storage_path . DIRECTORY_SEPARATOR . $path;
 	}
 
 	/**
 	 * Set the root URL of the application.
 	 *
-	 * @param string $url Root URL to set.
+	 * @param string|null $url Root URL to set, or null to use the default.
 	 */
-	public function set_root_url( string $url ) {
+	public function set_root_url( ?string $url = null ) {
+		if ( ! $url ) {
+			$url = function_exists( 'home_url' ) ? \home_url() : '/';
+		}
+
 		$this->root_url = $url;
 	}
 
@@ -255,10 +281,23 @@ class Application extends Container implements Application_Contract {
 	 * Get the cache folder root
 	 * Folder that stores all compiled server-side assets for the application.
 	 *
+	 * @param string|null $path Path to append.
 	 * @return string
 	 */
-	public function get_cache_path(): string {
-		return $this->get_bootstrap_path( '/cache' );
+	public function get_cache_path( ?string $path = null ): string {
+		if ( function_exists( 'apply_filters' ) ) {
+			/**
+			 * Filter the path to the cache folder.
+			 *
+			 * @param string $cache_path Path to the cache folder.
+			 * @param Application $app Application instance.
+			 */
+			$cache_path = (string) apply_filters( 'mantle_cache_path', $this->get_bootstrap_path( 'cache' ), $this );
+		} else {
+			$cache_path = $this->get_bootstrap_path( 'cache' );
+		}
+
+		return $path ? $cache_path . DIRECTORY_SEPARATOR . $path : $cache_path;
 	}
 
 	/**
@@ -269,7 +308,7 @@ class Application extends Container implements Application_Contract {
 	 * @return string
 	 */
 	public function get_cached_packages_path(): string {
-		return $this->get_cache_path() . '/packages.php';
+		return $this->get_cache_path( 'packages.php' );
 	}
 
 	/**
@@ -279,7 +318,7 @@ class Application extends Container implements Application_Contract {
 	 * @return string
 	 */
 	public function get_cached_models_path(): string {
-		return $this->get_cache_path() . '/models.php';
+		return $this->get_cache_path( 'models.php' );
 	}
 
 	/**
@@ -324,7 +363,7 @@ class Application extends Container implements Application_Contract {
 	 * @return string
 	 */
 	public function get_config_path(): string {
-		return $this->base_path . '/config';
+		return $this->get_base_path( 'config' );
 	}
 
 	/**
@@ -361,17 +400,6 @@ class Application extends Container implements Application_Contract {
 	}
 
 	/**
-	 * Register the base service providers.
-	 */
-	protected function register_base_service_providers() {
-		$this->register( Console_Service_Provider::class );
-		$this->register( Event_Service_Provider::class );
-		$this->register( Log_Service_Provider::class );
-		$this->register( View_Service_Provider::class );
-		$this->register( Routing_Service_Provider::class );
-	}
-
-	/**
 	 * Register the core aliases.
 	 */
 	protected function register_core_aliases() {
@@ -400,6 +428,15 @@ class Application extends Container implements Application_Contract {
 	}
 
 	/**
+	 * Register the base services for the application.
+	 */
+	public function register_base_services() {
+		$this->load_environment_variables();
+		$this->load_base_configuration();
+		$this->load_facades();
+	}
+
+	/**
 	 * Flush the container of all bindings and resolved instances.
 	 */
 	public function flush() {
@@ -413,10 +450,10 @@ class Application extends Container implements Application_Contract {
 	/**
 	 * Run the given array of bootstrap classes.
 	 *
-	 * Bootstrap classes should implement `Mantle\Contracts\Bootstrapable`.
+	 * Bootstrap classes should implement {@see \Mantle\Contracts\Bootstrapable}.
 	 *
-	 * @param string[]        $bootstrappers Class names of packages to boot.
-	 * @param Kernel_Contract $kernel Kernel instance.
+	 * @param array<mixed, class-string<Bootstrapable>> $bootstrappers Class names of packages to boot.
+	 * @param Kernel_Contract                           $kernel Kernel instance.
 	 */
 	public function bootstrap_with( array $bootstrappers, Kernel_Contract $kernel ) {
 		$this->has_been_bootstrapped = true;
@@ -424,83 +461,6 @@ class Application extends Container implements Application_Contract {
 		foreach ( $bootstrappers as $bootstrapper ) {
 			$this->make( $bootstrapper )->bootstrap( $this, $kernel );
 		}
-	}
-
-	/**
-	 * Register all of the configured providers.
-	 */
-	public function register_configured_providers() {
-		// Get providers from the application config.
-		$providers = collect( $this->make( 'config' )->get( 'app.providers', [] ) );
-
-		// Include providers from the package manifest.
-		$providers->push( ...$this->make( Package_Manifest::class )->providers() );
-
-		// Only register service providers that implement Isolated_Service_Provider
-		// when in isolation mode.
-		if ( $this->is_running_in_console_isolation() ) {
-			$providers = $providers->filter(
-				fn ( string $provider ) => in_array(
-					Isolated_Service_Provider::class,
-					class_implements( $provider ),
-					true,
-				)
-			);
-		}
-
-		$providers->each( [ $this, 'register' ] );
-	}
-
-	/**
-	 * Get an instance of a service provider.
-	 *
-	 * @param string $name Provider class name.
-	 * @return Service_Provider|null
-	 */
-	public function get_provider( string $name ): ?Service_Provider {
-		$providers = Arr::where(
-			$this->get_providers(),
-			function( Service_Provider $provider ) use ( $name ) {
-				return $provider instanceof $name;
-			}
-		);
-
-		return array_shift( $providers );
-	}
-
-	/**
-	 * Get all service providers.
-	 *
-	 * @return Service_Provider[]
-	 */
-	public function get_providers(): array {
-		return $this->service_providers;
-	}
-
-	/**
-	 * Register a Service Provider
-	 *
-	 * @param Service_Provider|string $provider Provider instance or class name to register.
-	 * @return Application
-	 */
-	public function register( $provider ): Application {
-		$provider_name = is_string( $provider ) ? $provider : get_class( $provider );
-
-		if ( ! empty( $this->service_providers[ $provider_name ] ) ) {
-			return $this;
-		}
-
-		if ( is_string( $provider ) ) {
-			$provider = new $provider( $this );
-		}
-
-		if ( ! ( $provider instanceof Service_Provider ) ) {
-			\wp_die( 'Provider is not instance of Service_Provider: ' . $provider_name ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		}
-
-		$provider->register();
-		$this->service_providers[ $provider_name ] = $provider;
-		return $this;
 	}
 
 	/**
@@ -575,7 +535,7 @@ class Application extends Container implements Application_Contract {
 			return $this->environment;
 		}
 
-		return Environment::get( 'ENV', function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : '' );
+		return Environment::get( 'APP_ENV', function_exists( 'wp_get_environment_type' ) ? wp_get_environment_type() : '' );
 	}
 
 	/**
@@ -601,6 +561,17 @@ class Application extends Container implements Application_Contract {
 		}
 
 		return (string) $this['config']->get( 'app.namespace', 'App' );
+	}
+
+	/**
+	 * Alias to get_namespace().
+	 *
+	 * @throws RuntimeException Thrown on error determining namespace.
+	 *
+	 * @return string
+	 */
+	public function namespace(): string {
+		return $this->get_namespace();
 	}
 
 	/**

--- a/src/mantle/application/concerns/trait-loads-base-configuration.php
+++ b/src/mantle/application/concerns/trait-loads-base-configuration.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Loads_Base_Configuration trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Application\Concerns;
+
+use Dotenv\Dotenv;
+use Dotenv\Exception\InvalidFileException;
+use Mantle\Application\Application;
+use Mantle\Config\Repository;
+use Mantle\Framework\Console\Kernel;
+use Mantle\Support\Environment;
+
+/**
+ * Load a base configuration for Mantle to operate.
+ *
+ * @mixin \Mantle\Application\Application
+ */
+trait Loads_Base_Configuration {
+	/**
+	 * Load the base configuration for the application.
+	 */
+	public function load_base_configuration() {
+		$cached = $this->get_cached_config_path();
+
+		// Check if a cached configuration file exists. If found, load it.
+		if ( is_file( $cached ) ) {
+			$items = require $cached;
+
+			$loaded_from_cache = true;
+		} else {
+			$items = [];
+		}
+
+		$config = new Repository( (array) $items );
+
+		// Set the global config alias.
+		$this->instance( 'config', $config );
+
+		// Load configuration files if the config hasn't been loaded from cache.
+		if ( isset( $loaded_from_cache ) ) {
+			$config->set( 'config.loaded_from_cache', true );
+		}
+	}
+}

--- a/src/mantle/application/concerns/trait-loads-facades.php
+++ b/src/mantle/application/concerns/trait-loads-facades.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Loads_Facades class file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Application\Concerns;
+
+use Mantle\Framework\Alias_Loader;
+use Mantle\Application\Application;
+use Mantle\Facade\Facade;
+use Mantle\Framework\Manifest\Package_Manifest;
+
+/**
+ * Register the Facades for the Application
+ *
+ * @mixin \Mantle\Application\Application
+ */
+trait Loads_Facades {
+	/**
+	 * Bootstrap the given application's Facades.
+	 */
+	public function load_facades() {
+		Facade::clear_resolved_instances();
+		Facade::set_facade_application( $this );
+	}
+}

--- a/src/mantle/application/concerns/trait-manages-service-providers.php
+++ b/src/mantle/application/concerns/trait-manages-service-providers.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Has_Service_Providers trait file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Application\Concerns;
+
+use InvalidArgumentException;
+use Mantle\Contracts\Support\Isolated_Service_Provider;
+use Mantle\Events\Event_Service_Provider;
+use Mantle\Framework\Manifest\Package_Manifest;
+use Mantle\Framework\Providers\Console_Service_Provider;
+use Mantle\Framework\Providers\Routing_Service_Provider;
+use Mantle\Log\Log_Service_Provider;
+use Mantle\Support\Service_Provider;
+use Mantle\View\View_Service_Provider;
+
+use function Mantle\Support\Helpers\collect;
+
+/**
+ * Trait to manage service providers for the application.
+ *
+ * @mixin \Mantle\Application\Application
+ */
+trait Manages_Service_Providers {
+	/**
+	 * All of the registered service providers.
+	 *
+	 * @var Service_Provider[]
+	 */
+	protected $service_providers = [];
+
+	/**
+	 * Register the base service providers.
+	 */
+	protected function register_base_service_providers() {
+		$this->register( Console_Service_Provider::class );
+		$this->register( Event_Service_Provider::class );
+		$this->register( Log_Service_Provider::class );
+		$this->register( View_Service_Provider::class );
+		$this->register( Routing_Service_Provider::class );
+	}
+
+	/**
+	 * Register all of the configured providers.
+	 */
+	public function register_configured_providers() {
+		// Get providers from the application config.
+		$providers = collect( $this->make( 'config' )->get( 'app.providers', [] ) );
+
+		// Include providers from the package manifest.
+		$providers->push( ...$this->make( Package_Manifest::class )->providers() );
+
+		// Only register service providers that implement Isolated_Service_Provider
+		// when in isolation mode.
+		if ( $this->is_running_in_console_isolation() ) {
+			$providers = $providers->filter(
+				fn ( string $provider ) => in_array(
+					Isolated_Service_Provider::class,
+					class_implements( $provider ),
+					true,
+				)
+			);
+		}
+
+		$providers->each( [ $this, 'register' ] );
+	}
+
+	/**
+	 * Get an instance of a service provider.
+	 *
+	 * @param class-string<Service_Provider> $name Provider class name.
+	 * @return Service_Provider|null
+	 */
+	public function get_provider( string $name ): ?Service_Provider {
+		return collect( $this->get_providers() )->first(
+			fn( Service_Provider $provider ) => $provider instanceof $name,
+		);
+	}
+
+	/**
+	 * Get all service providers.
+	 *
+	 * @return Service_Provider[]
+	 */
+	public function get_providers(): array {
+		return $this->service_providers;
+	}
+
+	/**
+	 * Register a Service Provider
+	 *
+	 * @throws InvalidArgumentException If the provider is not an instance of Service_Provider.
+	 *
+	 * @param Service_Provider|class-string<Service_Provider> $provider Provider instance or class name to register.
+	 * @return static
+	 */
+	public function register( Service_Provider|string $provider ): static {
+		$provider_name = is_string( $provider ) ? $provider : get_class( $provider );
+
+		if ( ! empty( $this->service_providers[ $provider_name ] ) ) {
+			return $this;
+		}
+
+		if ( is_string( $provider ) ) {
+			$provider = new $provider( $this );
+		}
+
+		if ( ! ( $provider instanceof Service_Provider ) ) {
+			throw new InvalidArgumentException( "Provider is not instance of Service_Provider: {$provider_name}" );
+		}
+
+		$provider->register();
+
+		$this->service_providers[ $provider_name ] = $provider;
+
+		return $this;
+	}
+}

--- a/src/mantle/assets/class-asset-service-provider.php
+++ b/src/mantle/assets/class-asset-service-provider.php
@@ -12,7 +12,7 @@ use Mantle\Support\Service_Provider;
 /**
  * Asset Service Provider
  */
-abstract class Asset_Service_Provider extends Service_Provider {
+class Asset_Service_Provider extends Service_Provider {
 	/**
 	 * Register the service provider.
 	 */

--- a/src/mantle/contracts/framework/interface-bootloader.php
+++ b/src/mantle/contracts/framework/interface-bootloader.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Bootloader interface file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Contracts\Framework;
+
+use Closure;
+
+/**
+ * Bootloader Contract
+ *
+ * Used to instantiate the application and load the framework.
+ */
+interface Bootloader {
+	/**
+	 * Boot the application given the current context.
+	 *
+	 * @return static
+	 */
+	public function boot(): static;
+
+	/**
+	 * Bind to the container before booting.
+	 *
+	 * @param string              $abstract Abstract to bind.
+	 * @param Closure|string|null $concrete Concrete to bind.
+	 * @return static
+	 */
+	public function bind( string $abstract, Closure|string|null $concrete ): static;
+}

--- a/src/mantle/contracts/http/interface-kernel.php
+++ b/src/mantle/contracts/http/interface-kernel.php
@@ -8,7 +8,7 @@
 namespace Mantle\Contracts\Http;
 
 use Mantle\Http\Request;
-
+use Mantle\Http\Response;
 /**
  * Http Kernel
  */
@@ -19,4 +19,13 @@ interface Kernel {
 	 * @param Request $request Request object.
 	 */
 	public function handle( Request $request );
+
+	/**
+	 * Terminate the HTTP request.
+	 *
+	 * @param Request  $request  Request object.
+	 * @param Response $response Response object.
+	 * @return void
+	 */
+	public function terminate( Request $request, mixed $response ): void;
 }

--- a/src/mantle/contracts/interface-application.php
+++ b/src/mantle/contracts/interface-application.php
@@ -127,11 +127,20 @@ interface Application extends Container {
 	/**
 	 * Get the application namespace.
 	 *
-	 * @return string
-	 *
 	 * @throws RuntimeException Thrown on error determining namespace.
+	 *
+	 * @return string
 	 */
 	public function get_namespace(): string;
+
+	/**
+	 * Alias to get_namespace().
+	 *
+	 * @throws RuntimeException Thrown on error determining namespace.
+	 *
+	 * @return string
+	 */
+	public function namespace(): string;
 
 	/**
 	 * Check if the application is running in the console.
@@ -240,4 +249,12 @@ interface Application extends Container {
 	 * @return string
 	 */
 	public function get_cached_events_path(): string;
+
+	/**
+	 * Register a service provider.
+	 *
+	 * @param Service_Provider|class-string<Service_Provider> $provider Provider to register.
+	 * @return static
+	 */
+	public function register( Service_Provider|string $provider ): static;
 }

--- a/src/mantle/events/class-dispatcher.php
+++ b/src/mantle/events/class-dispatcher.php
@@ -116,7 +116,11 @@ class Dispatcher implements Dispatcher_Contract {
 	public function dispatch( $event, $payload = [ null ] ) {
 		[ $event, $payload ] = $this->parse_event_and_payload( $event, $payload );
 
-		return apply_filters( $event, ...$payload ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
+		if ( function_exists( 'apply_filters' ) ) {
+			return apply_filters( $event, ...$payload ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/mantle/facade/class-facade.php
+++ b/src/mantle/facade/class-facade.php
@@ -56,6 +56,15 @@ abstract class Facade {
 	}
 
 	/**
+	 * Get the application instance for the Facade.
+	 *
+	 * @return \Mantle\Contracts\Application|null
+	 */
+	public static function get_facade_application(): ?Application {
+		return static::$app;
+	}
+
+	/**
 	 * Set the application instance for the Facade.
 	 *
 	 * @param \Mantle\Contracts\Application $app Application instance.
@@ -116,7 +125,7 @@ abstract class Facade {
 		$instance = static::get_facade_root();
 
 		if ( ! $instance ) {
-			throw new RuntimeException( 'A facade root has not been set.' );
+			throw new RuntimeException( 'A facade root has not been set. Have you booted the application? Try using bootloader()->boot()?' );
 		}
 
 		return $instance->$method( ...$args );

--- a/src/mantle/framework/bootstrap/class-load-configuration.php
+++ b/src/mantle/framework/bootstrap/class-load-configuration.php
@@ -7,45 +7,30 @@
 
 namespace Mantle\Framework\Bootstrap;
 
-use Exception;
 use Mantle\Application\Application;
-use Mantle\Config\Repository;
 use Mantle\Contracts\Config\Repository as Repository_Contract;
+use Mantle\Filesystem\Filesystem;
 use Mantle\Support\Arr;
 use Symfony\Component\Finder\Finder;
 use Mantle\Support\Helpers;
 use Mantle\Support\Str;
 
+use function Mantle\Support\Helpers\collect;
+
 /**
- * Load the Application's Configuration
+ * Load the Application's Configuration from the filesystem.
  */
 class Load_Configuration {
 	/**
 	 * Load the configuration for the application.
 	 *
-	 * @todo Add cached config usage.
-	 *
 	 * @param Application $app Application instance.
 	 */
 	public function bootstrap( Application $app ) {
-		$cached = $app->get_cached_config_path();
+		$config = $app->make( 'config' );
 
-		$items = [];
-
-		// Check if a cached configuration file exists.
-		if ( is_file( $cached ) ) {
-			$items = require $cached;
-
-			$loaded_from_cache = true;
-		}
-
-		$config = new Repository( $items );
-
-		// Set the global config alias.
-		$app->instance( 'config', $config );
-
-		// Load configuration files if the config hasn't been loaded from cache.
-		if ( ! isset( $loaded_from_cache ) ) {
+		// Load the configuration files if not loaded from cache.
+		if ( ! $config->get( 'config.loaded_from_cache' ) ) {
 			$this->load_configuration_files( $app, $config );
 		}
 	}
@@ -55,15 +40,14 @@ class Load_Configuration {
 	 *
 	 * @param Application         $app Application instance.
 	 * @param Repository_Contract $repository Configuration Repository.
-	 *
-	 * @throws Exception Thrown on missing 'app' config file.
+	 * @return void
 	 */
-	protected function load_configuration_files( Application $app, Repository_Contract $repository ) {
+	protected function load_configuration_files( Application $app, Repository_Contract $repository ): void {
 		$files = $this->get_configuration_files( $app );
 
 		// Bail early if 'app' is not found.
 		if ( empty( $files['app'] ) ) {
-			throw new Exception( 'Unable to find the "app" configuration file.' );
+			return;
 		}
 
 		// Filter the environment config files from the root-level ones.
@@ -77,8 +61,9 @@ class Load_Configuration {
 		// Load the root-level config.
 		$this->load_configuration_to_repository( $root_config_files, $repository );
 
-		// Load the environment-specific configurations if one exists.
 		$env = $app->environment();
+
+		// Load the environment-specific configurations if one exists.
 		if ( ! empty( $environment_config[ $env ] ) ) {
 			$this->load_configuration_to_repository( $environment_config[ $env ], $repository, true );
 		}
@@ -91,20 +76,25 @@ class Load_Configuration {
 	 * @return array
 	 */
 	protected function get_configuration_files( Application $app ): array {
-		$path  = $app->get_config_path();
 		$files = [];
 
 		$finder = Finder::create()
 			->files()
 			->name( '*.php' )
 			->depth( '< 2' ) // Only descend two levels.
-			->in( $path );
+			->in( $this->get_configuration_directories( $app ) );
 
 		foreach ( $finder as $file ) {
 			$name = basename( $file->getRealPath(), '.php' );
 
 			// Get the environment the configuration file is from.
-			$environment = str_replace( Str::trailing_slash( $path ), '', Str::trailing_slash( $file->getPath() ) );
+			$environment = basename( dirname( $file->getRealPath() ) );
+
+			// Ignore the 'config' directory as an environment.
+			if ( in_array( $environment, [ 'config', 'configuration' ], true ) ) {
+				$environment = null;
+			}
+
 			if ( empty( $environment ) ) {
 				$files[ $name ] = $file->getRealPath();
 			} else {
@@ -116,6 +106,39 @@ class Load_Configuration {
 	}
 
 	/**
+	 * Retrieve the configuration directories to load from.
+	 *
+	 * @param Application $app Application instance.
+	 * @return array<int, string>
+	 */
+	protected function get_configuration_directories( Application $app ): array {
+		/**
+		 * Filter the configuration directories to load from.
+		 *
+		 * @param array<int, string> $paths Configuration directories.
+		 * @param Application        $app Application instance.
+		 */
+		$paths = $app['events']->dispatch(
+			'mantle_config_paths',
+			[
+				[
+					dirname( __DIR__, 4 ) . '/config',
+					$app->get_config_path(),
+				],
+				$app,
+			],
+		);
+
+		return collect( $paths )
+			->unique()
+			->filter(
+				fn ( $dir ) => is_string( $dir ) && is_dir( $dir ),
+			)
+			->values()
+			->all();
+	}
+
+	/**
 	 * Load specific configuration files to a repository
 	 *
 	 * @param string[]            $files Files to load.
@@ -123,8 +146,10 @@ class Load_Configuration {
 	 * @param bool                $merge Flag to merge the configuration instead of overwriting.
 	 */
 	protected function load_configuration_to_repository( array $files, Repository_Contract $repository, bool $merge = false ) {
+		$filesystem = new Filesystem();
+
 		foreach ( $files as $key => $root_config_file ) {
-			$config = require $root_config_file;
+			$config = $filesystem->get_require( $root_config_file );
 
 			if ( ! $merge || ! $repository->has( $key ) ) {
 				$repository->set( $key, $config );

--- a/src/mantle/framework/bootstrap/class-register-aliases.php
+++ b/src/mantle/framework/bootstrap/class-register-aliases.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Register_Facades class file.
+ * Register_Aliases class file.
  *
  * @package Mantle
  */
@@ -13,19 +13,15 @@ use Mantle\Facade\Facade;
 use Mantle\Framework\Manifest\Package_Manifest;
 
 /**
- * Register the Facades for the Application
+ * Register the Aliases for the application
  */
-class Register_Facades {
+class Register_Aliases {
 	/**
 	 * Bootstrap the given application.
 	 *
 	 * @param Application $app Application instance.
 	 */
 	public function bootstrap( Application $app ) {
-		Facade::clear_resolved_instances();
-		Facade::set_facade_application( $app );
-
-		// Load the Facades from the config.
 		Alias_Loader::get_instance(
 			array_merge(
 				(array) $app->make( 'config' )->get( 'app.aliases' ),

--- a/src/mantle/framework/class-bootloader.php
+++ b/src/mantle/framework/class-bootloader.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Bootloader class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Framework;
+
+use Closure;
+use Mantle\Application\Application;
+use Mantle\Console\Command;
+use Mantle\Contracts;
+use Mantle\Contracts\Framework\Bootloader as Contract;
+use Mantle\Http\Request;
+use Mantle\Support\Str;
+use Mantle\Support\Traits\Conditionable;
+
+/**
+ * Boot Manager
+ *
+ * Used to instantiate the application and load the framework given the current
+ * context. Removes the need for boilerplate code to be included in projects
+ * (ala laravel/laravel) but still allows for the flexibility to do so if they
+ * so choose.
+ */
+class Bootloader implements Contract {
+	use Conditionable;
+
+	/**
+	 * Current instance of the manager.
+	 *
+	 * @var Bootloader|null
+	 */
+	protected static ?Bootloader $instance = null;
+
+	/**
+	 * Application base path.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $base_path = null;
+
+	/**
+	 * Retrieve the instance of the manager.
+	 *
+	 * @param Contracts\Application|null $app Application instance.
+	 * @return Bootloader
+	 */
+	public static function get_instance( ?Contracts\Application $app = null ): Bootloader {
+		if ( is_null( static::$instance ) ) {
+			static::$instance = new static( $app );
+		}
+
+		return static::$instance;
+	}
+
+	/**
+	 * Alias to `get_instance()` method.
+	 *
+	 * @param Contracts\Application|null $app Application instance.
+	 * @return Bootloader
+	 */
+	public static function instance( ?Contracts\Application $app = null ): Bootloader {
+		return static::get_instance( $app );
+	}
+
+	/**
+	 * Set the instance of the manager.
+	 *
+	 * @param Bootloader|null $instance Instance of the manager.
+	 * @return void
+	 */
+	public static function set_instance( ?Bootloader $instance = null ): void {
+		static::$instance = $instance;
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Contracts\Application|null $app Application instance.
+	 */
+	public function __construct( protected ?Contracts\Application $app = null ) {
+		static::set_instance( $this );
+	}
+
+	/**
+	 * Bind to the container before booting.
+	 *
+	 * @param string              $abstract Abstract to bind.
+	 * @param Closure|string|null $concrete Concrete to bind.
+	 * @return static
+	 */
+	public function bind( string $abstract, Closure|string|null $concrete ): static {
+		if ( is_null( $this->app ) ) {
+			$this->boot_application();
+		}
+
+		$this->app->bind( $abstract, $concrete );
+
+		return $this;
+	}
+
+	/**
+	 * Boot the application given the current context.
+	 *
+	 * @return static
+	 */
+	public function boot(): static {
+		$this->boot_application();
+
+		// Bail if the application is already booted.
+		if ( $this->app->is_booted() ) {
+			return $this;
+		}
+
+		if ( $this->app->is_running_in_console_isolation() ) {
+			$this->boot_console();
+		} elseif ( $this->app->is_running_in_console() ) {
+			$this->boot_console_wp_cli();
+		} else {
+			$this->boot_http();
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Boot the application and attach the relevant container classes.
+	 *
+	 * @return void
+	 */
+	protected function boot_application(): void {
+		if ( is_null( $this->app ) ) {
+			$this->app = new Application( $this->get_base_path() );
+		}
+
+		if ( function_exists( 'do_action' ) ) {
+			/**
+			 * Fired before the application is booted.
+			 *
+			 * @param \Mantle\Contracts\Application $app Application instance.
+			 */
+			do_action( 'mantle_bootloader_before_boot', $this->app );
+		}
+
+		$this->app->singleton_if(
+			Contracts\Console\Kernel::class,
+			\Mantle\Framework\Console\Kernel::class,
+		);
+
+		$this->app->singleton_if(
+			Contracts\Http\Kernel::class,
+			\Mantle\Framework\Http\Kernel::class,
+		);
+
+		$this->app->singleton_if(
+			Contracts\Exceptions\Handler::class,
+			\Mantle\Framework\Exceptions\Handler::class,
+		);
+
+		/**
+		 * Fired after the application is booted.
+		 *
+		 * @param \Mantle\Contracts\Application $app Application instance.
+		 */
+		$this->app['events']->dispatch( 'mantle_bootloader_booted', $this->app );
+	}
+
+	/**
+	 * Retrieve the application instance.
+	 *
+	 * @return Contracts\Application|null
+	 */
+	public function get_application(): ?Contracts\Application {
+		return $this->app;
+	}
+
+	/**
+	 * Get the calculated base path for the application.
+	 *
+	 * @todo Calculate a better default path from the plugin file.
+	 *
+	 * @return string|null
+	 */
+	public function get_base_path(): ?string {
+		if ( ! empty( $this->base_path ) ) {
+			return $this->base_path;
+		}
+
+		return match ( true ) {
+			! empty( $_ENV['MANTLE_BASE_PATH'] ) => $_ENV['MANTLE_BASE_PATH'],
+			defined( 'MANTLE_BASE_PATH' ) => constant( 'MANTLE_BASE_PATH' ),
+			default => dirname( __DIR__, 3 ),
+		};
+	}
+
+	/**
+	 * Set the base path for the application.
+	 *
+	 * @param string|null $base_path Base path for the application.
+	 * @return static
+	 */
+	public function set_base_path( ?string $base_path = null ): static {
+		$this->base_path = $base_path;
+
+		return $this;
+	}
+
+	/**
+	 * Boot the application in the console context.
+	 *
+	 * @return void
+	 */
+	protected function boot_console(): void {
+		$kernel = $this->app->make( Contracts\Console\Kernel::class );
+
+		$status    = $kernel->handle(
+			$input = new \Symfony\Component\Console\Input\ArgvInput(),
+			new \Symfony\Component\Console\Output\ConsoleOutput(),
+		);
+
+		$kernel->terminate( $input, $status );
+
+		exit( (int) $status );
+	}
+
+	/**
+	 * Boot the application in the WP-CLI context.
+	 *
+	 * @return void
+	 */
+	protected function boot_console_wp_cli(): void {
+		\WP_CLI::add_command(
+			/**
+			 * Command prefix for Mantle WP-CLI commands.
+			 *
+			 * @param string $prefix The command prefix.
+			 * @param \Mantle\Contracts\Application $app The application instance.
+			 */
+			(string) apply_filters( 'mantle_console_command_prefix', Command::PREFIX, $this->app ),
+			function () {
+				$kernel = $this->app->make( Contracts\Console\Kernel::class );
+
+				$status    = $kernel->handle(
+					$input = new \Symfony\Component\Console\Input\ArgvInput(
+						collect( (array) ( $_SERVER['argv'] ?? [] ) ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+							// Remove the `wp` prefix from argv and any invalid arguments (such as --url).
+							->filter( fn ( $value, $index ) => 0 !== $index && ! Str::starts_with( $value, '--url=' ) )
+							->all()
+					),
+					new \Symfony\Component\Console\Output\ConsoleOutput(),
+				);
+
+				$kernel->terminate( $input, $status );
+
+				exit( (int) $status );
+			},
+			[
+				'shortdesc' => __( 'Mantle Framework Command Line Interface', 'mantle' ),
+			]
+		);
+	}
+
+	/**
+	 * Boot the application in the HTTP context.
+	 *
+	 * @return void
+	 */
+	protected function boot_http() {
+		$kernel = $this->app->make( Contracts\Http\Kernel::class );
+
+		$kernel->handle( Request::capture() );
+	}
+}

--- a/src/mantle/framework/console/class-kernel.php
+++ b/src/mantle/framework/console/class-kernel.php
@@ -12,12 +12,10 @@ use Mantle\Console\Application as Console_Application;
 use Mantle\Console\Closure_Command;
 use Mantle\Console\Command;
 use Mantle\Console\Events\Lightweight_Event_Dispatcher;
-use Mantle\Console\Exception_Handler as Console_Exception_Handler;
 use Mantle\Contracts\Application;
 use Mantle\Contracts\Console\Application as Console_Application_Contract;
 use Mantle\Contracts\Console\Kernel as Kernel_Contract;
 use Mantle\Contracts\Exceptions\Handler as Exception_Handler;
-use Mantle\Support\Str;
 use Mantle\Support\Traits\Loads_Classes;
 use ReflectionClass;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -45,9 +43,8 @@ class Kernel implements Kernel_Contract {
 	 * @var array
 	 */
 	protected $bootstrappers = [
-		\Mantle\Framework\Bootstrap\Load_Environment_Variables::class,
 		\Mantle\Framework\Bootstrap\Load_Configuration::class,
-		\Mantle\Framework\Bootstrap\Register_Facades::class,
+		\Mantle\Framework\Bootstrap\Register_Aliases::class,
 		\Mantle\Framework\Bootstrap\Register_Providers::class,
 		\Mantle\Framework\Bootstrap\Boot_Providers::class,
 		\Mantle\Framework\Bootstrap\Register_Cli_Commands::class,
@@ -90,7 +87,6 @@ class Kernel implements Kernel_Contract {
 		$this->app = $app;
 
 		$this->ensure_environment_is_set();
-		$this->register_wpcli_command();
 	}
 
 	/**
@@ -301,36 +297,6 @@ class Kernel implements Kernel_Contract {
 		}
 
 		defined( 'ABSPATH' ) || define( 'ABSPATH', preg_replace( '#/wp-content/.*$#', '/', __DIR__ ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
-	}
-
-	/**
-	 * Register a proxy WP-CLI command that will proxy back to the Symfony
-	 * application.
-	 */
-	protected function register_wpcli_command() {
-		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
-			return;
-		}
-
-		\WP_CLI::add_command(
-			Command::PREFIX,
-			function () {
-				$status = $this->handle(
-					new \Symfony\Component\Console\Input\ArgvInput(
-						collect( (array) ( $_SERVER['argv'] ?? [] ) ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-							// Remove the `wp` prefix from argv and any invalid arguments (such as --url).
-							->filter( fn ( $value, $index ) => 0 !== $index && ! Str::starts_with( $value, '--url=' ) )
-							->all()
-					),
-					new \Symfony\Component\Console\Output\ConsoleOutput(),
-				);
-
-				exit( (int) $status );
-			},
-			[
-				'shortdesc' => __( 'Mantle Framework Command Line Interface', 'mantle' ),
-			]
-		);
 	}
 
 	/**

--- a/src/mantle/framework/console/class-view-clear-command.php
+++ b/src/mantle/framework/console/class-view-clear-command.php
@@ -45,7 +45,7 @@ class View_Clear_Command extends Command {
 			$files->delete( $file );
 		}
 
-		$this->line( 'Compiled views cleared!' );
+		$this->success( 'Compiled views cleared.' );
 
 		return Command::SUCCESS;
 	}

--- a/src/mantle/framework/exceptions/class-handler.php
+++ b/src/mantle/framework/exceptions/class-handler.php
@@ -36,7 +36,7 @@ use function Mantle\Support\Helpers\collect;
  *
  * @todo Add testing to improve coverage.
  */
-abstract class Handler implements Contract {
+class Handler implements Contract {
 
 	/**
 	 * The container implementation.

--- a/src/mantle/framework/helpers.php
+++ b/src/mantle/framework/helpers.php
@@ -11,12 +11,9 @@
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound, Squiz.Commenting.FunctionComment
  */
 
-use Mantle\Application\Application;
-use Mantle\Contracts\Http\Routing\Response_Factory;
-use Mantle\Contracts\Http\View\Factory as View_Factory;
-use Mantle\Support\Environment;
+use Mantle\Contracts\Application;
+use Mantle\Framework\Bootloader;
 use Mantle\Framework\Exceptions\Handler as ExceptionHandler;
-use Symfony\Component\Routing\Generator\UrlGenerator;
 
 if ( ! function_exists( 'report' ) ) {
 	/**
@@ -31,5 +28,17 @@ if ( ! function_exists( 'report' ) ) {
 		}
 
 		app( ExceptionHandler::class )->report( $exception );
+	}
+}
+
+if ( ! function_exists( 'bootloader' ) ) {
+	/**
+	 * Retrieve the Bootloader instance.
+	 *
+	 * @param Application|null  $app Application instance, optional.
+	 * @return Bootloader
+	 */
+	function bootloader( ?Application $app = null ): Bootloader {
+		return Bootloader::get_instance( $app );
 	}
 }

--- a/src/mantle/http/view/class-view-finder.php
+++ b/src/mantle/http/view/class-view-finder.php
@@ -11,6 +11,8 @@ namespace Mantle\Http\View;
 use InvalidArgumentException;
 use Mantle\Support\Str;
 
+use function Mantle\Support\Helpers\event;
+
 /**
  * View Finder
  *
@@ -87,8 +89,10 @@ class View_Finder {
 	 * Set the default paths to load from for WordPress sites.
 	 */
 	public function set_default_paths() {
-		$this->add_path( get_stylesheet_directory(), 'stylesheet-path' );
-		$this->add_path( get_template_directory(), 'template-path' );
+		if ( function_exists( 'get_stylesheet_directory' ) ) {
+			$this->add_path( get_stylesheet_directory(), 'stylesheet-path' );
+			$this->add_path( get_template_directory(), 'template-path' );
+		}
 
 		if ( defined( 'ABSPATH' ) && defined( 'WPINC' ) ) {
 			$this->add_path( ABSPATH . WPINC . '/theme-compat', 'theme-compat' );
@@ -96,6 +100,13 @@ class View_Finder {
 
 		// Allow mantle-site to load views.
 		$this->add_path( $this->base_path . '/views', 'mantle-site' );
+
+		/**
+		 * Dispatched when the view finder is setting its default paths.
+		 *
+		 * @param View_Finder $view_finder View finder instance.
+		 */
+		event( 'mantle_view_finder_paths', $this );
 	}
 
 	/**
@@ -112,7 +123,7 @@ class View_Finder {
 			throw new InvalidArgumentException( 'Alias cannot contain invalid characters.' );
 		}
 
-		$path = \untrailingslashit( $path );
+		$path = Str::untrailing_slash( $path );
 
 		if ( $alias ) {
 			$this->paths[ $alias ] = $path;

--- a/src/mantle/query-monitor/class-query-monitor-service-provider.php
+++ b/src/mantle/query-monitor/class-query-monitor-service-provider.php
@@ -7,13 +7,8 @@
 
 namespace Mantle\Query_Monitor;
 
-use Mantle\Contracts\Events\Dispatcher;
-use Mantle\Http\Routing\Events\Response_Sent;
-use Mantle\Http\Routing\Events\Route_Matched;
 use Mantle\Support\Service_Provider;
 use QM_Collectors;
-
-use function Mantle\Support\Helpers\remove_action_validated;
 
 /**
  * Query Monitor Service Provider
@@ -68,7 +63,7 @@ class Query_Monitor_Service_Provider extends Service_Provider {
 
 		foreach ( $this->query_monitor_dispatches as $callback ) {
 			// Remove the dispatcher from the 'shutdown' hook.
-			remove_action_validated( 'shutdown', $callback, 0 );
+			remove_action( 'shutdown', $callback, 0 );
 			$callback();
 		}
 

--- a/src/mantle/testing/concerns/trait-create-application.php
+++ b/src/mantle/testing/concerns/trait-create-application.php
@@ -160,7 +160,7 @@ trait Create_Application {
 	 * @todo Allow for overriding the configuration aliases and providers easily within the unit test.
 	 */
 	protected function resolve_application_core( $app ) {
-		$app->make( \Mantle\Framework\Bootstrap\Register_Facades::class )->bootstrap( $app );
+		$app->make( \Mantle\Framework\Bootstrap\Register_Aliases::class )->bootstrap( $app );
 		$app->make( \Mantle\Framework\Bootstrap\Register_Providers::class )->bootstrap( $app );
 		$app->make( \Mantle\Framework\Bootstrap\Boot_Providers::class )->bootstrap( $app );
 	}

--- a/src/mantle/testkit/class-application.php
+++ b/src/mantle/testkit/class-application.php
@@ -76,13 +76,6 @@ class Application extends Container implements Application_Contract {
 	protected $booted = false;
 
 	/**
-	 * All of the registered service providers.
-	 *
-	 * @var Service_Provider[]
-	 */
-	protected $service_providers = [];
-
-	/**
 	 * Environment file name.
 	 *
 	 * @var string
@@ -362,7 +355,7 @@ class Application extends Container implements Application_Contract {
 	 * @return array
 	 */
 	public function get_providers(): array {
-		return $this->service_providers;
+		return [];
 	}
 
 	/**
@@ -370,9 +363,10 @@ class Application extends Container implements Application_Contract {
 	 *
 	 * @throws RuntimeException Thrown on use.
 	 *
-	 * @param object $provider Service provider to register.
+	 * @param Service_Provider|string $provider Service provider to register.
+	 * @return static
 	 */
-	public function register( $provider ): Application {
+	public function register( Service_Provider|string $provider ): static {
 		throw new RuntimeException( 'Not supported with Testkit' );
 	}
 
@@ -456,6 +450,17 @@ class Application extends Container implements Application_Contract {
 	 */
 	public function get_namespace(): string {
 		return Environment::get( 'APP_NAMESPACE', 'App' );
+	}
+
+	/**
+	 * Alias to get_namespace().
+	 *
+	 * @throws RuntimeException Thrown on error determining namespace.
+	 *
+	 * @return string
+	 */
+	public function namespace(): string {
+		return $this->get_namespace();
 	}
 
 	/**

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -40,9 +40,7 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_blade_compiler() {
 		$this->app->singleton(
 			'blade.compiler',
-			function( $app ) {
-				return new BladeCompiler( new Filesystem(), $app['config']['view.compiled'] );
-			}
+			fn( $app ) => new BladeCompiler( new Filesystem(), $app['config']['view.compiled'] ),
 		);
 	}
 
@@ -52,17 +50,15 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_engine_resolver() {
 		$this->app->singleton(
 			'view.engine.resolver',
-			function() {
-				return tap(
-					new Engine_Resolver(),
-					function( Engine_Resolver $resolver ) {
-						// Register the various view engines.
-						$this->register_php_engine( $resolver );
-						$this->register_file_engine( $resolver );
-						$this->register_compiler_engine( $resolver );
-					}
-				);
-			}
+			fn() => tap(
+				new Engine_Resolver(),
+				function( Engine_Resolver $resolver ) {
+					// Register the various view engines.
+					$this->register_php_engine( $resolver );
+					$this->register_file_engine( $resolver );
+					$this->register_compiler_engine( $resolver );
+				}
+			),
 		);
 	}
 
@@ -74,9 +70,7 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_php_engine( Engine_Resolver $resolver ) {
 		$resolver->register(
 			'php',
-			function() {
-				return new Php_Engine();
-			}
+			fn () => new Php_Engine(),
 		);
 	}
 
@@ -88,9 +82,7 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_file_engine( Engine_Resolver $resolver ) {
 		$resolver->register(
 			'file',
-			function() {
-				return new File_Engine();
-			}
+			fn () => new File_Engine(),
 		);
 	}
 
@@ -102,9 +94,7 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_compiler_engine( Engine_Resolver $resolver ) {
 		$resolver->register(
 			'blade',
-			function() {
-				return new CompilerEngine( $this->app['blade.compiler'] );
-			}
+			fn () => new CompilerEngine( $this->app['blade.compiler'] ),
 		);
 	}
 
@@ -114,15 +104,13 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_loader() {
 		$this->app->singleton(
 			'view.loader',
-			function ( $app ) {
-				return tap(
-					new View_Finder( $app->get_base_path() ),
-					function ( View_Finder $loader ) {
-						// Register the base view folder for the project.
-						$loader->add_path( $this->app->get_base_path( 'views/' ) );
-					}
-				);
-			}
+			fn ( $app ) => tap(
+				new View_Finder( $app->get_base_path() ),
+				function ( View_Finder $loader ) {
+					// Register the base view folder for the project.
+					$loader->add_path( $this->app->get_base_path( 'views/' ) );
+				}
+			),
 		);
 	}
 
@@ -140,6 +128,7 @@ class View_Service_Provider extends Service_Provider {
 				);
 
 				$factory->share( 'app', $app );
+
 				return $factory;
 			}
 		);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,9 @@ namespace Mantle\Tests;
 define( 'MANTLE_PHPUNIT_INCLUDES_PATH', __DIR__ . '/includes' );
 define( 'MANTLE_PHPUNIT_FIXTURES_PATH', __DIR__ . '/fixtures' );
 define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
-define( 'MANTLE_TESTING_DEBUG', true );
+
+// Enable debugging flag for local development on the testing framework.
+// define( 'MANTLE_TESTING_DEBUG', true );
 
 \Mantle\Testing\manager()
 	->maybe_rsync_plugin()

--- a/tests/events/test-event-dispatcher.php
+++ b/tests/events/test-event-dispatcher.php
@@ -85,6 +85,58 @@ class Test_Event_Dispatcher extends \Mockery\Adapter\Phpunit\MockeryTestCase {
 
 		$this->assertTrue( $_SERVER['__event_run'] );
 	}
+
+	public function test_dispatch_string_event_name() {
+		$events = app( 'events' );
+
+		$events->listen(
+			__FUNCTION__,
+			fn () => $_SERVER['__event_run'] = true
+		);
+
+		$events->dispatch( __FUNCTION__ );
+
+		$this->assertTrue( $_SERVER['__event_run'] );
+	}
+
+	public function test_dispatch_string_event_name_with_payload() {
+		$events = app( 'events' );
+
+		$events->listen(
+			__FUNCTION__,
+			fn ( $payload ) => $_SERVER['__event_run'] = $payload
+		);
+
+		$events->dispatch( __FUNCTION__, [ 'foo' ] );
+
+		$this->assertEquals( 'foo', $_SERVER['__event_run'] );
+	}
+
+	public function test_dispatch_string_event_name_with_single_non_array_payload() {
+		$events = app( 'events' );
+
+		$events->listen(
+			__FUNCTION__,
+			fn ( $payload ) => $_SERVER['__event_run'] = $payload
+		);
+
+		$events->dispatch( __FUNCTION__, 'foo' );
+
+		$this->assertEquals( 'foo', $_SERVER['__event_run'] );
+	}
+
+	public function test_dispatch_string_event_name_with_multiple_payloads() {
+		$events = app( 'events' );
+
+		$events->listen(
+			__FUNCTION__,
+			fn ( ...$args ) => $_SERVER['__event_run'] = implode( '', $args )
+		);
+
+		$events->dispatch( __FUNCTION__, [ 'foo', 'bar' ] );
+
+		$this->assertEquals( 'foobar', $_SERVER['__event_run'] );
+	}
 }
 
 class Example_Event {

--- a/tests/framework/test-application.php
+++ b/tests/framework/test-application.php
@@ -2,26 +2,34 @@
 namespace Mantle\Tests\Framework;
 
 use Mantle\Application\Application;
-use Mantle\Framework\Bootstrap\Load_Environment_Variables;
 use Mantle\Support\Service_Provider;
 use Mockery as m;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Test_Application extends \Mockery\Adapter\Phpunit\MockeryTestCase {
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		unset( $_ENV['APP_ENV'] );
+	}
+
 	public function test_environment() {
+		$_ENV['APP_ENV'] = 'test-env';
+
 		$app = new Application();
 
-		$_ENV['ENV'] = 'test-env';
 		$this->assertEquals( 'test-env', $app->environment() );
 
-		$_ENV['ENV'] = 'another-test-env';
+		$_ENV['APP_ENV'] = 'another-test-env';
+
 		$this->assertEquals( 'another-test-env', $app->environment() );
 	}
 
 	public function test_is_environment() {
-		$_ENV['ENV'] = 'test-env';
-		$app         = new Application();
+		$_ENV['APP_ENV'] = 'test-env';
+
+		$app = new Application();
 
 		$this->assertTrue( $app->is_environment( 'test-env', 'another-thing' ) );
 		$this->assertTrue( $app->is_environment( 'test-env' ) );
@@ -30,6 +38,7 @@ class Test_Application extends \Mockery\Adapter\Phpunit\MockeryTestCase {
 
 	public function test_abort_404() {
 		$app = new Application();
+
 		$this->expectException( NotFoundHttpException::class );
 		$this->expectExceptionMessage( 'Not found message' );
 
@@ -38,6 +47,7 @@ class Test_Application extends \Mockery\Adapter\Phpunit\MockeryTestCase {
 
 	public function test_abort_500() {
 		$app = new Application();
+
 		$this->expectException( HttpException::class );
 		$this->expectExceptionMessage( 'Something went wrong' );
 
@@ -115,8 +125,7 @@ class Test_Application extends \Mockery\Adapter\Phpunit\MockeryTestCase {
 		$app = new Application();
 		$app->environment_path( __DIR__ . '/../fixtures/config' );
 		$app->environment_file( 'env-file' );
-
-		( new Load_Environment_Variables() )->bootstrap( $app );
+		$app->load_environment_variables();
 
 		$this->assertEquals( 'bar', environment( 'ENV_VAR_FOO' ) );
 		$this->assertEquals( 'bar', $_ENV['ENV_VAR_FOO'] );
@@ -129,8 +138,7 @@ class Test_Application extends \Mockery\Adapter\Phpunit\MockeryTestCase {
 		$app = new Application();
 		$app->environment_path( __DIR__ . '/../fixtures/config' );
 		$app->environment_file( 'fake-file' );
-
-		( new Load_Environment_Variables() )->bootstrap( $app );
+		$app->load_environment_variables();
 	}
 }
 

--- a/tests/framework/test-bootloader.php
+++ b/tests/framework/test-bootloader.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Mantle\Tests\Framework;
+
+use Mantle\Application\Application;
+use Mantle\Framework\Bootloader;
+use Mantle\Http\Request;
+use Mantle\Http\Response;
+use Mantle\Testing\Concerns\Interacts_With_Hooks;
+use PHPUnit\Framework\TestCase;
+
+class Test_Bootloader extends TestCase {
+	use Interacts_With_Hooks;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		Bootloader::set_instance( null );
+
+		$this->interacts_with_hooks_set_up();
+	}
+
+	public function tearDown(): void {
+		$this->interacts_with_hooks_tear_down();
+
+		Bootloader::set_instance( null );
+
+		parent::tearDown();
+	}
+
+	public function test_it_can_create_an_instance() {
+		$this->assertInstanceOf( Bootloader::class, Bootloader::get_instance() );
+		$this->assertNotNull( Bootloader::get_instance()->get_base_path() );
+	}
+
+	public function test_it_set_basepath_from_env() {
+		$_ENV['MANTLE_BASE_PATH'] = '/foo/bar';
+
+		$this->assertSame( '/foo/bar', Bootloader::get_instance()->get_base_path() );
+	}
+
+	public function test_it_can_be_used_by_helper() {
+		$this->assertInstanceOf( Bootloader::class, bootloader() );
+	}
+
+	public function test_it_will_set_instance_on_construct() {
+		$manager = new Bootloader();
+
+		$this->assertSame( $manager, Bootloader::get_instance() );
+	}
+
+	public function test_it_can_bind_custom_kernel() {
+		Bootloader::instance( $app = new Application() )
+			->bind( \Mantle\Contracts\Http\Kernel::class, Testable_Http_Kernel::class )
+			->boot();
+
+		// Ensure the custom kernel was bound.
+		$this->assertInstanceOf(
+			Testable_Http_Kernel::class,
+			$app->make( \Mantle\Contracts\Http\Kernel::class ),
+		);
+
+		// Ensure the standard console kernel was still bound.
+		$this->assertInstanceOf(
+			\Mantle\Framework\Console\Kernel::class,
+			$app->make( \Mantle\Contracts\Console\Kernel::class ),
+		);
+	}
+
+	public function test_it_can_boot_application() {
+		$this->expectApplied( 'mantle_bootloader_before_boot' )->once();
+		$this->expectApplied( 'mantle_bootloader_booted' )->once();
+
+		// Path filters.
+		$this->expectApplied( 'mantle_bootstrap_path' )->once()->andReturnString();
+		$this->expectApplied( 'mantle_cache_path' )->andReturnString();
+		$this->expectApplied( 'mantle_storage_path' )->once()->andReturnString();
+
+		$manager = new Bootloader();
+
+		$manager->boot();
+
+		$app = $manager->get_application();
+
+		$this->assertNotEmpty(
+			$app->make( \Mantle\Contracts\Console\Kernel::class ),
+		);
+
+		$this->assertNotEmpty(
+			$app->make( \Mantle\Contracts\Http\Kernel::class ),
+		);
+
+		$this->assertNotEmpty(
+			$app->make( \Mantle\Contracts\Exceptions\Handler::class ),
+		);
+
+		$this->assertTrue( $app->has_been_bootstrapped() );
+	}
+
+	public function test_it_can_setup_routing() {
+		add_filter( 'wp_using_themes', fn () => true, 99 );
+
+		$manager = new Bootloader();
+
+		$manager->boot();
+
+		$app = $manager->get_application();
+
+		$this->assertTrue( $app->bound( 'router' ) );
+
+		// Register the route.
+		$app->make( 'router' )->get( '/example-router', fn () => 'Hello World' );
+
+		$request = Request::create( '/example-router' );
+
+		$app->instance( 'request', $request );
+
+		$kernel = $app->make( \Mantle\Contracts\Http\Kernel::class );
+
+		// Make the request through the kernel.
+		$response = $kernel->send_request_through_router( $request );
+
+		$this->assertInstanceof( Response::class, $response );
+		$this->assertSame( 'Hello World', $response->getContent() );
+	}
+}
+
+class Testable_Http_Kernel implements \Mantle\Contracts\Http\Kernel {
+	/**
+	 * Run the HTTP Application.
+	 *
+	 * @param Request $request Request object.
+	 */
+	public function handle( Request $request ) {
+		$_SERVER['__testable_http_kernel__'] = $request;
+	}
+
+	/**
+	 * Terminate the HTTP request.
+	 *
+	 * @param Request  $request  Request object.
+	 * @param mixed    $response Response object.
+	 * @return void
+	 */
+	public function terminate( Request $request, mixed $response ): void {
+		$_SERVER['__testable_http_kernel_terminate__'] = $request;
+	}
+}

--- a/tests/framework/test-isolated-framework.php
+++ b/tests/framework/test-isolated-framework.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Mantle\Tests\Framework;
+
+use Mantle\Application\Application;
+use Mantle\Facade\Facade;
+use Mantle\Facade\Route;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Designed to test the application in complete isolation for use outside of a
+ * mantle-based application.
+ */
+class Test_Isolated_Framework extends TestCase {
+	public Application $app;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->app = new Application();
+
+		Application::set_instance( $this->app );
+
+		if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
+			define( 'WP_RUN_CORE_TESTS', true );
+		}
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		Application::set_instance( null );
+
+		unset( $this->app );
+	}
+
+	public function test_can_read_the_environment() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+
+		$this->assertEquals( 'staging', $this->app->environment() );
+	}
+
+	public function test_can_read_the_namespace() {
+		$this->assertEquals( 'App', app()->get_namespace() );
+
+		config()->set( 'app.namespace', 'MyApp' );
+		$this->assertEquals( 'MyApp', app()->get_namespace() );
+	}
+
+	public function test_sets_up_facade() {
+		$this->assertEquals( $this->app, Facade::get_facade_application() );
+	}
+}


### PR DESCRIPTION
Refactor the application to be less reliant on the boilerplate code in https://github.com/alleyinteractive/mantle and work more independently.

## Problem

Mantle projects often require a good amount of boilerplate code to use them (see https://github.com/alleyinteractive/mantle). This boilerplate code is prohibiting Mantle from reaching its fullest potential. For the most part, nobody prefers having to port over _all_ of this code to make Mantle run. It's holding back the greatness from within the framework.

## Solution

Introduce the Bootloader. The Bootloader abstracts the setting up of the framework with the right kernel given the current context. Though mirroring https://github.com/laravel/laravel is wonderful (boot the console kernel in `artisan`, boot the web kernel in `public/index.php`, etc.), it doesn't translate well WordPress land.

We still want applications to have the flexibility to do whatever they want with Mantle. But we want to allow for that while making it **as simple as possible** to run it without all the boilerplate code.

Here's an example of what is now possible (previously this required a whole bunch of setup code):

```php
// Boot the application.
bootloader()->boot();

// And get going!

// Register a router.
Route::get( '/example-route/', function () {
	dispatch( function () {
		file_put_contents(ABSPATH . '/example.txt', time() );
	} );

	return 'aye';
} );

Route::get( '/another-example/', function() {
	dispatch( function () {
		file_put_contents(ABSPATH . '/example.txt', time() );
	} );

	return response()->json( [ 'aye' => 'aye' ] );
} );
```

There is something to be said about how to make this even more extendable and easier to use. But it is a start!

Projects like `alleyinteractive/mantle` are now a starter kit of what can be done but no longer prescribes all the setup code needed. All you need is the above code and you should be good-to-go.

https://github.com/alleyinteractive/mantle/compare/0.12.x