### PR TITLE
Fluent Factory

### DIFF
--- a/src/mantle/database/factory/class-factory.php
+++ b/src/mantle/database/factory/class-factory.php
@@ -251,7 +251,7 @@ abstract class Factory {
 	/**
 	 * Create a new fluent factory instance.
 	 *
-	 * @return static
+	 * @return Fluent_Factory
 	 */
 	protected function create_fluent_factory(): Fluent_Factory {
 		return new Fluent_Factory(
@@ -267,7 +267,7 @@ abstract class Factory {
 	 * @param array  $args   The arguments.
 	 * @return mixed
 	 */
-	public function __call( string $method, array $args ) {
+	public function __call( string $method, array $args ): mixed {
 		return $this->create_fluent_factory()->$method( ...$args );
 	}
 }

--- a/src/mantle/database/factory/class-factory.php
+++ b/src/mantle/database/factory/class-factory.php
@@ -25,6 +25,8 @@ use function Mantle\Support\Helpers\tap;
  * Base Factory
  *
  * @template TObject of \Mantle\Database\Model\Model
+ *
+ * @method \Mantle\Database\Factory\Fluent_Factory<TObject> count(int $count)
  */
 abstract class Factory {
 	use Concerns\Resolves_Factories,
@@ -244,5 +246,28 @@ abstract class Factory {
 		return fn ( array $args, Closure $next ) => $next(
 			array_merge( $args, $this->definition() ),
 		);
+	}
+
+	/**
+	 * Create a new fluent factory instance.
+	 *
+	 * @return static
+	 */
+	protected function create_fluent_factory(): Fluent_Factory {
+		return new Fluent_Factory(
+			clone $this,
+			$this->faker,
+		);
+	}
+
+	/**
+	 * Magic method to proxy calls to the fluent factory.
+	 *
+	 * @param string $method The method name.
+	 * @param array  $args   The arguments.
+	 * @return mixed
+	 */
+	public function __call( string $method, array $args ) {
+		return $this->create_fluent_factory()->$method( ...$args );
 	}
 }

--- a/src/mantle/database/factory/class-fluent-factory.php
+++ b/src/mantle/database/factory/class-fluent-factory.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Fluent_Factory class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Database\Factory;
+
+use BadMethodCallException;
+use Faker\Generator;
+
+use function Mantle\Support\Helpers\collect;
+
+/**
+ * Fluent Database Factory
+ *
+ * Extends upon the factory that is included with Mantle (one that is designed
+ * to mirror WordPress) and builds upon it to provide a fluent interface.
+ *
+ * @template TObject of \Mantle\Database\Model\Model
+ */
+class Fluent_Factory extends Factory {
+	/**
+	 * Number of objects to create.
+	 *
+	 * @var int
+	 */
+	protected int $count = 1;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Factory   $factory The factory to make fluent.
+	 * @param Generator $faker The Faker instance.
+	 */
+	protected function __construct(
+		protected Factory $factory,
+		Generator $faker,
+	) {
+		parent::__construct( $faker );
+	}
+
+	/**
+	 * Set the number of objects to create in the factory.
+	 *
+	 * @param int $count Count of objects to create.
+	 * @return static
+	 */
+	public function count( int $count ): static {
+		$this->count = $count;
+
+		return $this;
+	}
+
+	/**
+	 * Create one or multiple objects and return the IDs.
+	 *
+	 * @param array $args Arguments to pass to the factory.
+	 * @return \Mantle\Support\Collection<int, mixed>|mixed
+	 */
+	public function create( array $args = [] ): mixed {
+		if ( 1 === $this->count ) {
+			return $this->factory->create( $args );
+		} else {
+			return collect( $this->factory->create_many( $this->count, $args ) );
+		}
+	}
+
+	/**
+	 * Create one or multiple objects and return the objects.
+	 *
+	 * @param array $args Arguments to pass to the factory.
+	 * @return \Mantle\Support\Collection<int, TObject>|TObject
+	 */
+	public function create_and_get( array $args = [] ): mixed {
+		if ( 1 === $this->count ) {
+			return $this->factory->create_and_get( $args );
+		}
+
+		return collect()
+			->times(
+				$this->count,
+				fn () => $this->factory->create_and_get( $args ),
+			);
+	}
+
+	/**
+	 * Method to proxy back to the definition method on the factory.
+	 *
+	 * @return array
+	 */
+	public function definition(): array {
+		return $this->factory->definition();
+	}
+
+	/**
+	 * Retrieves an object by ID.
+	 *
+	 * @param mixed $object_id The object ID.
+	 * @return TObject
+	 */
+	public function get_object_by_id( mixed $object_id ): mixed {
+		return $this->factory->get_object_by_id( $object_id );
+	}
+
+	/**
+	 * Magic method to prevent an infinite loop when calling methods that do not
+	 * exist on this class. Allows for the factory to proxy back to the base
+	 * factory for scopes and other methods.
+	 *
+	 * @param string $method The method name.
+	 * @param array  $args   The arguments.
+	 * @return mixed
+	 *
+	 * @throws BadMethodCallException If the method does not exist.
+	 */
+	public function __call( string $method, array $args ): mixed {
+		if ( method_exists( $this->factory, $method ) ) {
+			$value = $this->factory->$method( ...$args );
+
+			if ( $value instanceof Factory ) {
+				return $this->make_fluent( $value );
+			}
+
+			return $value;
+		}
+
+		throw new BadMethodCallException( "Method {$method} does not exist." );
+	}
+
+	/**
+	 * Convert a factory to a fluent factory and copy over the state from the
+	 * current fluent factory.
+	 *
+	 * @param Factory $factory The factory to convert.
+	 * @return self
+	 */
+	protected function make_fluent( Factory $factory ): self {
+		return $factory
+			->create_fluent_factory()
+			->count( $this->count );
+	}
+}

--- a/tests/database/factory/test-factory.php
+++ b/tests/database/factory/test-factory.php
@@ -80,6 +80,41 @@ class Test_Factory extends Framework_Test_Case {
 
 		Factory\Factory::default_factory_name( $class::class ); // @phpstan-ignore-line
 	}
+
+	public function test_create_multiple_fluently() {
+		$post_ids = Testable_Post::factory()->count( 3 )->create()->all();
+
+		$this->assertIsArray( $post_ids );
+		$this->assertCount( 3, $post_ids );
+		$this->assertContainsOnly( 'int', $post_ids );
+
+		$posts = Testable_Post::factory()->count( 12 )->create_and_get()->all();
+
+		$this->assertIsArray( $posts );
+		$this->assertCount( 12, $posts );
+		$this->assertContainsOnlyInstancesOf( Testable_Post::class, $posts );
+
+		$this->assertInstanceOf(
+			Testable_Post::class,
+			Testable_Post::factory()->count( 1 )->create_and_get(),
+		);
+	}
+
+	public function test_create_multiple_fluently_with_scopes() {
+		$posts = Testable_Post_With_Factory::factory()
+			->count( 3 )
+			->custom_state()
+			->as_models()
+			->create_and_get()
+			->all();
+
+		$this->assertIsArray( $posts );
+		$this->assertCount( 3, $posts );
+		$this->assertEquals(
+			'Title from the custom state',
+			$posts[0]->title,
+		);
+	}
 }
 
 class Testable_Post extends Model\Post {


### PR DESCRIPTION
Allow for the following syntax (starts from here 😄):

```php
use App\Models\Post;

Post::factory()->count( 3 )->create_and_get()
```