### PR TITLE
User: align user factory `create` method

### DIFF
--- a/src/mantle/testing/factory/class-user-factory.php
+++ b/src/mantle/testing/factory/class-user-factory.php
@@ -45,11 +45,11 @@ class User_Factory extends Factory {
 	public function create( array $args = [] ): ?int {
 		$args = array_merge(
 			[
-				'description'  => $this->faker->sentence(),
-				'role'         => 'subscriber',
-				'user_email'   => $this->faker->email(),
-				'user_login'   => $this->faker->userName(),
-				'user_pass'    => 'password',
+				'description' => $this->faker->sentence(),
+				'role'        => 'subscriber',
+				'user_email'  => $this->faker->email(),
+				'user_login'  => $this->faker->userName(),
+				'user_pass'   => 'password',
 			],
 			$args
 		);

--- a/src/mantle/testing/factory/class-user-factory.php
+++ b/src/mantle/testing/factory/class-user-factory.php
@@ -7,7 +7,6 @@
 
 namespace Mantle\Testing\Factory;
 
-use Closure;
 use Faker\Generator;
 use Mantle\Database\Model\User;
 
@@ -44,15 +43,9 @@ class User_Factory extends Factory {
 	 * @return int|null
 	 */
 	public function create( array $args = [] ): ?int {
-		$first_name = $this->faker->firstName();
-		$last_name  = $this->faker->lastName();
-
 		$args = array_merge(
 			[
 				'description'  => $this->faker->sentence(),
-				'display_name' => "{$first_name} {$last_name}",
-				'first_name'   => $first_name,
-				'last_name'    => $last_name,
 				'role'         => 'subscriber',
 				'user_email'   => $this->faker->email(),
 				'user_login'   => $this->faker->userName(),

--- a/tests/testing/test-factory.php
+++ b/tests/testing/test-factory.php
@@ -8,7 +8,6 @@ use Mantle\Database\Model\Term;
 use Mantle\Testing\Concerns\With_Faker;
 use Mantle\Testing\Framework_Test_Case;
 
-
 use function Mantle\Support\Helpers\collect;
 
 class Test_Factory extends Framework_Test_Case {

--- a/tests/testing/test-factory.php
+++ b/tests/testing/test-factory.php
@@ -5,11 +5,15 @@ use Carbon\Carbon;
 use Closure;
 use Mantle\Database\Model\Post;
 use Mantle\Database\Model\Term;
+use Mantle\Testing\Concerns\With_Faker;
 use Mantle\Testing\Framework_Test_Case;
+
 
 use function Mantle\Support\Helpers\collect;
 
 class Test_Factory extends Framework_Test_Case {
+	use With_Faker;
+
 	public function test_post_factory() {
 		$this->assertInstanceOf( \WP_Post::class, static::factory()->post->create_and_get() );
 
@@ -123,6 +127,15 @@ class Test_Factory extends Framework_Test_Case {
 		)->create();
 
 		$this->assertEquals( '_test_meta_value', get_user_meta( $user_id, '_test_meta_key', true ) );
+	}
+
+	public function test_user_login_factory() {
+		$user_login = $this->faker->userName;
+		$user       = static::factory()->user
+			->create_and_get( [ 'user_login' => $user_login ] );
+
+		$this->assertSame( $user_login, $user->display_name );
+		$this->assertSame( $user_login, $user->user_login );
 	}
 
 	public function test_comment_factory() {


### PR DESCRIPTION
Fix an issue where Mantle is trying to be helpful but changing the behavior of the test when compared using the `WP_UnitTestCase` test class.