### PR TITLE
Allow dynamic instance of a model to be created without defining the model class

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -70,11 +70,13 @@ return [
 		'Config'  => Mantle\Facade\Config::class,
 		'Event'   => Mantle\Facade\Event::class,
 		'Log'     => Mantle\Facade\Log::class,
+		'Post'    => Mantle\Database\Model\Post::class,
 		'Queue'   => Mantle\Facade\Queue::class,
 		'Request' => Mantle\Facade\Request::class,
 		'Route'   => Mantle\Facade\Route::class,
-		'View'    => Mantle\Facade\View::class,
 		'Storage' => Mantle\Facade\Storage::class,
+		'Term'    => Mantle\Database\Model\Term::class,
+		'View'    => Mantle\Facade\View::class,
 	],
 
 	/*

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -138,6 +138,20 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 	}
 
 	/**
+	 * Create a new model instance for a given post type.
+	 *
+	 * @param string $post_type Post type to create the model for.
+	 * @return self
+	 */
+	public static function for( string $post_type ): self {
+		$instance = new class extends Post {};
+
+		$instance::$object_name = $post_type;
+
+		return $instance;
+	}
+
+	/**
 	 * Query builder class to use.
 	 *
 	 * @return string|null

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -144,9 +144,25 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 	 * @return self
 	 */
 	public static function for( string $post_type ): self {
-		$instance = new class() extends Post {};
+		$instance = new class() extends Post {
+			/**
+			 * Post type for the model.
+			 *
+			 * @var string
+			 */
+			public static string $for_object_name = '';
 
-		$instance::$object_name = $post_type;
+			/**
+			 * Retrieve the object name.
+			 *
+			 * @return string|null
+			 */
+			public static function get_object_name(): ?string {
+				return static::$for_object_name;
+			}
+		};
+
+		$instance::$for_object_name = $post_type;
 
 		return $instance;
 	}

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -144,7 +144,7 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 	 * @return self
 	 */
 	public static function for( string $post_type ): self {
-		$instance = new class extends Post {};
+		$instance = new class() extends Post {};
 
 		$instance::$object_name = $post_type;
 

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -94,7 +94,7 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	 * @return self
 	 */
 	public static function for( string $taxonomy ): self {
-		$instance = new class extends Term {};
+		$instance = new class() extends Term {};
 
 		$instance::$object_name = $taxonomy;
 

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -94,9 +94,25 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	 * @return self
 	 */
 	public static function for( string $taxonomy ): self {
-		$instance = new class() extends Term {};
+		$instance = new class() extends Term {
+			/**
+			 * Object name.
+			 *
+			 * @var string
+			 */
+			public static string $for_object_name = '';
 
-		$instance::$object_name = $taxonomy;
+			/**
+			 * Retrieve the object name.
+			 *
+			 * @return string|null
+			 */
+			public static function get_object_name(): ?string {
+				return static::$for_object_name;
+			}
+		};
+
+		$instance::$for_object_name = $taxonomy;
 
 		return $instance;
 	}

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -88,6 +88,20 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	}
 
 	/**
+	 * Create a new model instance for a given taxonomy.
+	 *
+	 * @param string $taxonomy Taxonomy to create the model for.
+	 * @return self
+	 */
+	public static function for( string $taxonomy ): self {
+		$instance = new class extends Term {};
+
+		$instance::$object_name = $taxonomy;
+
+		return $instance;
+	}
+
+	/**
 	 * Query builder class to use.
 	 *
 	 * @return string|null

--- a/src/mantle/testing/factory/class-attachment-factory.php
+++ b/src/mantle/testing/factory/class-attachment-factory.php
@@ -24,19 +24,11 @@ use function Mantle\Support\Helpers\get_post_object;
  */
 class Attachment_Factory extends Post_Factory {
 	/**
-	 * Faker instance.
-	 *
-	 * @var Generator
-	 */
-	protected $faker;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param Generator $generator Faker generator.
+	 * @param Generator $faker Faker generator.
 	 */
-	public function __construct( Generator $generator ) {
-		$this->faker = $generator;
+	public function __construct( protected Generator $faker ) {
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-blog-factory.php
+++ b/src/mantle/testing/factory/class-blog-factory.php
@@ -19,19 +19,11 @@ use function Mantle\Support\Helpers\get_site_object;
  */
 class Blog_Factory extends Factory {
 	/**
-	 * Faker instance.
-	 *
-	 * @var Generator
-	 */
-	protected $faker;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param Generator $generator Faker generator.
+	 * @param Generator $faker Faker generator.
 	 */
-	public function __construct( Generator $generator ) {
-		$this->faker = $generator;
+	public function __construct( protected Generator $faker ) {
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-comment-factory.php
+++ b/src/mantle/testing/factory/class-comment-factory.php
@@ -19,26 +19,11 @@ use function Mantle\Support\Helpers\get_comment_object;
  */
 class Comment_Factory extends Factory {
 	/**
-	 * Faker instance.
-	 *
-	 * @var Generator
-	 */
-	protected $faker;
-
-	/**
-	 * Taxonomy name.
-	 *
-	 * @var string
-	 */
-	protected $taxonomy;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param Generator $generator Faker generator.
+	 * @param Generator $faker Faker generator.
 	 */
-	public function __construct( Generator $generator ) {
-		$this->faker = $generator;
+	public function __construct( protected Generator $faker ) {
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-post-factory.php
+++ b/src/mantle/testing/factory/class-post-factory.php
@@ -26,28 +26,12 @@ class Post_Factory extends Factory {
 	use Concerns\With_Meta;
 
 	/**
-	 * Faker instance.
-	 *
-	 * @var Generator
-	 */
-	protected $faker;
-
-	/**
-	 * Post type to use.
-	 *
-	 * @var string
-	 */
-	protected string $post_type;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param Generator $generator Faker generator.
+	 * @param Generator $faker Faker generator.
 	 * @param string    $post_type Post type to use.
 	 */
-	public function __construct( Generator $generator, string $post_type = 'post' ) {
-		$this->faker     = $generator;
-		$this->post_type = $post_type;
+	public function __construct( protected Generator $faker, protected string $post_type = 'post' ) {
 	}
 
 	/**
@@ -84,9 +68,12 @@ class Post_Factory extends Factory {
 	 * @return static
 	 */
 	public function with_post_type( string $post_type ): static {
-		return tap(
-			clone $this,
-			fn ( Post_Factory $factory ) => $factory->post_type = $post_type
+		return $this->with_middleware(
+			function ( array $args, Closure $next ) use ( $post_type ) {
+				$args['post_type'] = $post_type;
+
+				return $next( $args );
+			}
 		);
 	}
 

--- a/src/mantle/testing/factory/class-post-factory.php
+++ b/src/mantle/testing/factory/class-post-factory.php
@@ -15,6 +15,7 @@ use WP_Post;
 
 use function Mantle\Support\Helpers\collect;
 use function Mantle\Support\Helpers\get_post_object;
+use function Mantle\Support\Helpers\tap;
 
 /**
  * Post Factory
@@ -36,7 +37,7 @@ class Post_Factory extends Factory {
 	 *
 	 * @var string
 	 */
-	protected $post_type;
+	protected string $post_type;
 
 	/**
 	 * Constructor.
@@ -55,7 +56,7 @@ class Post_Factory extends Factory {
 	 * @param array<int, \WP_Term|int|string>|\WP_Term|int|string ...$terms Terms to assign to the post.
 	 * @return static
 	 */
-	public function with_terms( ...$terms ) {
+	public function with_terms( ...$terms ): static {
 		$terms = collect( $terms )->flatten()->all();
 
 		return $this->with_middleware(
@@ -68,12 +69,35 @@ class Post_Factory extends Factory {
 	 *
 	 * @return static
 	 */
-	public function with_thumbnail() {
+	public function with_thumbnail(): static {
 		return $this->with_meta(
 			[
 				'_thumbnail_id' => ( new Attachment_Factory( $this->faker ) )->create(),
 			]
 		);
+	}
+
+	/**
+	 * Create a new factory instance to create posts for a specific post type.
+	 *
+	 * @param string $post_type Post type to use.
+	 * @return static
+	 */
+	public function with_post_type( string $post_type ): static {
+		return tap(
+			clone $this,
+			fn ( Post_Factory $factory ) => $factory->post_type = $post_type
+		);
+	}
+
+	/**
+	 * Alias for {@see Post_Factory::with_post_type()}.
+	 *
+	 * @param string $post_type Post type to use.
+	 * @return static
+	 */
+	public function for( string $post_type ): static {
+		return $this->with_post_type( $post_type );
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-term-factory.php
+++ b/src/mantle/testing/factory/class-term-factory.php
@@ -22,28 +22,12 @@ class Term_Factory extends Factory {
 	use Concerns\With_Meta;
 
 	/**
-	 * Faker instance.
-	 *
-	 * @var Generator
-	 */
-	protected $faker;
-
-	/**
-	 * Taxonomy name.
-	 *
-	 * @var string
-	 */
-	protected $taxonomy;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param Generator $generator Faker generator.
+	 * @param Generator $faker Faker generator.
 	 * @param string    $taxonomy Taxonomy name.
 	 */
-	public function __construct( Generator $generator, string $taxonomy ) {
-		$this->faker    = $generator;
-		$this->taxonomy = $taxonomy;
+	public function __construct( protected Generator $faker, protected string $taxonomy ) {
 	}
 
 	/**

--- a/src/mantle/testing/factory/class-user-factory.php
+++ b/src/mantle/testing/factory/class-user-factory.php
@@ -22,19 +22,11 @@ class User_Factory extends Factory {
 	use Concerns\With_Meta;
 
 	/**
-	 * Faker instance.
-	 *
-	 * @var Generator
-	 */
-	protected $faker;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param Generator $generator Faker generator.
+	 * @param Generator $faker Faker generator.
 	 */
-	public function __construct( Generator $generator ) {
-		$this->faker = $generator;
+	public function __construct( protected Generator $faker ) {
 	}
 
 	/**

--- a/tests/database/model/test-post-object.php
+++ b/tests/database/model/test-post-object.php
@@ -9,6 +9,8 @@ use Mantle\Database\Model\Term;
 use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testing\Framework_Test_Case;
 
+use function Mantle\Support\Helpers\factory;
+
 class Test_Post_Object extends Framework_Test_Case {
 	use Refresh_Database;
 
@@ -234,6 +236,25 @@ class Test_Post_Object extends Framework_Test_Case {
 		$post_id = $this->factory->post->create( [ 'post_type' => 'example_post_type' ] );
 
 		$this->assertNull( Testable_Post::find( $post_id ) );
+	}
+
+	public function test_dynamic_model_instance() {
+		register_post_type( 'foo_post_type' );
+
+		$post_id = $this->factory->post->for( 'foo_post_type' )->create();
+		$post_two = $this->factory->post->for( 'foo_post_type' )->create( [
+			'post_title' => 'Post Two',
+		] );
+
+		$this->assertEquals( 'foo_post_type', get_post_type( $post_id ) );
+
+		$this->assertEmpty( Post::find( $post_id ) );
+		$this->assertInstanceOf( Post::class, Post::for( 'foo_post_type' ) );
+		$this->assertEquals( $post_id, Post::for( 'foo_post_type' )->find( $post_id )->id() );
+		$this->assertEquals(
+			$post_two,
+			Post::for( 'foo_post_type' )->where( 'title', 'Post Two' )->first()->id(),
+		);
 	}
 
 	public function test_query_builder() {


### PR DESCRIPTION
As a bridge to defining your own model for a post type, you can use Mantle models to interface with a dynamic post type name. 

The main use case for this PR is for simplified use outside of the framework -- where you want to use Mantle's models and query builder without setting up your own model classes.

```php
Post::for( 'my-post-type' )->where( 'title', 'Title here' )->first();
```