### PR TITLE
Remove types on LoggerInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "nunomaduro/collision": "^6.0",
         "nunomaduro/termwind": "^1.14",
         "psr/container": "^1.1.1 || ^2.0.1",
-        "psr/log": "^1.0.1 || ^2.0 || ^3.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "ramsey/uuid": "^4.7",
         "symfony/console": "^6.0",
         "symfony/finder": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "nunomaduro/collision": "^6.0",
         "nunomaduro/termwind": "^1.14",
         "psr/container": "^1.1.1 || ^2.0.1",
-        "psr/log": "^1.0.1 || ^2.0 || ^3.0",
+        "psr/log": "^3.0",
         "ramsey/uuid": "^4.7",
         "symfony/console": "^6.0",
         "symfony/finder": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "nunomaduro/collision": "^6.0",
         "nunomaduro/termwind": "^1.14",
         "psr/container": "^1.1.1 || ^2.0.1",
-        "psr/log": "^3.0",
+        "psr/log": "^1.0.1 || ^2.0 || ^3.0",
         "ramsey/uuid": "^4.7",
         "symfony/console": "^6.0",
         "symfony/finder": "^6.0",

--- a/src/mantle/log/class-log-manager.php
+++ b/src/mantle/log/class-log-manager.php
@@ -379,7 +379,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @throws \Psr\Log\InvalidArgumentException Thrown on invalid arguments.
 	 */
-	public function log( $level, string|\Stringable $message, array $context = [] ): void {
+	public function log( $level, $message, array $context = [] ) {
 		$this->driver()->$level( $message, $context );
 	}
 

--- a/src/mantle/log/class-log-manager.php
+++ b/src/mantle/log/class-log-manager.php
@@ -269,7 +269,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function emergency( string|\Stringable $message, array $context = [] ): void {
+	public function emergency( $message, array $context = [] ): void {
 		$this->driver()->emergency( $message, $context );
 	}
 
@@ -284,7 +284,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function alert( string|\Stringable $message, array $context = [] ): void {
+	public function alert( $message, array $context = [] ): void {
 		$this->driver()->alert( $message, $context );
 	}
 
@@ -298,7 +298,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function critical( string|\Stringable $message, array $context = [] ): void {
+	public function critical( $message, array $context = [] ): void {
 		$this->driver()->critical( $message, $context );
 	}
 
@@ -311,7 +311,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function error( string|\Stringable $message, array $context = [] ): void {
+	public function error( $message, array $context = [] ): void {
 		$this->driver()->error( $message, $context );
 	}
 
@@ -326,7 +326,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function warning( string|\Stringable $message, array $context = [] ): void {
+	public function warning( $message, array $context = [] ): void {
 		$this->driver()->warning( $message, $context );
 	}
 
@@ -338,7 +338,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function notice( string|\Stringable $message, array $context = [] ): void {
+	public function notice( $message, array $context = [] ): void {
 		$this->driver()->notice( $message, $context );
 	}
 
@@ -352,7 +352,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function info( string|\Stringable $message, array $context = [] ): void {
+	public function info( $message, array $context = [] ): void {
 		$this->driver()->info( $message, $context );
 	}
 
@@ -364,7 +364,7 @@ class Log_Manager implements LoggerInterface {
 	 *
 	 * @return void
 	 */
-	public function debug( string|\Stringable $message, array $context = [] ): void {
+	public function debug( $message, array $context = [] ): void {
 		$this->driver()->debug( $message, $context );
 	}
 

--- a/src/mantle/log/composer.json
+++ b/src/mantle/log/composer.json
@@ -8,7 +8,7 @@
         "mantle-framework/contracts": "^0.12",
         "mantle-framework/support": "^0.12",
         "monolog/monolog": "^2.7",
-        "psr/log": "^3.0"
+        "psr/log": "^1.0.1 || ^2.0 || ^3.0"
     },
     "extra": {
         "wordpress-autoloader": {

--- a/src/mantle/log/composer.json
+++ b/src/mantle/log/composer.json
@@ -8,7 +8,7 @@
         "mantle-framework/contracts": "^0.12",
         "mantle-framework/support": "^0.12",
         "monolog/monolog": "^2.7",
-        "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+        "psr/log": "^1.0|^2.0|^3.0"
     },
     "extra": {
         "wordpress-autoloader": {

--- a/src/mantle/log/composer.json
+++ b/src/mantle/log/composer.json
@@ -8,7 +8,7 @@
         "mantle-framework/contracts": "^0.12",
         "mantle-framework/support": "^0.12",
         "monolog/monolog": "^2.7",
-        "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+        "psr/log": "^3.0"
     },
     "extra": {
         "wordpress-autoloader": {

--- a/src/mantle/query-monitor/composer.json
+++ b/src/mantle/query-monitor/composer.json
@@ -11,7 +11,7 @@
         "mantle-framework/log": "^0.12",
         "mantle-framework/support": "^0.12",
         "monolog/monolog": "^2.7",
-        "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+        "psr/log": "^1.0|^2.0|^3.0"
     },
     "extra": {
         "wordpress-autoloader": {

--- a/src/mantle/query-monitor/composer.json
+++ b/src/mantle/query-monitor/composer.json
@@ -11,7 +11,7 @@
         "mantle-framework/log": "^0.12",
         "mantle-framework/support": "^0.12",
         "monolog/monolog": "^2.7",
-        "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+        "psr/log": "^3.0"
     },
     "extra": {
         "wordpress-autoloader": {

--- a/src/mantle/query-monitor/composer.json
+++ b/src/mantle/query-monitor/composer.json
@@ -11,7 +11,7 @@
         "mantle-framework/log": "^0.12",
         "mantle-framework/support": "^0.12",
         "monolog/monolog": "^2.7",
-        "psr/log": "^3.0"
+        "psr/log": "^1.0.1 || ^2.0 || ^3.0"
     },
     "extra": {
         "wordpress-autoloader": {

--- a/tests/log/test-log-manager.php
+++ b/tests/log/test-log-manager.php
@@ -70,10 +70,12 @@ class Test_Log_Manager extends \Mockery\Adapter\Phpunit\MockeryTestCase {
 		$this->instance->info( 'Test Message' );
 		$this->instance->error( 'Error Message' );
 		$this->instance->debug( 'Debug Message to ignore' );
+		$this->instance->emergency( 'Example emergency' );
 
 		// Check if the handler received the message.
 		$this->assertTrue( $this->handler->hasRecord( 'Test Message', 'info' ) );
 		$this->assertTrue( $this->handler->hasRecord( 'Error Message', 'error' ) );
+		$this->assertTrue( $this->handler->hasRecord( 'Example emergency', 'emergency' ) );
 
 		// Logger should have ignored the debug message.
 		$this->assertFalse( $this->handler->hasRecord( 'Debug Message to ignore', 'debug' ) );


### PR DESCRIPTION
Provides a fix for #420. Removes types from the `LoggerInterface` class `Log_Manager` to provide compatibility with `psr/log` 1-3. Laravel does a similar thing to support all 3.