### PR TITLE
Update trait-installs-wordpress.php

### DIFF
--- a/src/mantle/testkit/concerns/trait-installs-wordpress.php
+++ b/src/mantle/testkit/concerns/trait-installs-wordpress.php
@@ -31,7 +31,7 @@ trait Installs_WordPress {
 		 *
 		 * @deprecated Logic condensed into {@see \Mantle\Testing\Installation_Manager::after()}.
 		 */
-		$callback = function_exists( 'mantle_after_wordpress_install' ) ? 'mantle_after_wordpress_install' : 'null';
+		$callback = function_exists( 'mantle_after_wordpress_install' ) ? 'mantle_after_wordpress_install' : null;
 
 		\Mantle\Testing\manager()
 			->after( $callback )


### PR DESCRIPTION
This PR fixes a bug where the `Installs_WordPress` trait fails if `mantle_after_wordpress_install` function doesn't exist.