### PR TITLE
Fix http-client content_type method

### DIFF
--- a/src/mantle/http-client/class-pending-request.php
+++ b/src/mantle/http-client/class-pending-request.php
@@ -228,7 +228,7 @@ class Pending_Request {
 	 * @return static
 	 */
 	public function content_type( string $content_type ) {
-		return $this->with_headers( [ 'Content-Type' => $content_type ] );
+		return $this->with_header( 'Content-Type', $content_type, true );
 	}
 
 	/**

--- a/tests/http-client/test-http-client.php
+++ b/tests/http-client/test-http-client.php
@@ -439,4 +439,11 @@ EOF
 
 		$this->assertEquals( 'Bar', $request->header( 'X-Foo' ) );
 	}
+
+	public function test_headers_as_form() {
+		$request = $this->http_factory
+			->as_form();
+
+		$this->assertEquals( 'application/x-www-form-urlencoded', $request->header( 'Content-Type' ) );
+	}
 }


### PR DESCRIPTION
Using `content_type()` multiples times (as with `as_form()`, since the object is created with default `as_json()`) results in a header array value which trigger an "array to string conversion" error in Requests