### PR TITLE
Improve the handling of various arguments to with_terms()

### DIFF
--- a/src/mantle/database/model/term/trait-model-term.php
+++ b/src/mantle/database/model/term/trait-model-term.php
@@ -7,6 +7,7 @@
 
 namespace Mantle\Database\Model\Term;
 
+use InvalidArgumentException;
 use Mantle\Database\Model\Model_Exception;
 use Mantle\Database\Model\Term;
 use Mantle\Support\Arr;
@@ -129,7 +130,7 @@ trait Model_Term {
 		// If taxonomy is not specified, chunk the terms into taxonomy groups.
 		if ( ! $taxonomy ) {
 			$terms = $terms->map_to_dictionary(
-				function ( $term ) {
+				function ( $term, $key ) {
 					if ( $term instanceof WP_Term ) {
 						return [ $term->taxonomy => $term ];
 					}
@@ -138,9 +139,16 @@ trait Model_Term {
 						return [ $term->taxonomy => $term->core_object() ];
 					}
 
-					$term = get_term_object( $term );
+					if ( ! is_numeric( $term ) ) {
+						$term = get_term_by( 'slug', $term );
+						// throw new InvalidArgumentException( "Invalid term value passed to set_terms (expected Term/WP_Term/int): {$term}" );
+					} else {
+						$term = get_term_object( $term );
+					}
 
-					if ( $term ) {
+					dump('term', $term);
+
+					if ( $term instanceof WP_Term ) {
 						return [ $term->taxonomy => $term ];
 					}
 

--- a/src/mantle/database/model/term/trait-model-term.php
+++ b/src/mantle/database/model/term/trait-model-term.php
@@ -11,10 +11,12 @@ use InvalidArgumentException;
 use Mantle\Database\Model\Model_Exception;
 use Mantle\Database\Model\Term;
 use Mantle\Support\Arr;
+use Mantle\Support\Collection;
 use WP_Term;
 
 use function Mantle\Support\Helpers\collect;
 use function Mantle\Support\Helpers\get_term_object;
+use function Mantle\Support\Helpers\get_term_object_by;
 
 /**
  * Interface for interfacing with a model's terms.
@@ -129,35 +131,74 @@ trait Model_Term {
 
 		// If taxonomy is not specified, chunk the terms into taxonomy groups.
 		if ( ! $taxonomy ) {
-			$terms = $terms->map_to_dictionary(
-				function ( $term, $key ) {
+			$terms = $terms->reduce(
+				function ( array $carry, $term ): array {
 					if ( $term instanceof WP_Term ) {
-						return [ $term->taxonomy => $term ];
+						$carry[ $term->taxonomy ][] = $term;
+
+						return $carry;
 					}
 
 					if ( $term instanceof Term ) {
-						return [ $term->taxonomy => $term->core_object() ];
+						$carry[ $term->taxonomy ][] = $term->core_object();
+
+						return $carry;
+					}
+
+					// Support an array of taxonomy => term ID/object/slug pairs.
+					if ( is_array( $term ) ) {
+						foreach ( $term as $taxonomy => $item ) {
+							if ( $item instanceof WP_Term || $item instanceof Term ) {
+								$carry[ $item->taxonomy ][] = $item instanceof Term
+									? $item->core_object()
+									: $item;
+
+								continue;
+							}
+
+							if ( is_numeric( $item ) ) {
+								$item = get_term_object( $item );
+
+								if ( $item instanceof WP_Term ) {
+									$carry[ $item->taxonomy ][] = $item;
+								}
+
+
+								continue;
+							}
+
+							// Attempt to infer if the key is a taxonomy slug and this is a
+							// taxonomy => term slug pair.
+							if ( ! is_string( $taxonomy ) || ! taxonomy_exists( $taxonomy ) ) {
+								continue;
+							}
+
+							$item = get_term_object_by( 'slug', $item, $taxonomy );
+
+							if ( $item ) {
+								$carry[ $taxonomy ][] = $item;
+							}
+						}
+
+						return $carry;
 					}
 
 					if ( ! is_numeric( $term ) ) {
-						$term = get_term_by( 'slug', $term );
-						// throw new InvalidArgumentException( "Invalid term value passed to set_terms (expected Term/WP_Term/int): {$term}" );
-					} else {
-						$term = get_term_object( $term );
+						throw new InvalidArgumentException( "Invalid term value passed to set_terms (expected Term/WP_Term/int): {$term}" );
 					}
 
-					dump('term', $term);
+					$term = get_term_object( $term );
 
-					if ( $term instanceof WP_Term ) {
-						return [ $term->taxonomy => $term ];
+					if ( $term ) {
+						$carry[ $term->taxonomy ][] = $term;
 					}
 
-					return null;
-				}
-			)
-			->filter();
+					return $carry;
+				},
+				[],
+			);
 
-			foreach ( $terms as $taxonomy => $items ) {
+			foreach ( collect( $terms )->filter() as $taxonomy => $items ) {
 				$this->set_terms( Arr::pluck( $items, 'term_id' ), $taxonomy, $append );
 			}
 

--- a/src/mantle/database/model/term/trait-model-term.php
+++ b/src/mantle/database/model/term/trait-model-term.php
@@ -163,7 +163,6 @@ trait Model_Term {
 									$carry[ $item->taxonomy ][] = $item;
 								}
 
-
 								continue;
 							}
 

--- a/src/mantle/support/class-collection.php
+++ b/src/mantle/support/class-collection.php
@@ -751,7 +751,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 * @template TMapToDictionaryKey of array-key
 	 * @template TMapToDictionaryValue
 	 *
-	 * @param  callable(TValue, TKey): array<TMapToDictionaryKey, TMapToDictionaryValue>|null $callback
+	 * @param  callable(TValue, TKey): array<TMapToDictionaryKey, TMapToDictionaryValue> $callback
 	 * @return static<TMapToDictionaryKey, array<int, TMapToDictionaryValue>>
 	 */
 	public function map_to_dictionary( callable $callback ) {
@@ -759,10 +759,6 @@ class Collection implements ArrayAccess, Enumerable {
 
 		foreach ( $this->items as $key => $item ) {
 			$pair = $callback( $item, $key );
-
-			if ( is_null( $pair ) ) {
-				continue;
-			}
 
 			$key = key( $pair );
 

--- a/src/mantle/support/class-collection.php
+++ b/src/mantle/support/class-collection.php
@@ -751,7 +751,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 * @template TMapToDictionaryKey of array-key
 	 * @template TMapToDictionaryValue
 	 *
-	 * @param  callable(TValue, TKey): array<TMapToDictionaryKey, TMapToDictionaryValue> $callback
+	 * @param  callable(TValue, TKey): array<TMapToDictionaryKey, TMapToDictionaryValue>|null $callback
 	 * @return static<TMapToDictionaryKey, array<int, TMapToDictionaryValue>>
 	 */
 	public function map_to_dictionary( callable $callback ) {
@@ -1009,12 +1009,21 @@ class Collection implements ArrayAccess, Enumerable {
 	/**
 	 * Reduce the collection to a single value.
 	 *
-	 * @param    callable $callback
-	 * @param    mixed    $initial
-	 * @return mixed
+	 * @template TReduceInitial
+	 * @template TReduceReturnType
+	 *
+	 * @param  callable(TReduceInitial|TReduceReturnType, TValue, TKey): TReduceReturnType $callback
+	 * @param  TReduceInitial                                                              $initial
+	 * @return TReduceReturnType|TReduceInitial
 	 */
 	public function reduce( callable $callback, $initial = null ) {
-		return array_reduce( $this->items, $callback, $initial );
+		$result = $initial;
+
+		foreach ( $this as $key => $value ) {
+			$result = $callback( $result, $value, $key );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/src/mantle/support/class-collection.php
+++ b/src/mantle/support/class-collection.php
@@ -760,6 +760,10 @@ class Collection implements ArrayAccess, Enumerable {
 		foreach ( $this->items as $key => $item ) {
 			$pair = $callback( $item, $key );
 
+			if ( is_null( $pair ) ) {
+				continue;
+			}
+
 			$key = key( $pair );
 
 			$value = reset( $pair );

--- a/src/mantle/testing/factory/class-post-factory.php
+++ b/src/mantle/testing/factory/class-post-factory.php
@@ -41,7 +41,12 @@ class Post_Factory extends Factory {
 	 * @return static
 	 */
 	public function with_terms( ...$terms ): static {
-		$terms = collect( $terms )->flatten()->all();
+		// Handle an array in the first argument.
+		if ( 1 === count( $terms ) && is_array( $terms[0] ) ) {
+			$terms = $terms[0];
+		}
+
+		$terms = collect( $terms )->all();
 
 		return $this->with_middleware(
 			fn ( array $args, Closure $next ) => $next( $args )->set_terms( $terms ),

--- a/tests/testing/test-factory.php
+++ b/tests/testing/test-factory.php
@@ -194,6 +194,20 @@ class Test_Factory extends Framework_Test_Case {
 		$this->assertTrue( has_term( $tag->term_id, 'post_tag', $post ) );
 	}
 
+	public function test_posts_with_terms_multiple_taxonomies_and_term_slug() {
+		$tag = static::factory()->tag->create_and_get();
+
+		$post = static::factory()->post->with_terms( [
+			$category = static::factory()->category->create_and_get(),
+			[
+				'post_tag' => $tag->slug,
+			],
+		] )->create_and_get();
+
+		$this->assertTrue( has_term( $category->term_id, 'category', $post ) );
+		$this->assertTrue( has_term( $tag->term_id, 'post_tag', $post ) );
+	}
+
 	public function test_post_with_meta() {
 		$post = static::factory()->post->with_meta(
 			[

--- a/tests/testing/test-factory.php
+++ b/tests/testing/test-factory.php
@@ -192,11 +192,31 @@ class Test_Factory extends Framework_Test_Case {
 
 		$this->assertTrue( has_term( $category->term_id, 'category', $post ) );
 		$this->assertTrue( has_term( $tag->term_id, 'post_tag', $post ) );
+
+		$post = static::factory()->post->with_terms( [
+			$category = static::factory()->category->create_and_get(),
+			$tag = static::factory()->tag->create_and_get(),
+		] )->create_and_get();
+
+		$this->assertTrue( has_term( $category->term_id, 'category', $post ) );
+		$this->assertTrue( has_term( $tag->term_id, 'post_tag', $post ) );
 	}
 
 	public function test_posts_with_terms_multiple_taxonomies_and_term_slug() {
 		$tag = static::factory()->tag->create_and_get();
 
+		// Test with the arguments passed as individual parameters.
+		$post = static::factory()->post->with_terms(
+			$category = static::factory()->category->create_and_get(),
+			[
+				'post_tag' => $tag->slug,
+			],
+		)->create_and_get();
+
+		$this->assertTrue( has_term( $category->term_id, 'category', $post ) );
+		$this->assertTrue( has_term( $tag->term_id, 'post_tag', $post ) );
+
+		// Test with the arguments wrapped in an array.
 		$post = static::factory()->post->with_terms( [
 			$category = static::factory()->category->create_and_get(),
 			[


### PR DESCRIPTION
Improves the argument handling for those arguments passed to `with_terms()`.

Updates `with_terms()` to support any combination of an array of terms/IDs, term objects, taxonomy => slugs, etc.

Resolves https://github.com/alleyinteractive/mantle/issues/162