### PR TITLE
Adding a database collection with found rows

### DIFF
--- a/src/mantle/database/query/class-builder.php
+++ b/src/mantle/database/query/class-builder.php
@@ -3,7 +3,7 @@
  * Builder class file.
  *
  * phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
- * phpcs:disable Squiz.Commenting.FunctionComment
+ * phpcs:disable Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FunctionComment
  * phpcs:disable PEAR.Functions.FunctionCallSignature.CloseBracketLine, PEAR.Functions.FunctionCallSignature.MultipleArguments, PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket
  *
  * @package Mantle
@@ -26,8 +26,6 @@ use Mantle\Support\Collection;
 use Mantle\Support\Str;
 use Mantle\Support\Traits\Conditionable;
 
-use function Mantle\Support\Helpers\collect;
-
 /**
  * Builder Query Builder
  *
@@ -41,9 +39,9 @@ abstract class Builder {
 	/**
 	 * Model to build on.
 	 *
-	 * @var string[]|string
+	 * @var class-string<TModel>|array<class-string<TModel>>
 	 */
-	protected $model;
+	protected array|string $model;
 
 	/**
 	 * Result limit per-page.
@@ -132,9 +130,9 @@ abstract class Builder {
 	/**
 	 * Storage of the found rows for a query.
 	 *
-	 * @var int
+	 * @var int|null
 	 */
-	protected int $found_rows = 0;
+	protected ?int $found_rows = 0;
 
 	/**
 	 * Relationships to eager load.
@@ -914,16 +912,13 @@ abstract class Builder {
 	/**
 	 * Collect all the model object names in an associative Collection.
 	 *
-	 * @return Collection Collection with object names as keys and model
-	 *                    class names as values.
+	 * @return Collection<string, class-string<\Mantle\Database\Model\Model>> Collection of model class names keyed by object name.
 	 */
 	public function get_model_object_names(): Collection {
-		return collect( (array) $this->model )
+		return ( new Collection( (array) $this->model ) ) // @phpstan-ignore-line should return
 			->combine( $this->model )
 			->map(
-				function ( $model ) {
-					return $model::get_object_name();
-				}
+				fn ( $model ) => $model::get_object_name(),
 			)
 			->flip();
 	}

--- a/src/mantle/database/query/class-collection.php
+++ b/src/mantle/database/query/class-collection.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Collection class file
+ *
+ * phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Database\Query;
+
+use Mantle\Database\Model\Model;
+use Mantle\Support\Collection as Base_Collection;
+
+/**
+ * Database Query Collection
+ *
+ * @template TKey of array-key
+ * @template TModel of \Mantle\Database\Model\Model
+ *
+ * @extends \Mantle\Support\Collection<TKey, TModel>
+ */
+class Collection extends Base_Collection {
+	/**
+	 * Total number of rows found for the query.
+	 *
+	 * @var int|null
+	 */
+	public ?int $found_rows = null;
+
+	/**
+	 * Set the total number of rows found for the query.
+	 *
+	 * @param int|null $found_rows Total number of rows found for the query.
+	 * @return static
+	 */
+	public function with_found_rows( ?int $found_rows ): static {
+		$this->found_rows = $found_rows;
+
+		return $this;
+	}
+
+	/**
+	 * Get the total number of rows found for the query.
+	 *
+	 * @return int|null
+	 */
+	public function found_rows(): ?int {
+		return $this->found_rows;
+	}
+
+	/**
+	 * Retrieve the models in the collection.
+	 *
+	 * @return \Mantle\Support\Collection<int, class-string<TModel>>
+	 */
+	public function models(): Base_Collection {
+		return $this->map( fn ( $model ) => $model::class )->values()->unique();
+	}
+
+	/**
+	 * Run a map over each of the items.
+	 *
+	 * @template TMapValue
+	 *
+	 * @param  callable(TModel, TKey): TMapValue $callback The callback to run.
+	 * @return \Mantle\Support\Collection<TKey, TMapValue>|static<TKey, TMapValue>
+	 */
+	public function map( callable $callback ) {
+		$result = parent::map( $callback );
+
+		if ( $result instanceof self ) {
+			$result->with_found_rows( $this->found_rows );
+		}
+
+		return $result->contains( fn ( $item ) => ! $item instanceof Model )
+			? $result->to_base()
+			: $result;
+	}
+
+	/**
+	 * Run an associative map over each of the items.
+	 *
+	 * The callback should return an associative array with a single key/value pair.
+	 *
+	 * @template TMapWithKeysKey of array-key
+	 * @template TMapWithKeysValue
+	 *
+	 * @param  callable(TModel, TKey): array<TMapWithKeysKey, TMapWithKeysValue> $callback The callback to run.
+	 * @return \Mantle\Support\Collection<TMapWithKeysKey, TMapWithKeysValue>|static<TMapWithKeysKey, TMapWithKeysValue>
+	 */
+	public function map_with_keys( callable $callback ) {
+		$result = parent::map_with_keys( $callback );
+
+		if ( $result instanceof self ) {
+			$result->with_found_rows( $this->found_rows );
+		}
+
+		return $result->contains( fn ( $item ) => ! $item instanceof Model )
+			? $result->to_base()
+			: $result;
+	}
+
+	/**
+	 * The following methods are intercepted to always return base collections.
+	 */
+
+	/**
+	 * Count the number of items in the collection by a field or using a callback.
+	 *
+	 * @param  (callable(TModel, TKey): array-key)|string|null $count_by
+	 * @return \Mantle\Support\Collection<array-key, int>
+	 */
+	public function count_by( $count_by = null ) {
+		return $this->to_base()->count_by( $count_by );
+	}
+
+	/**
+	 * Collapse the collection of items into a single array.
+	 *
+	 * @return \Mantle\Support\Collection<int, mixed>
+	 */
+	public function collapse() {
+		return $this->to_base()->collapse();
+	}
+
+	/**
+	 * Get a flattened array of the items in the collection.
+	 *
+	 * @param  int|float $depth
+	 * @return \Mantle\Support\Collection<int, mixed>
+	 */
+	public function flatten( $depth = INF ) {
+		return $this->to_base()->flatten( $depth );
+	}
+
+	/**
+	 * Flip the items in the collection.
+	 *
+	 * @return \Mantle\Support\Collection<int|string, TKey>
+	 */
+	public function flip() {
+		return $this->to_base()->flip();
+	}
+
+	/**
+	 * Get the keys of the collection items.
+	 *
+	 * @return \Mantle\Support\Collection<int, TKey>
+	 */
+	public function keys() {
+		return $this->to_base()->keys();
+	}
+
+	/**
+	 * Pad collection to the specified length with a value.
+	 *
+	 * @template TPadValue
+	 *
+	 * @param  int       $size
+	 * @param  TPadValue $value
+	 * @return \Mantle\Support\Collection<int, TModel|TPadValue>
+	 */
+	public function pad( $size, $value ) {
+		return $this->to_base()->pad( $size, $value );
+	}
+
+	/**
+	 * Get an array with the values of a given key.
+	 *
+	 * @param  string|array<array-key, string> $value
+	 * @param  string|null                     $key
+	 * @return \Mantle\Support\Collection<array-key, mixed>
+	 */
+	public function pluck( $value, $key = null ) {
+		return $this->to_base()->pluck( $value, $key );
+	}
+
+	/**
+	 * Zip the collection together with one or more arrays.
+	 *
+	 * @template TZipValue
+	 *
+	 * @param  \Mantle\Contracts\Support\Arrayable<array-key, TZipValue>|iterable<array-key, TZipValue> ...$items
+	 * @return static<int, static<TKey, TModel|TZipValue>>
+	 */
+	public function zip( ...$items ) { // @phpstan-ignore-line return
+		return $this->to_base()->zip( ...$items );
+	}
+}

