### PR TITLE
Ensure that REST API headers are persisted when testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,7 @@
             "src/mantle/cache/autoload.php",
             "src/mantle/config/autoload.php",
             "src/mantle/http/autoload.php",
+            "src/mantle/http-client/autoload.php",
             "src/mantle/queue/autoload.php",
             "src/mantle/support/autoload.php",
             "src/mantle/testing/autoload.php"

--- a/src/mantle/http-client/autoload.php
+++ b/src/mantle/http-client/autoload.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Mantle HTTP Client Helpers
+ *
+ * Intentionally not Namespaced to allow for root-level access to
+ * framework methods.
+ *
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound, Squiz.Commenting.FunctionComment
+ *
+ * @package Mantle
+ */
+
+declare( strict_types=1 );
+
+use Mantle\Http_Client\Pending_Request;
+use Mantle\Http_Client\Response;
+
+if ( ! function_exists( 'http_client' ) ) {
+	/**
+	 * Create a new pending request of the the HTTP Client.
+	 *
+	 * @param string|null $url URL to request, optional.
+	 * @return Pending_Request|Response
+	 * @phpstan-return ($url is string ? Response : Pending_Request)
+	 */
+	function http_client( ?string $url = null ): Pending_Request|Response {
+		return $url ? Pending_Request::create()->get( $url ) : Pending_Request::create();
+	}
+}

--- a/src/mantle/http-client/class-factory.php
+++ b/src/mantle/http-client/class-factory.php
@@ -51,6 +51,10 @@ class Factory {
 	 * @return Response|Pending_Request|Pool|mixed
 	 */
 	public static function __callStatic( string $method, array $parameters ) {
+		if ( static::has_macro( $method ) ) {
+			return ( new static() )->macro_call( $method, $parameters );
+		}
+
 		return ( new static() )->{$method}( ...$parameters );
 	}
 }

--- a/src/mantle/http-client/class-pending-request.php
+++ b/src/mantle/http-client/class-pending-request.php
@@ -9,6 +9,7 @@ namespace Mantle\Http_Client;
 
 use Mantle\Support\Pipeline;
 use Mantle\Support\Traits\Conditionable;
+use Mantle\Support\Traits\Macroable;
 
 use function Mantle\Support\Helpers\retry;
 use function Mantle\Support\Helpers\tap;
