### PR TITLE
Feature/dependencies test trait

### DIFF
--- a/src/mantle/testing/concerns/trait-dependency-assertions.php
+++ b/src/mantle/testing/concerns/trait-dependency-assertions.php
@@ -1,0 +1,55 @@
+<?php //phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+/**
+ * Dependency_Assertions trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Concerns;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+use Mantle\Support\Collection;
+
+trait Dependency_Assertions {
+
+	public static function assertDependenciesLoaded( array $dependencies ) {
+		if( count( $dependencies ) === 0 ) {
+			PHPUnit::markTestIncomplete( 'Asserting an empty dependency array has been loaded does not assert that no dependencies have been loaded.' );
+		}
+
+		foreach( $dependencies as $dependency ) {
+			if ( is_array( $dependency ) ) {
+				$dependency = array_shift( $dependency );
+			}
+
+			if ( ! is_string( $dependency ) ) {
+				PHPUnit::fail( 'Dependency type not string.' );
+				continue;
+			}
+
+			self::assertDependencyLoaded( $dependency );
+		}
+	}
+
+	public static function assertDependencyLoaded( string $dependency ) {
+		static $includes;
+
+		if (
+			! is_array( $includes ) ||
+			empty( $includes )
+		) {
+			$includes = new Collection( get_included_files() );
+		}
+
+		PHPUnit::assertTrue(
+			$includes
+				->filter(fn( $file ) => strpos( $file, $dependency ) !== false)
+				->count() > 0,
+			sprintf(
+				'%s dependency not found in included files.',
+				(string) $dependency
+			)
+		);
+	}
+
+}

--- a/src/mantle/testing/concerns/trait-dependency-assertions.php
+++ b/src/mantle/testing/concerns/trait-dependency-assertions.php
@@ -12,12 +12,20 @@ use Mantle\Support\Collection;
 
 trait Dependency_Assertions {
 
+	/**
+	 * Asserts that the contents of an array are loaded prior to testing.
+	 *
+	 * Array can be an array of strings or an array of arrays where the first value is a string -- for instance,
+	 * a data provider.
+	 *
+	 * @param array $dependencies Dependencies array.
+	 */
 	public static function assertDependenciesLoaded( array $dependencies ) {
-		if( count( $dependencies ) === 0 ) {
+		if ( count( $dependencies ) === 0 ) {
 			PHPUnit::markTestIncomplete( 'Asserting an empty dependency array has been loaded does not assert that no dependencies have been loaded.' );
 		}
 
-		foreach( $dependencies as $dependency ) {
+		foreach ( $dependencies as $dependency ) {
 			if ( is_array( $dependency ) ) {
 				$dependency = array_shift( $dependency );
 			}
@@ -31,6 +39,11 @@ trait Dependency_Assertions {
 		}
 	}
 
+	/**
+	 * Asserts that a file is loaded.
+	 *
+	 * @param string $dependency The dependency file name.
+	 */
 	public static function assertDependencyLoaded( string $dependency ) {
 		static $includes;
 
@@ -43,7 +56,7 @@ trait Dependency_Assertions {
 
 		PHPUnit::assertTrue(
 			$includes
-				->filter(fn( $file ) => strpos( $file, $dependency ) !== false)
+				->filter( fn( $file ) => strpos( $file, $dependency ) !== false )
 				->count() > 0,
 			sprintf(
 				'%s dependency not found in included files.',


### PR DESCRIPTION
This trait adds assertions to allow for easily validating whether dependency plugins are loaded during testing.

For the purposes of this PR, I'm defining a "dependency plugin" as a plugin that is active on the Production site that we want to verify is loaded during integration tests to account for interactivity issues between the plugin and the site custom code.