--- a/src/mantle/database/query/class-post-query-builder.php
+++ b/src/mantle/database/query/class-post-query-builder.php
@@ -313,13 +313,15 @@ class Post_Query_Builder extends Builder {
 	}
 
 	/**
-	 * Fetch the query with 'no_found_rows' set to true. This prevents counting
-	 * all the available rows for a query.
+	 * Fetch the query with 'no_found_rows' set to a value.
 	 *
+	 * Setting to 'true' prevents counting all the available rows for a query.
+	 *
+	 * @param bool $value Whether to set 'no_found_rows' to true.
 	 * @return static
 	 */
-	public function withNoFoundRows(): static {
-		return $this->where( 'no_found_rows', true );
+	public function withNoFoundRows( bool $value = true ): static {
+		return $this->where( 'no_found_rows', $value );
 	}
 
 	/**

--- a/src/mantle/database/query/class-post-query-builder.php
+++ b/src/mantle/database/query/class-post-query-builder.php
@@ -11,7 +11,7 @@ namespace Mantle\Database\Query;
 use Mantle\Database\Model\Term;
 use Mantle\Database\Query\Concerns\Queries_Dates;
 use Mantle\Support\Helpers;
-use Mantle\Support\Collection;
+use RuntimeException;
 use WP_Term;
 
 use function Mantle\Support\Helpers\collect;
@@ -117,7 +117,6 @@ class Post_Query_Builder extends Builder {
 
 		return array_merge(
 			[
-				'fields'              => 'ids',
 				'ignore_sticky_posts' => true,
 				'meta_query'          => $this->meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				'order'               => $order,
@@ -130,6 +129,9 @@ class Post_Query_Builder extends Builder {
 			],
 			$this->get_date_query_args(),
 			$this->wheres,
+			[
+				'fields' => 'ids',
+			]
 		);
 	}
 
@@ -148,14 +150,21 @@ class Post_Query_Builder extends Builder {
 			fn () => $query->query( $this->get_query_args() ),
 		);
 
-		$this->found_rows = $query->found_posts;
-		$post_ids         = $query->posts;
-
-		if ( empty( $post_ids ) ) {
-			return collect();
+		if ( empty( $query->found_posts ) && count( $query->posts ) > 0 ) {
+			$this->found_rows = null;
+		} else {
+			$this->found_rows = $query->found_posts;
 		}
 
-		$models = $this->get_models( $post_ids );
+		$post_ids = $query->posts;
+
+		if ( empty( $post_ids ) ) {
+			return ( new Collection() )->with_found_rows( $this->found_rows ); // @phpstan-ignore-line should return
+		}
+
+		$models = $this
+			->get_models( $post_ids )
+			->with_found_rows( $this->found_rows );
 
 		// Return the models if there are no models or if multiple model instances
 		// are used. Eager loading does not currently support multiple models.
@@ -195,10 +204,17 @@ class Post_Query_Builder extends Builder {
 	protected function get_models( array $post_ids ): Collection {
 		if ( is_array( $this->model ) ) {
 			$model_object_types = $this->get_model_object_names();
-			return collect( $post_ids )
+
+			return Collection::from( $post_ids )
 				->map(
 					function ( $post_id ) use ( $model_object_types ) {
 						$post_type = \get_post_type( $post_id );
+
+						if ( empty( $model_object_types[ $post_type ] ) ) {
+							throw new RuntimeException(
+								"Missing model for object type [{ $post_type }]."
+							);
+						}
 
 						if ( empty( $post_type ) ) {
 							return null;
@@ -207,12 +223,13 @@ class Post_Query_Builder extends Builder {
 						return $model_object_types[ $post_type ]::find( $post_id );
 					}
 				)
-				->filter();
-		} else {
-			return collect( $post_ids )
-				->map( [ $this->model, 'find' ] )
-				->filter();
+				->filter()
+				->values();
 		}
+
+		return Collection::from( $post_ids )
+			->map( [ $this->model, 'find' ] )
+			->filter();
 	}
 
 	/**
@@ -293,6 +310,16 @@ class Post_Query_Builder extends Builder {
 	public function orWhereTerm( ...$args ) {
 		$this->tax_query['relation'] = 'OR';
 		return $this->whereTerm( ...$args );
+	}
+
+	/**
+	 * Fetch the query with 'no_found_rows' set to true. This prevents counting
+	 * all the available rows for a query.
+	 *
+	 * @return static
+	 */
+	public function withNoFoundRows(): static {
+		return $this->where( 'no_found_rows', true );
 	}
 
 	/**

--- a/src/mantle/support/class-collection.php
+++ b/src/mantle/support/class-collection.php
@@ -446,7 +446,7 @@ class Collection implements ArrayAccess, Enumerable {
 	/**
 	 * Get a flattened array of the items in the collection.
 	 *
-	 *  @param  int|float $depth
+	 * @param  int|float $depth
 	 * @return static<int, mixed>
 	 */
 	public function flatten( $depth = INF ) {
@@ -456,7 +456,7 @@ class Collection implements ArrayAccess, Enumerable {
 	/**
 	 * Flip the items in the collection.
 	 *
-	 * @return static<TValue, TKey>
+	 * @return static<int|string, TKey>
 	 */
 	public function flip() {
 		return new static( array_flip( $this->items ) );
@@ -1327,7 +1327,7 @@ class Collection implements ArrayAccess, Enumerable {
 	 * @template TZipValue
 	 *
 	 * @param  \Mantle\Contracts\Support\Arrayable<array-key, TZipValue>|iterable<array-key, TZipValue> ...$items
-	 * @return static<int, static<int, TValue|TZipValue>>
+	 * @return static<int, static<TKey, TValue|TZipValue>>
 	 */
 	public function zip( ...$items ) {
 		$arrayable_items = array_map(

--- a/tests/database/query/test-post-query-builder.php
+++ b/tests/database/query/test-post-query-builder.php
@@ -527,6 +527,36 @@ class Test_Post_Query_Builder extends Framework_Test_Case {
 		$this->assertEquals( 1, Testable_Post::whereIn( 'id', [ $post_id ] )->count() );
 	}
 
+	public function test_found_rows() {
+		static::factory()->post->create_many( 25 );
+
+		$query = Testable_Post::query()
+			->take( 10 )
+			->get();
+
+		$this->assertInstanceOf( \Mantle\Database\Query\Collection::class, $query );
+		$this->assertEquals( 10, $query->count() );
+		$this->assertEquals( 25, $query->found_rows() );
+
+		$models = $query->models();
+
+		$this->assertNotInstanceOf( \Mantle\Database\Query\Collection::class, $models );
+		$this->assertEquals( 1, $models->count() );
+	}
+
+	public function test_no_found_rows_true() {
+		static::factory()->post->create_many( 10 );
+
+		$query = Testable_Post::query()
+			->withNoFoundRows()
+			->take( 10 )
+			->get();
+
+		$this->assertInstanceOf( \Mantle\Database\Query\Collection::class, $query );
+		$this->assertEquals( 10, $query->count() );
+		$this->assertNull( $query->found_rows() );
+	}
+
 	public function test_post_by_date() {
 		$old_date = Carbon::now( wp_timezone() )->subMonth();
 		$now      = Carbon::now( wp_timezone() );


### PR DESCRIPTION
- Adds a database collection with support for passing the `found_rows` along to the response. 
- Adds support for easily passing `no_found_rows` to queries.