@@ -17,7 +18,7 @@ use function Mantle\Support\Helpers\tap;
  * Pending Request to be made with the Http Client.
  */
 class Pending_Request {
-	use Conditionable;
+	use Conditionable, Macroable;
 
 	/**
 	 * Base URL for the request.

--- a/src/mantle/http-client/composer.json
+++ b/src/mantle/http-client/composer.json
@@ -17,6 +17,11 @@
             }
         }
     },
+    "autoload": {
+        "files": [
+            "autoload.php"
+        ]
+    },
     "license": "GPL-2.0-or-later",
     "authors": [
         {

--- a/src/mantle/testing/concerns/trait-makes-http-requests.php
+++ b/src/mantle/testing/concerns/trait-makes-http-requests.php
@@ -354,7 +354,7 @@ trait Makes_Http_Requests {
 				ob_end_clean();
 
 				$response_content = $this->rest_api_response['body'];
-				$response_headers = $this->rest_api_response['headers'];
+				$response_headers = array_merge( (array) $response_headers, (array) $this->rest_api_response['headers'] );
 			} else {
 				try {
 					// Execute the request, inasmuch as WordPress would.

--- a/src/mantle/testing/concerns/trait-makes-http-requests.php
+++ b/src/mantle/testing/concerns/trait-makes-http-requests.php
@@ -11,10 +11,12 @@ use Mantle\Database\Model\Model;
 use Mantle\Framework\Http\Kernel as HttpKernel;
 use Mantle\Http\Request;
 use Mantle\Support\Str;
+use Mantle\Testing\Doubles\Spy_REST_Server;
 use Mantle\Testing\Exceptions\Exception;
 use Mantle\Testing\Exceptions\WP_Redirect_Exception;
 use Mantle\Testing\Test_Response;
 use Mantle\Testing\Utils;
+use PHPUnit\Framework\Assert;
 use RuntimeException;
 use WP;
 use WP_Query;
@@ -43,28 +45,28 @@ trait Makes_Http_Requests {
 	 *
 	 * @var bool
 	 */
-	protected $follow_redirects = false;
+	protected bool $follow_redirects = false;
 
 	/**
 	 * Store flag if the request was for the REST API.
 	 *
-	 * @var string|bool
+	 * @var array{body: string, headers: array<string, string>}|null
 	 */
-	protected $rest_api_response = false;
+	protected ?array $rest_api_response = null;
 
 	/**
 	 * The array of callbacks to be run before the event is started.
 	 *
-	 * @var array
+	 * @var array<callable>
 	 */
-	protected $before_callbacks = [];
+	protected array $before_callbacks = [];
 
 	/**
 	 * The array of callbacks to be run after the event is finished.
 	 *
-	 * @var array
+	 * @var array<callable>
 	 */
-	protected $after_callbacks = [];
+	protected array $after_callbacks = [];
 
 	/**
 	 * Setup the trait in the test case.
@@ -351,7 +353,8 @@ trait Makes_Http_Requests {
 				// Use the response from the REST API server.
 				ob_end_clean();
 
-				$response_content = $this->rest_api_response;
+				$response_content = $this->rest_api_response['body'];
+				$response_headers = $this->rest_api_response['headers'];
 			} else {
 				try {
 					// Execute the request, inasmuch as WordPress would.
@@ -421,7 +424,7 @@ trait Makes_Http_Requests {
 			}
 		}
 
-		$this->rest_api_response = false;
+		$this->rest_api_response = null;
 
 		// phpcs:enable
 	}
@@ -532,17 +535,25 @@ trait Makes_Http_Requests {
 			return;
 		}
 
-		// Initialize the server.
 		$server = rest_get_server();
-		$route  = untrailingslashit( $GLOBALS['wp']->query_vars['rest_route'] );
-		if ( empty( $route ) ) {
-			$route = '/';
-		}
 
-		$server->serve_request( $route );
+		if ( $server instanceof Spy_REST_Server ) {
+			$route = untrailingslashit( $GLOBALS['wp']->query_vars['rest_route'] );
 
-		if ( isset( $server->sent_body ) ) {
-			$this->rest_api_response = $server->sent_body;
+			if ( empty( $route ) ) {
+				$route = '/';
+			}
+
+			$server->serve_request( $route );
+
+			if ( isset( $server->sent_body ) ) {
+				$this->rest_api_response = [
+					'body'    => $server->sent_body,
+					'headers' => $server->sent_headers,
+				];
+			}
+		} else {
+			Assert::fail( 'Expected the Mantle Spy REST Server to be used.' );
 		}
 	}
 

--- a/src/mantle/testing/doubles/class-spy-rest-server.php
+++ b/src/mantle/testing/doubles/class-spy-rest-server.php
@@ -6,8 +6,8 @@ use WP_REST_Server;
 
 class Spy_REST_Server extends WP_REST_Server {
 
-	public $sent_headers        = array();
-	public $sent_body           = '';
+	public array $sent_headers  = [];
+	public $sent_body           = null;
 	public $last_request        = null;
 	public $override_by_default = false;
 

--- a/tests/http-client/test-http-client.php
+++ b/tests/http-client/test-http-client.php
@@ -446,4 +446,14 @@ EOF
 
 		$this->assertEquals( 'application/x-www-form-urlencoded', $request->header( 'Content-Type' ) );
 	}
+
+	public function test_helper_function() {
+		$this->fake_request();
+
+		http_client()->get( 'https://example.com/' );
+		http_client( 'https://example.com/direct' );
+
+		$this->assertRequestSent( 'https://example.com/' );
+		$this->assertRequestSent( 'https://example.com/direct' );
+	}
 }

--- a/tests/testing/concerns/test-makes-http-requests.php
+++ b/tests/testing/concerns/test-makes-http-requests.php
@@ -7,6 +7,7 @@ use Mantle\Framework\Providers\Routing_Service_Provider;
 use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testing\Framework_Test_Case;
 use Mantle\Testing\Test_Response;
+use WP_REST_Response;
 
 use function Mantle\Support\Helpers\collect;
 
@@ -120,6 +121,25 @@ class Test_Makes_Http_Requests extends Framework_Test_Case {
 			->assertJsonPath( 'title.rendered', get_the_title( $post_id ) )
 			->assertJsonPathExists( 'guid' )
 			->assertJsonPathMissing( 'example_path' );
+	}
+
+	public function test_rest_api_route_headers() {
+		$this->ignoreIncorrectUsage();
+
+		register_rest_route(
+			'/mantle/v1',
+			__FUNCTION__,
+			[
+				'methods'  => 'GET',
+				'validate_callback' => '__return_true',
+				'callback' => fn () => new WP_REST_Response( [ 'key' => 'value here' ], 201, [ 'test-header' => 'test-value' ] ),
+			]
+		);
+
+		$this->get( rest_url( '/mantle/v1/' . __FUNCTION__ ) )
+			->assertStatus( 201 )
+			->assertHeader( 'test-header', 'test-value' )
+			->assertJsonPath( 'key', 'value here' );
 	}
 
 	public function test_rest_api_route_error() {


### PR DESCRIPTION
Ensure that REST API headers that were previously ignored are now fully testable. 