### PR TITLE
Adding chunk()/chunk_by_id()/each()/each_by_id() methods to the query builder, fixing order by aliases

### DIFF
--- a/src/mantle/database/model/class-model.php
+++ b/src/mantle/database/model/class-model.php
@@ -24,6 +24,17 @@ use function Mantle\Support\Helpers\tap;
 
 /**
  * Database Model
+ *
+ * @method static \Mantle\Support\Collection all()
+ * @method static static first()
+ * @method static static first_or_fail()
+ * @method static void delete(bool $force)
+ * @method static boolean chunk(int $count, callable $callback)
+ * @method static boolean chunk_by_id(int $count, callable $callback)
+ * @method static boolean each(callable $callback, int $count = 100)
+ * @method static boolean each_by_id(callable $callback, int $count = 100, string $attribute = 'id')
+ * @method static \Mantle\Contracts\Paginator\Paginator simple_paginate(int $per_page = 20, int $current_page = null)
+ * @method static \Mantle\Contracts\Paginator\Paginator paginate(int $per_page = 20, int $current_page = null)
  */
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, Url_Routable {
 	use Forward_Calls,

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -14,8 +14,6 @@ use Mantle\Database\Query\Builder;
 use Mantle\Database\Query\Post_Query_Builder;
 use Mantle\Support\Helpers;
 
-use function Mantle\Support\Helpers\collect;
-
 /**
  * Post Model
  *
@@ -62,6 +60,7 @@ use function Mantle\Support\Helpers\collect;
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereTerm( array|\WP_Term|\Mantle\Database\Model\Term|int $term, ?string $taxonomy = null, string $operator = 'IN', string $field = 'term_id' )
  * @method static \Mantle\Contracts\Paginator\Paginator simple_paginate(int $per_page = 20, int $current_page = null)
  * @method static \Mantle\Contracts\Paginator\Paginator paginate(int $per_page = 20, int $current_page = null)
+ * @method static boolean chunk(int count, callable $callback)
  */
 class Post extends Model implements Contracts\Database\Core_Object, Contracts\Database\Model_Meta, Contracts\Database\Updatable {
 	use Events\Post_Events,

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -61,6 +61,7 @@ use Mantle\Support\Helpers;
  * @method static \Mantle\Contracts\Paginator\Paginator simple_paginate(int $per_page = 20, int $current_page = null)
  * @method static \Mantle\Contracts\Paginator\Paginator paginate(int $per_page = 20, int $current_page = null)
  * @method static boolean chunk(int count, callable $callback)
+ * @method static boolean chunk_by_id(int $count, callable $callback)
  */
 class Post extends Model implements Contracts\Database\Core_Object, Contracts\Database\Model_Meta, Contracts\Database\Updatable {
 	use Events\Post_Events,

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -58,10 +58,6 @@ use Mantle\Support\Helpers;
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereTitle( string $title )
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereType( string $type )
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereTerm( array|\WP_Term|\Mantle\Database\Model\Term|int $term, ?string $taxonomy = null, string $operator = 'IN', string $field = 'term_id' )
- * @method static \Mantle\Contracts\Paginator\Paginator simple_paginate(int $per_page = 20, int $current_page = null)
- * @method static \Mantle\Contracts\Paginator\Paginator paginate(int $per_page = 20, int $current_page = null)
- * @method static boolean chunk(int count, callable $callback)
- * @method static boolean chunk_by_id(int $count, callable $callback)
  */
 class Post extends Model implements Contracts\Database\Core_Object, Contracts\Database\Model_Meta, Contracts\Database\Updatable {
 	use Events\Post_Events,

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -183,6 +183,15 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 	}
 
 	/**
+	 * Create a new query instance.
+	 *
+	 * @return \Mantle\Database\Query\Post_Query_Builder<static>
+	 */
+	public static function query(): Post_Query_Builder {
+		return ( new static() )->new_query();
+	}
+
+	/**
 	 * Getter for Object ID.
 	 *
 	 * @return int

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -60,6 +60,8 @@ use function Mantle\Support\Helpers\collect;
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereTitle( string $title )
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereType( string $type )
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereTerm( array|\WP_Term|\Mantle\Database\Model\Term|int $term, ?string $taxonomy = null, string $operator = 'IN', string $field = 'term_id' )
+ * @method static \Mantle\Contracts\Paginator\Paginator simple_paginate(int $per_page = 20, int $current_page = null)
+ * @method static \Mantle\Contracts\Paginator\Paginator paginate(int $per_page = 20, int $current_page = null)
  */
 class Post extends Model implements Contracts\Database\Core_Object, Contracts\Database\Model_Meta, Contracts\Database\Updatable {
 	use Events\Post_Events,

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -132,6 +132,15 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	}
 
 	/**
+	 * Create a new query instance.
+	 *
+	 * @return \Mantle\Database\Query\Term_Query_Builder<static>
+	 */
+	public static function query(): Term_Query_Builder {
+		return ( new static() )->new_query();
+	}
+
+	/**
 	 * Get the meta type for the object.
 	 *
 	 * @return string

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -23,11 +23,9 @@ use Mantle\Support\Helpers;
  * @property string $taxonomy
  *
  * @method static \Mantle\Database\Query\Term_Query_Builder whereId( int $id )
- * @method static \Mantle\Database\Query\Term_Query_Builder whereName( string $name )
- * @method static \Mantle\Database\Query\Term_Query_Builder whereSlug( string $slug )
- * @method static \Mantle\Database\Query\Term_Query_Builder whereTaxonomy( string $taxonomy )
- *
- * @mixin \Mantle\Database\Query\Term_Query_Builder
+ * @method static \Mantle\Database\Query\Term_Query_Builder whereName(string $name)
+ * @method static \Mantle\Database\Query\Term_Query_Builder whereSlug(string $slug)
+ * @method static \Mantle\Database\Query\Term_Query_Builder whereTaxonomy(string $taxonomy)
  */
 class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	use Events\Term_Events,

--- a/src/mantle/database/query/class-builder.php
+++ b/src/mantle/database/query/class-builder.php
@@ -626,8 +626,12 @@ abstract class Builder {
 				function ( array $clauses, mixed $query ) use ( $column, $last_id ) {
 					global $wpdb;
 
+					if ( ! is_object( $query ) ) {
+						return $clauses;
+					}
+
 					$table = match ( $query::class ) {
-						\WP_Tax_Query::class => $wpdb->terms,
+						\WP_Term_Query::class => $wpdb->terms,
 						default => $wpdb->posts,
 					};
 

--- a/src/mantle/database/query/class-builder.php
+++ b/src/mantle/database/query/class-builder.php
@@ -626,7 +626,12 @@ abstract class Builder {
 				function ( array $clauses, mixed $query ) use ( $column, $last_id ) {
 					global $wpdb;
 
-					$clauses['where'] .= $wpdb->prepare( " AND {$wpdb->posts}.%s > %s", $column, $last_id );
+					$table = match ( $query::class ) {
+						\WP_Tax_Query::class => $wpdb->terms,
+						default => $wpdb->posts,
+					};
+
+					$clauses['where'] .= $wpdb->prepare( " AND {$table}.{$column} > %s", $last_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 					return $clauses;
 				}

--- a/src/mantle/database/query/class-builder.php
+++ b/src/mantle/database/query/class-builder.php
@@ -17,6 +17,7 @@ use Mantle\Database\Model\Model;
 use Mantle\Database\Model\Model_Not_Found_Exception;
 use Mantle\Database\Pagination\Length_Aware_Paginator;
 use Mantle\Database\Pagination\Paginator;
+use Mantle\Database\Query\Concerns\Query_Clauses;
 use Mantle\Support\Arr;
 use Mantle\Support\Collection;
 use Mantle\Support\Str;
@@ -30,7 +31,7 @@ use function Mantle\Support\Helpers\collect;
  * @template TModel of \Mantle\Database\Model\Model
  */
 abstract class Builder {
-	use Conditionable;
+	use Conditionable, Query_Clauses;
 
 	/**
 	 * Model to build on.
@@ -129,6 +130,13 @@ abstract class Builder {
 	 * @var string[]
 	 */
 	protected array $eager_load = [];
+
+	/**
+	 * Query hash for the built query.
+	 *
+	 * @var string
+	 */
+	protected string $query_hash = '';
 
 	/**
 	 * Constructor.
@@ -376,7 +384,7 @@ abstract class Builder {
 	}
 
 	/**
-	 * Alias for `removeOrderBy()`.
+	 * Alias for `removeOrder()`.
 	 *
 	 * @return static
 	 */
@@ -680,6 +688,9 @@ abstract class Builder {
 	/**
 	 * Chunk the results of the query.
 	 *
+	 * Note: this method uses pagination and not suited for operations where
+	 * data would be deleted which would affect subsequent pagination.
+	 *
 	 * @param int                                                           $count Number of items to chunk by.
 	 * @param callable(\Mantle\Support\Collection<int, TModel>, int): mixed $callback Callback to run on each chunk.
 	 * @return boolean
@@ -750,6 +761,15 @@ abstract class Builder {
 				}
 			)
 			->flip();
+	}
+
+	/**
+	 * Retrieve the hash of the query object.
+	 *
+	 * @return string
+	 */
+	public function get_query_hash(): string {
+		return $this->query_hash;
 	}
 
 	/**

--- a/src/mantle/database/query/class-post-query-builder.php
+++ b/src/mantle/database/query/class-post-query-builder.php
@@ -97,13 +97,15 @@ class Post_Query_Builder extends Builder {
 			$post_type = $this->model::get_object_name();
 		}
 
+		[ $order, $order_by ] = $this->get_builder_order( 'DESC', 'date' );
+
 		return array_merge(
 			[
 				'fields'              => 'ids',
 				'ignore_sticky_posts' => true,
 				'meta_query'          => $this->meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				'order'               => $this->order,
-				'orderby'             => $this->order_by,
+				'order'               => $order,
+				'orderby'             => $order_by,
 				'paged'               => $this->page,
 				'post_type'           => $post_type,
 				'posts_per_page'      => $this->limit,

--- a/src/mantle/database/query/class-post-query-builder.php
+++ b/src/mantle/database/query/class-post-query-builder.php
@@ -122,7 +122,15 @@ class Post_Query_Builder extends Builder {
 	 * @return Collection<int, TModel>
 	 */
 	public function get(): Collection {
-		$query            = new \WP_Query( $this->get_query_args() );
+		$query = new \WP_Query();
+
+		// Store the query hash for reference by side-effects.
+		$this->query_hash = spl_object_hash( $query );
+
+		$this->with_clauses(
+			fn () => $query->query( $this->get_query_args() ),
+		);
+
 		$this->found_rows = $query->found_posts;
 		$post_ids         = $query->posts;
 

--- a/src/mantle/database/query/class-post-query-builder.php
+++ b/src/mantle/database/query/class-post-query-builder.php
@@ -73,6 +73,15 @@ class Post_Query_Builder extends Builder {
 	];
 
 	/**
+	 * Query order by aliases.
+	 *
+	 * @var array
+	 */
+	protected array $query_order_by_aliases = [
+		'id' => 'ID',
+	];
+
+	/**
 	 * Tax Query.
 	 *
 	 * @var array

--- a/src/mantle/database/query/class-term-query-builder.php
+++ b/src/mantle/database/query/class-term-query-builder.php
@@ -57,6 +57,15 @@ class Term_Query_Builder extends Builder {
 	];
 
 	/**
+	 * Query order by aliases.
+	 *
+	 * @var array
+	 */
+	protected array $query_order_by_aliases = [
+		'id' => 'term_id',
+	];
+
+	/**
 	 * Get the query arguments.
 	 *
 	 * @return array

--- a/src/mantle/database/query/class-term-query-builder.php
+++ b/src/mantle/database/query/class-term-query-builder.php
@@ -57,20 +57,6 @@ class Term_Query_Builder extends Builder {
 	];
 
 	/**
-	 * Order of the query.
-	 *
-	 * @var string
-	 */
-	protected string $order = 'ASC';
-
-	/**
-	 * Query by of the query.
-	 *
-	 * @var string
-	 */
-	protected string $order_by = 'name';
-
-	/**
 	 * Get the query arguments.
 	 *
 	 * @return array
@@ -91,14 +77,16 @@ class Term_Query_Builder extends Builder {
 			$this->limit = null;
 		}
 
+		[ $order, $order_by ] = $this->get_builder_order( 'ASC', 'name' );
+
 		return array_merge(
 			[
 				'fields'     => 'ids',
 				'hide_empty' => false,
 				'meta_query' => $this->meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'number'     => $this->limit,
-				'order'      => $this->order,
-				'orderby'    => $this->order_by,
+				'order'      => $order,
+				'orderby'    => $order_by,
 				'taxonomy'   => $taxonomies,
 			],
 			$this->wheres,

--- a/src/mantle/database/query/concerns/trait-query-clauses.php
+++ b/src/mantle/database/query/concerns/trait-query-clauses.php
@@ -2,7 +2,7 @@
 /**
  * Modifies_Query trait file
  *
- * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag, Squiz.Commenting.FunctionComment.ParamNameNoMatch
  *
  * @package Mantle
  */
@@ -25,13 +25,21 @@ trait Query_Clauses {
 	/**
 	 * Query clauses to be added to the query.
 	 *
-	 * @var array<int, callable(array<string>, \WP_Query|\WP_Term_Query)>>
+	 * @var array<int, callable(array<string>, \WP_Query|\WP_Term_Query $query, ...): array<string>> The query clauses.
 	 */
 	protected array $clauses = [];
 
 	/**
+	 * Storage of the term query.
+	 *
+	 * @var \WP_Term_Query|null
+	 */
+	protected ?\WP_Term_Query $query_clause_query = null;
+
+	/**
 	 * Add a clause to the query.
 	 *
+	 * @param callable(array<string>, \WP_Query|\WP_Term_Query $query, ...): array<string> $clause The query clause.
 	 * @return static
 	 */
 	public function add_clause( callable $clause ): static {
@@ -54,18 +62,25 @@ trait Query_Clauses {
 	/**
 	 * Apply the query clauses to the query.
 	 *
-	 * @param array<string>            $clauses The query clauses.
-	 * @param \WP_Query|\WP_Term_Query $query The query object.
+	 * @param array<string> $clauses The query clauses.
+	 * @param mixed         ...$args Other arguments passed to the filter.
 	 * @return array<string> The modified query clauses.
 	 */
-	public function apply_clauses( array $clauses, \WP_Query|\WP_Term_Query $query ): array {
-		// Only apply the clauses if the query hash matches.
-		if ( spl_object_hash( $query ) !== $this->get_query_hash() ) {
+	public function apply_clauses( array $clauses, ...$args ): array {
+		// Extract the query from the arguments.
+		$query = $args[0] ?? null;
+
+		if ( is_array( $query ) && isset( $this->query_clause_query ) ) {
+			$query = $this->query_clause_query;
+		}
+
+		// Only apply the clauses if the query is set and the query hash matches.
+		if ( ! $query || spl_object_hash( $query ) !== $this->get_query_hash() ) {
 			return $clauses;
 		}
 
 		foreach ( $this->clauses as $clause ) {
-			$clauses = $clause( $clauses, $query );
+			$clauses = $clause( $clauses, $query, ...$args );
 		}
 
 		return $clauses;
@@ -78,7 +93,7 @@ trait Query_Clauses {
 		if ( $this instanceof Post_Query_Builder ) {
 			add_filter( 'posts_clauses', [ $this, 'apply_clauses' ], 10, 2 );
 		} elseif ( $this instanceof Term_Query_Builder ) {
-			add_filter( 'terms_clauses', [ $this, 'apply_clauses' ], 10, 2 );
+			add_action( 'pre_get_terms', [ $this, 'on_pre_get_terms' ] );
 		}
 	}
 
@@ -89,7 +104,11 @@ trait Query_Clauses {
 		if ( $this instanceof Post_Query_Builder ) {
 			remove_filter( 'posts_clauses', [ $this, 'apply_clauses' ], 10 );
 		} elseif ( $this instanceof Term_Query_Builder ) {
+			remove_action( 'pre_get_terms', [ $this, 'on_pre_get_terms' ], 10 );
 			remove_filter( 'terms_clauses', [ $this, 'apply_clauses' ], 10 );
+
+			// Reset the query object being stored.
+			$this->query_clause_query = null;
 		}
 	}
 
@@ -101,6 +120,11 @@ trait Query_Clauses {
 	 * @return TReturnValue The return value of the callback.
 	 */
 	protected function with_clauses( callable $callback ): mixed {
+		// Skip if there are no clauses to apply.
+		if ( empty( $this->clauses ) ) {
+			return $callback();
+		}
+
 		$this->register_clauses();
 
 		$result = $callback();
@@ -108,5 +132,30 @@ trait Query_Clauses {
 		$this->unregister_clauses();
 
 		return $result;
+	}
+
+	/**
+	 * Register the 'pre_get_terms' listener for a term query.
+	 *
+	 * As a workaround for the lack of query being passed to the 'terms_clauses'
+	 * filter, we use the 'pre_get_terms' filter to register the 'terms_clauses'
+	 * filter and store the query object.
+	 *
+	 * @param \WP_Term_Query $query The term query.
+	 */
+	public function on_pre_get_terms( \WP_Term_Query $query ): void {
+		// Only apply the clauses if the query hash matches.
+		if ( spl_object_hash( $query ) !== $this->get_query_hash() ) {
+			return;
+		}
+
+		// Store the query object.
+		$this->query_clause_query = $query;
+
+		// Remove the 'pre_get_terms' filter.
+		remove_action( 'pre_get_terms', [ $this, 'on_pre_get_terms' ] );
+
+		// Register the 'terms_clauses' filter.
+		add_filter( 'terms_clauses', [ $this, 'apply_clauses' ], 10, 3 );
 	}
 }

--- a/src/mantle/database/query/concerns/trait-query-clauses.php
+++ b/src/mantle/database/query/concerns/trait-query-clauses.php
@@ -25,7 +25,7 @@ trait Query_Clauses {
 	/**
 	 * Query clauses to be added to the query.
 	 *
-	 * @var array<int, callable(array<string>, \WP_Query|\WP_Term_Query $query, ...): array<string>> The query clauses.
+	 * @var array<int, callable(array<string>, \WP_Query|\WP_Term_Query $query): array<string>> The query clauses.
 	 */
 	protected array $clauses = [];
 
@@ -39,7 +39,7 @@ trait Query_Clauses {
 	/**
 	 * Add a clause to the query.
 	 *
-	 * @param callable(array<string>, \WP_Query|\WP_Term_Query $query, ...): array<string> $clause The query clause.
+	 * @param callable(array<string>, \WP_Query|\WP_Term_Query $query): array<string> $clause The query clause.
 	 * @return static
 	 */
 	public function add_clause( callable $clause ): static {

--- a/src/mantle/database/query/concerns/trait-query-clauses.php
+++ b/src/mantle/database/query/concerns/trait-query-clauses.php
@@ -2,6 +2,8 @@
 /**
  * Modifies_Query trait file
  *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ *
  * @package Mantle
  */
 
@@ -13,9 +15,9 @@ use Mantle\Database\Query\Term_Query_Builder;
 /**
  * Allow a query to be modified.
  *
- * Provides an API for modifying the subsequent query performed by
- * WP_Query/WP_Term_Query/etc. in a controlled manner and does not affect other
- * queries.
+ * Provides an way to modify the subsequent query performed by
+ * WP_Query/WP_Term_Query/etc. in a controlled manner which will not affect
+ * other queries.
  *
  * @mixin \Mantle\Database\Query\Builder
  */
@@ -52,7 +54,7 @@ trait Query_Clauses {
 	/**
 	 * Apply the query clauses to the query.
 	 *
-	 * @param array<string> $clauses The query clauses.
+	 * @param array<string>            $clauses The query clauses.
 	 * @param \WP_Query|\WP_Term_Query $query The query object.
 	 * @return array<string> The modified query clauses.
 	 */
@@ -98,7 +100,7 @@ trait Query_Clauses {
 	 * @param callable(): TReturnValue $callback The callback to execute.
 	 * @return TReturnValue The return value of the callback.
 	 */
-	public function with_clauses( callable $callback ): mixed {
+	protected function with_clauses( callable $callback ): mixed {
 		$this->register_clauses();
 
 		$result = $callback();

--- a/src/mantle/database/query/concerns/trait-query-clauses.php
+++ b/src/mantle/database/query/concerns/trait-query-clauses.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Modifies_Query trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Database\Query\Concerns;
+
+use Mantle\Database\Query\Post_Query_Builder;
+use Mantle\Database\Query\Term_Query_Builder;
+
+/**
+ * Allow a query to be modified.
+ *
+ * Provides an API for modifying the subsequent query performed by
+ * WP_Query/WP_Term_Query/etc. in a controlled manner and does not affect other
+ * queries.
+ *
+ * @mixin \Mantle\Database\Query\Builder
+ */
+trait Query_Clauses {
+	/**
+	 * Query clauses to be added to the query.
+	 *
+	 * @var array<int, callable(array<string>, \WP_Query|\WP_Term_Query)>>
+	 */
+	protected array $clauses = [];
+
+	/**
+	 * Add a clause to the query.
+	 *
+	 * @return static
+	 */
+	public function add_clause( callable $clause ): static {
+		$this->clauses[] = $clause;
+
+		return $this;
+	}
+
+	/**
+	 * Remove all clauses from the query.
+	 *
+	 * @return static
+	 */
+	public function clear_clauses(): static {
+		$this->clauses = [];
+
+		return $this;
+	}
+
+	/**
+	 * Apply the query clauses to the query.
+	 *
+	 * @param array<string> $clauses The query clauses.
+	 * @param \WP_Query|\WP_Term_Query $query The query object.
+	 * @return array<string> The modified query clauses.
+	 */
+	public function apply_clauses( array $clauses, \WP_Query|\WP_Term_Query $query ): array {
+		// Only apply the clauses if the query hash matches.
+		if ( spl_object_hash( $query ) !== $this->get_query_hash() ) {
+			return $clauses;
+		}
+
+		foreach ( $this->clauses as $clause ) {
+			$clauses = $clause( $clauses, $query );
+		}
+
+		return $clauses;
+	}
+
+	/**
+	 * Register the query clauses before the query is executed.
+	 */
+	protected function register_clauses(): void {
+		if ( $this instanceof Post_Query_Builder ) {
+			add_filter( 'posts_clauses', [ $this, 'apply_clauses' ], 10, 2 );
+		} elseif ( $this instanceof Term_Query_Builder ) {
+			add_filter( 'terms_clauses', [ $this, 'apply_clauses' ], 10, 2 );
+		}
+	}
+
+	/**
+	 * Unregister the query clauses after the query is executed.
+	 */
+	protected function unregister_clauses(): void {
+		if ( $this instanceof Post_Query_Builder ) {
+			remove_filter( 'posts_clauses', [ $this, 'apply_clauses' ], 10 );
+		} elseif ( $this instanceof Term_Query_Builder ) {
+			remove_filter( 'terms_clauses', [ $this, 'apply_clauses' ], 10 );
+		}
+	}
+
+	/**
+	 * Execute a callback with the clauses applied only for the closure.
+	 *
+	 * @template TReturnValue
+	 * @param callable(): TReturnValue $callback The callback to execute.
+	 * @return TReturnValue The return value of the callback.
+	 */
+	public function with_clauses( callable $callback ): mixed {
+		$this->register_clauses();
+
+		$result = $callback();
+
+		$this->unregister_clauses();
+
+		return $result;
+	}
+}

--- a/src/mantle/testing/factory/class-factory-container.php
+++ b/src/mantle/testing/factory/class-factory-container.php
@@ -72,7 +72,7 @@ class Factory_Container {
 	public $tag;
 
 	/**
-	 * Term Factory
+	 * Term Factory (alias for Tag Factory).
 	 *
 	 * @var Term_Factory<\WP_Term|\Mantle\Database\Model\Term>
 	 */

--- a/tests/database/query/test-paginator.php
+++ b/tests/database/query/test-paginator.php
@@ -2,9 +2,6 @@
 namespace Mantle\Tests\Database\Builder;
 
 use Mantle\Database\Model\Post;
-use Mantle\Database\Model\Term;
-use Mantle\Database\Query\Post_Query_Builder as Builder;
-use Mantle\Database\Query\Post_Query_Builder;
 use Mantle\Facade\Route;
 use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testing\Framework_Test_Case;

--- a/tests/database/query/test-post-query-builder.php
+++ b/tests/database/query/test-post-query-builder.php
@@ -305,6 +305,30 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 		}
 	}
 
+	public function test_query_clauses() {
+		$applied_count = 0;
+		$post_id       = $this->get_random_post_id();
+
+		$first = Testable_Post::query()
+			->add_clause(
+				function ( array $clauses ) use ( &$applied_count, $post_id ) {
+					$applied_count++;
+
+					$clauses['where'] .= ' AND ID = ' . $post_id;
+
+					return $clauses;
+				}
+			)
+			->first();
+
+			$this->assertEquals( $post_id, $first->id() );
+
+			$next = Testable_Post::first();
+
+			$this->assertNotEquals( $post_id, $next->id() );
+			$this->assertEquals( 1, $applied_count ); // The clauses should only be applied once.
+	}
+
 	public function test_chunk() {
 		static::factory()->post->create_many( 101 );
 

--- a/tests/database/query/test-post-query-builder.php
+++ b/tests/database/query/test-post-query-builder.php
@@ -302,6 +302,18 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 		}
 	}
 
+	public function test_chunk() {
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
+	}
+
+	public function test_chunk_by_id() {
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
+	}
+
+	public function test_each() {
+		$this->markTestIncomplete( 'This test has not been implemented yet.' );
+	}
+
 	/**
 	 * Get a random post ID, ensures the post ID is not the last in the set.
 	 *

--- a/tests/database/query/test-post-query-builder.php
+++ b/tests/database/query/test-post-query-builder.php
@@ -321,12 +321,12 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 			)
 			->first();
 
-			$this->assertEquals( $post_id, $first->id() );
+		$this->assertEquals( $post_id, $first->id() );
 
-			$next = Testable_Post::first();
+		$next = Testable_Post::first();
 
-			$this->assertNotEquals( $post_id, $next->id() );
-			$this->assertEquals( 1, $applied_count ); // The clauses should only be applied once.
+		$this->assertNotEquals( $post_id, $next->id() );
+		$this->assertEquals( 1, $applied_count ); // The clauses should only be applied once.
 	}
 
 	public function test_chunk() {
@@ -384,8 +384,6 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 
 	public function test_chunk_by_id() {
 		$post_ids = static::factory()->post->create_many( 105 );
-		// $post_ids = static::factory()->post->create_ordered_set( 105 );
-		// dump('IDS', $post_ids);
 
 		$last_page = null;
 		$count     = 0;
@@ -419,6 +417,8 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 
 		$this->assertTrue( $result );
 		$this->assertEquals( 105, $count );
+
+		$this->assertNull( get_post( collect( $post_ids )->last() ) );
 	}
 
 	public function test_each() {
@@ -445,6 +445,8 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 		} );
 
 		$this->assertEquals( collect( $post_ids )->sort()->values(), $ids->sort()->values() );
+
+		$this->assertNull( get_post( collect( $post_ids )->last() ) );
 	}
 
 	/**

--- a/tests/database/query/test-term-query-builder.php
+++ b/tests/database/query/test-term-query-builder.php
@@ -5,6 +5,7 @@ use Mantle\Database\Model\Term;
 use Mantle\Database\Query\Term_Query_Builder as Builder;
 use Mantle\Testing\Framework_Test_Case;
 
+use function Mantle\Support\Helpers\collect;
 
 class Test_Term_Query_Builder extends Framework_Test_Case {
 	public function test_term_by_name() {
@@ -22,7 +23,7 @@ class Test_Term_Query_Builder extends Framework_Test_Case {
 		$tag_id = $this->get_random_term_id();
 		$tag    = \get_term( $tag_id );
 
-		$first = Builder::create( Testable_Tag_Term::class )
+		$first = Testable_Tag_Term::query()
 			->whereSlug( $tag->slug )
 			->first();
 
@@ -63,20 +64,69 @@ class Test_Term_Query_Builder extends Framework_Test_Case {
 		$this->assertFalse( in_array( $tag_id, $get->to_array(), true ) );
 	}
 
+	public function test_term_orderby_asc() {
+		$term_ids = collect( static::factory()->term->create_many( 10 ) );
+
+		$get = Testable_Tag_Term::query()
+			->whereIn( 'id', $term_ids->shuffle()->values()->all() )
+			->orderBy( 'id', 'asc' )
+			->get()
+			->pluck( 'id' );
+
+		$this->assertEquals( $term_ids->sort()->values()->to_array(), $get->to_array() );
+	}
+
+	public function test_term_orderby_desc() {
+		$term_ids = collect( static::factory()->term->create_many( 10 ) );
+
+		$get = Testable_Tag_Term::query()
+			->whereIn( 'id', $term_ids->shuffle()->values()->all() )
+			->orderBy( 'id', 'desc' )
+			->get()
+			->pluck( 'id' );
+
+		$this->assertEquals( $term_ids->sort_desc()->values()->to_array(), $get->to_array() );
+	}
+
 	public function test_term_orderby_include() {
 		$term_ids = static::factory()->term->create_many( 10 );
 
 		// Shuffle to get a random order
 		shuffle( $term_ids );
 
-		$get = Builder::create( Testable_Tag_Term::class )
+		$get = Testable_Tag_Term::query()
 			->whereIn( 'id', $term_ids )
-			->orderBy( 'id' )
+			->orderByWhereIn( 'id' )
 			->get()
 			->pluck( 'id' );
 
 		$this->assertEquals( $term_ids, $get->to_array() );
+	}
 
+	public function test_query_clauses() {
+		$applied_count = 0;
+		$term_id       = $this->get_random_term_id();
+
+		$first = Testable_Tag::query()
+			->add_clause(
+				function ( array $clauses ) use ( &$applied_count, $term_id ) {
+					global $wpdb;
+
+					$applied_count++;
+
+					$clauses['where'] .= $wpdb->prepare( ' AND t.term_id = %d', $term_id );
+
+					return $clauses;
+				}
+			)
+			->firstOrFail();
+
+		$this->assertEquals( $term_id, $first->id() );
+
+		$next = Testable_Tag::first();
+
+		$this->assertNotEquals( $term_id, $next->id() );
+		$this->assertEquals( 1, $applied_count ); // The clauses should only be applied once.
 	}
 
 	/**


### PR DESCRIPTION
- Introduces query clause modification for an easy way to modify a query with query builder. In a future state, it'd be nice to do this fluently with `where()` but we'll get there. Supports posts and term queries.
- Fixes some assorted bugs found with order by.
- Adds updated doc blocks to models.
