### PR TITLE
Adding whereRaw() for modifying the raw query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.12.1 - 2023-08-18
+## v0.12.1 - 2023-08-21
 
 - Add better support for a query modifier on a relationship, fix an issue when
   saving multiple models.
+- Add `whereRaw()` for querying against raw attributes in a SQL query.
 
 ## v0.12.0 - 2023-08-17
 

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -61,6 +61,10 @@ use Mantle\Support\Helpers;
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> andWhereTerm( array|\WP_Term|\Mantle\Database\Model\Term|int $term, ?string $taxonomy = null, string $operator = 'IN', string $field = 'term_id' )
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> orWhereTerm( array|\WP_Term|\Mantle\Database\Model\Term|int $term, ?string $taxonomy = null, string $operator = 'IN', string $field = 'term_id' )
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereMeta( string $key, mixed $value, string $operator = '=' )
+ * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereRaw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' )
+ * @method static \Mantle\Database\Query\Post_Query_Builder<static> where_raw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' )
+ * @method static \Mantle\Database\Query\Post_Query_Builder<static> orWhereRaw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' )
+ * @method static \Mantle\Database\Query\Post_Query_Builder<static> or_where_raw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' )
  */
 class Post extends Model implements Contracts\Database\Core_Object, Contracts\Database\Model_Meta, Contracts\Database\Updatable {
 	use Events\Post_Events,

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -30,6 +30,10 @@ use Mantle\Support\Helpers;
  * @method static \Mantle\Database\Query\Term_Query_Builder<static> whereNotIn(string $key, array $values)
  * @method static \Mantle\Database\Query\Term_Query_Builder<static> whereIn(string $key, array $values)
  * @method static \Mantle\Database\Query\Term_Query_Builder<static> where(string|array $attribute, mixed $value)
+ * @method static \Mantle\Database\Query\Term_Query_Builder<static> whereRaw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' )
+ * @method static \Mantle\Database\Query\Term_Query_Builder<static> where_raw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' )
+ * @method static \Mantle\Database\Query\Term_Query_Builder<static> orWhereRaw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' )
+ * @method static \Mantle\Database\Query\Term_Query_Builder<static> or_where_raw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' )
  */
 class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	use Events\Term_Events,

--- a/src/mantle/database/query/class-builder.php
+++ b/src/mantle/database/query/class-builder.php
@@ -19,6 +19,7 @@ use Mantle\Database\Model\Model;
 use Mantle\Database\Model\Model_Not_Found_Exception;
 use Mantle\Database\Pagination\Length_Aware_Paginator;
 use Mantle\Database\Pagination\Paginator;
+use Mantle\Database\Query\Concerns\Query_Bindings;
 use Mantle\Database\Query\Concerns\Query_Clauses;
 use Mantle\Support\Arr;
 use Mantle\Support\Collection;
@@ -33,7 +34,9 @@ use function Mantle\Support\Helpers\collect;
  * @template TModel of \Mantle\Database\Model\Model
  */
 abstract class Builder {
-	use Conditionable, Query_Clauses;
+	use Conditionable,
+		Query_Bindings,
+		Query_Clauses;
 
 	/**
 	 * Model to build on.
@@ -281,7 +284,7 @@ abstract class Builder {
 	 * @param mixed        $value Value to compare against.
 	 * @return static
 	 */
-	public function where( $attribute, $value = '' ) {
+	public function where( array|string $attribute, mixed $value = '' ): static {
 		if ( is_array( $attribute ) && empty( $value ) ) {
 			foreach ( $attribute as $key => $value ) {
 				$this->where( $key, $value );
@@ -643,24 +646,7 @@ abstract class Builder {
 	 */
 	public function for_page_after_id( int $per_page, ?int $last_id = null, string $column = 'id' ): static {
 		if ( ! is_null( $last_id ) ) {
-			$this->add_clause(
-				function ( array $clauses, mixed $query ) use ( $column, $last_id ) {
-					global $wpdb;
-
-					if ( ! is_object( $query ) ) {
-						return $clauses;
-					}
-
-					$table = match ( $query::class ) {
-						\WP_Term_Query::class => $wpdb->terms,
-						default => $wpdb->posts,
-					};
-
-					$clauses['where'] .= $wpdb->prepare( " AND {$table}.{$column} > %s", $last_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-					return $clauses;
-				}
-			);
+			$this->where_raw( $column, '>', $last_id );
 		}
 
 		return $this

--- a/src/mantle/database/query/concerns/trait-query-bindings.php
+++ b/src/mantle/database/query/concerns/trait-query-bindings.php
@@ -81,7 +81,7 @@ trait Query_Bindings {
 		}
 
 		$this->bindings['where'][] = [
-			'boolean'  => 'AND',
+			'boolean'  => $boolean,
 			'column'   => $column,
 			'operator' => $operator,
 			'value'    => $value,
@@ -98,10 +98,43 @@ trait Query_Bindings {
 	 * @param array|string $column The column name or array of bindings.
 	 * @param string|null  $operator The operator OR the value if no value is provided.
 	 * @param mixed        $value The value.
+	 * @param string       $boolean The boolean operator (AND/OR) used to concatenate the clause.
 	 * @return static
 	 */
-	public function whereRaw( array|string $column, ?string $operator = null, mixed $value = null ): static {
-		return $this->where_raw( $column, $operator, $value );
+	public function whereRaw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' ): static {
+		return $this->where_raw( $column, $operator, $value, $boolean );
+	}
+
+	/**
+	 * Construct a WHERE clause with a boolean OR.
+	 *
+	 * @param array|string $column The column name or array of bindings.
+	 * @param string|null  $operator The operator OR the value if no value is provided.
+	 * @param mixed        $value The value.
+	 * @return static
+	 */
+	public function or_where_raw( array|string $column, ?string $operator = null, mixed $value = null ): static {
+		if ( is_array( $column ) ) {
+			foreach ( $column as $value ) {
+				$this->or_where_raw( ...array_values( $value ) );
+			}
+
+			return $this;
+		}
+
+		return $this->where_raw( $column, $operator, $value, 'OR' );
+	}
+
+	/**
+	 * Alias for or_where_raw().
+	 *
+	 * @param array|string $column The column name or array of bindings.
+	 * @param string|null  $operator The operator OR the value if no value is provided.
+	 * @param mixed        $value The value.
+	 * @return static
+	 */
+	public function orWhereRaw( array|string $column, ?string $operator = null, mixed $value = null ): static {
+		return $this->or_where_raw( $column, $operator, $value );
 	}
 
 	/**

--- a/src/mantle/database/query/concerns/trait-query-bindings.php
+++ b/src/mantle/database/query/concerns/trait-query-bindings.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Query_Bindings trait file
+ *
+ * phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Database\Query\Concerns;
+
+use InvalidArgumentException;
+
+use function Mantle\Support\Helpers\collect;
+
+/**
+ * Allow a query to use raw bindings in a controlled manner.
+ *
+ * @todo Add nested queries.
+ *
+ * @mixin \Mantle\Database\Query\Builder
+ */
+trait Query_Bindings {
+	/**
+	 * Raw query bindings.
+	 *
+	 * @var array
+	 */
+	protected array $bindings = [
+		'where' => [],
+	];
+
+	/**
+	 * The valid operators for a raw query binding.
+	 *
+	 * @var array
+	 */
+	protected array $operators = [
+		'=',
+		'!=',
+		'>',
+		'>=',
+		'<',
+		'<=',
+		'LIKE',
+		'NOT LIKE',
+		'IN',
+		'NOT IN',
+	];
+
+	/**
+	 * Flag to indicate if a raw query clause has been added.
+	 *
+	 * @var bool
+	 */
+	protected bool $raw_query_clause_added = false;
+
+	/**
+	 * Add a raw query binding.
+	 *
+	 * Allows the query to be built with raw SQL bindings.
+	 *
+	 * @param array|string $column The column name or array of bindings.
+	 * @param string|null  $operator The operator OR the value if no value is provided.
+	 * @param mixed        $value The value.
+	 * @param string       $boolean The boolean operator (AND/OR) used to concatenate the clause.
+	 * @return static
+	 */
+	public function where_raw( array|string $column, ?string $operator = null, mixed $value = null, string $boolean = 'AND' ): static {
+		if ( is_array( $column ) ) {
+			foreach ( $column as $value ) {
+				$this->where_raw( ...array_values( $value ) );
+			}
+
+			return $this;
+		}
+
+		if ( is_null( $value ) && ! is_null( $operator ) ) {
+			$value    = $operator;
+			$operator = '=';
+		}
+
+		$this->bindings['where'][] = [
+			'boolean'  => 'AND',
+			'column'   => $column,
+			'operator' => $operator,
+			'value'    => $value,
+		];
+
+		$this->add_raw_query_clause();
+
+		return $this;
+	}
+
+	/**
+	 * Alias for where_raw().
+	 *
+	 * @param array|string $column The column name or array of bindings.
+	 * @param string|null  $operator The operator OR the value if no value is provided.
+	 * @param mixed        $value The value.
+	 * @return static
+	 */
+	public function whereRaw( array|string $column, ?string $operator = null, mixed $value = null ): static {
+		return $this->where_raw( $column, $operator, $value );
+	}
+
+	/**
+	 * Add the raw query arguments to the query.
+	 */
+	public function add_raw_query_clause(): void {
+		if ( $this->raw_query_clause_added ) {
+			return;
+		}
+
+		$this->add_clause(
+			fn ( array $clauses, \WP_Query|\WP_Term_Query $query ) => $this->apply_query_bindings( $clauses, $query )
+		);
+
+		$this->raw_query_clause_added = true;
+	}
+
+	/**
+	 * Apply the query bindings to the clauses of a query.
+	 *
+	 * @throws InvalidArgumentException If the query class is invalid.
+	 *
+	 * @param array                    $clauses The query clauses.
+	 * @param \WP_Query|\WP_Term_Query $query The query object.
+	 * @return array The modified query clauses.
+	 */
+	protected function apply_query_bindings( array $clauses, \WP_Query|\WP_Term_Query $query ): array {
+		global $wpdb;
+
+		$table = match ( $query::class ) {
+			\WP_Query::class      => $wpdb->posts,
+			\WP_Term_Query::class => $wpdb->terms,
+			default               => throw new InvalidArgumentException( 'Invalid query class: ' . $query::class ),
+		};
+
+		foreach ( $this->bindings['where'] as $binding ) {
+			$clauses['where'] .= $this->get_where_clause( $table, $binding );
+		}
+
+		return $clauses;
+	}
+
+	/**
+	 * Get the where clause for a binding.
+	 *
+	 * @throws InvalidArgumentException If the operator is invalid.
+	 *
+	 * @param string $table The table name.
+	 * @param array  $binding The binding.
+	 * @return string The where clause.
+	 */
+	protected function get_where_clause( string $table, array $binding ): string {
+		global $wpdb;
+
+		$boolean  = $binding['boolean'];
+		$column   = $binding['column'];
+		$operator = $binding['operator'];
+		$value    = $binding['value'];
+
+		if ( ! in_array( $operator, $this->operators, true ) ) {
+			throw new InvalidArgumentException( "Invalid operator for raw query binding: {$operator}" );
+		}
+
+		// Handle an array of values, commonly used with IN/NOT IN.
+		if ( is_array( $value ) ) {
+			$value = collect( $value )
+				->map( 'esc_sql' )
+				->implode( ', ' );
+
+			return " {$boolean} {$table}.{$column} {$operator} ({$value})";
+		}
+
+		return $wpdb->prepare(
+			" {$boolean} {$table}.{$column} {$operator} %s", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$value
+		);
+	}
+}

--- a/src/mantle/database/query/concerns/trait-query-clauses.php
+++ b/src/mantle/database/query/concerns/trait-query-clauses.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Modifies_Query trait file
+ * Query_Clauses trait file
  *
  * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag, Squiz.Commenting.FunctionComment.ParamNameNoMatch
  *

--- a/tests/database/query/test-post-query-builder.php
+++ b/tests/database/query/test-post-query-builder.php
@@ -502,6 +502,16 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 		);
 	}
 
+	public function test_where_raw_or() {
+		$post_id = static::get_random_post_id();
+
+		$result = Testable_Post::whereRaw( 'ID', 'unknown' )
+			->orWhereRaw( 'ID', $post_id )
+			->first();
+
+		$this->assertEquals( $result->id(), $post_id );
+	}
+
 	/**
 	 * Get a random post ID, ensures the post ID is not the last in the set.
 	 *

--- a/tests/database/query/test-post-query-builder.php
+++ b/tests/database/query/test-post-query-builder.php
@@ -449,12 +449,65 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 		$this->assertNull( get_post( collect( $post_ids )->last() ) );
 	}
 
+	public function test_where_raw() {
+		$post_id = static::get_random_post_id();
+
+		$result = Testable_Post::query()
+			->where_raw( 'ID', $post_id )
+			->first();
+
+		$this->assertEquals( $result->id(), $post_id );
+	}
+
+	public function test_where_raw_like() {
+		$post_id = static::get_random_post_id();
+
+		$result = Testable_Post::query()
+			->where_raw( 'post_title', 'LIKE', get_the_title( $post_id ) )
+			->first();
+
+		$this->assertEquals( $result->id(), $post_id );
+
+		$post_id = Testable_Post::factory()->create( [
+			'post_title' => 'This is a post title',
+		] );
+
+		$result = Testable_Post::query()
+			->order_by( 'id', 'asc' )
+			->where_raw( 'post_title', 'LIKE', 'This is a%' )
+			->first();
+
+		$this->assertEquals( $result->id(), $post_id );
+	}
+
+	public function test_where_in_raw() {
+		$post_ids = static::factory()->post->create_many( 10 );
+
+		// Shuffle to get a random order
+		$post_ids = collect( $post_ids )->shuffle()->values();
+
+		$expected = $post_ids->random( 3 )->values();
+
+		$results = Builder::create( Testable_Post::class )
+			->whereRaw( 'ID', 'IN', $expected->all() )
+			->orderBy( 'id', 'asc' )
+			->get();
+
+		$this->assertNotEmpty( $results );
+
+		$this->assertCount( 3, $results );
+		$this->assertEquals(
+			$expected->sort()->values()->all(),
+			$results->pluck( 'id' )->all()
+		);
+	}
+
 	/**
 	 * Get a random post ID, ensures the post ID is not the last in the set.
 	 *
 	 * @return integer
 	 */
-	protected function get_random_post_id( $args = [] ): int {
+	protected static function get_random_post_id( $args = [] ): int {
 		$post_ids = static::factory()->post->create_many( 11, $args );
 		array_pop( $post_ids );
 		return $post_ids[ array_rand( $post_ids ) ];


### PR DESCRIPTION
Adds `whereRaw()`/`where_raw()` to allow the raw query to be modified. Useful when you need to make a custom query modification and `WP_Query`/`WP_Term_Query` doesn't cut it.