### PR TITLE
Adds a trait to easily silence remote requests during testing

### DIFF
--- a/src/mantle/testing/concerns/trait-interacts-with-requests.php
+++ b/src/mantle/testing/concerns/trait-interacts-with-requests.php
@@ -153,18 +153,6 @@ trait Interacts_With_Requests {
 	}
 
 	/**
-	 * Alias for fake_request().
-	 *
-	 * @param Closure|string|array                  $url_or_callback URL to fake, array of URL and response pairs, or a closure
-	 *                                                               that will return a faked response.
-	 * @param Mock_Http_Response|Mock_Http_Sequence $response Optional response object, defaults to creating a 200 response.
-	 * @return static|Mock_Http_Response
-	 */
-	public function fake( Mock_Http_Response|Mock_Http_Sequence|Closure|string|array|null $url_or_callback = null, Mock_Http_Response|Mock_Http_Sequence|Closure $response = null ) {
-		return $this->fake_request( $url_or_callback, $response );
-	}
-
-	/**
 	 * Filters pre_http_request to intercept the request, mock a response, and
 	 * return it. If the response has already been preempted, the preempt will
 	 * be returned instead. Regardless, this object unhooks itself from the

--- a/src/mantle/testing/concerns/trait-interacts-with-requests.php
+++ b/src/mantle/testing/concerns/trait-interacts-with-requests.php
@@ -26,6 +26,8 @@ use function Mantle\Support\Helpers\value;
 
 /**
  * Allow Mock HTTP Requests
+ *
+ * @mixin \PHPUnit\Framework\TestCase
  */
 trait Interacts_With_Requests {
 	/**
@@ -82,7 +84,7 @@ trait Interacts_With_Requests {
 	 *
 	 * @param Mock_Http_Response|\Closure|bool $response A default response or callback to use, boolean otherwise.
 	 */
-	public function prevent_stray_requests( $response = true ) {
+	public function prevent_stray_requests( Mock_Http_Response|Closure|bool $response = true ) {
 		$this->preventing_stray_requests = $response;
 	}
 

--- a/src/mantle/testing/concerns/trait-interacts-with-requests.php
+++ b/src/mantle/testing/concerns/trait-interacts-with-requests.php
@@ -349,9 +349,10 @@ trait Interacts_With_Requests {
 	 * @param int             $expected_times Number of times the request should have been
 	 *                                        sent, optional.
 	 */
-	public function assertRequestSent( $url_or_callback = null, int $expected_times = null ) {
+	public function assertRequestSent( string|callable|null $url_or_callback = null, int $expected_times = null ): void {
 		if ( is_null( $url_or_callback ) ) {
 			PHPUnit::assertTrue( $this->recorded_requests->is_not_empty(), 'A request was made.' );
+
 			return;
 		}
 
@@ -376,7 +377,7 @@ trait Interacts_With_Requests {
 	 *
 	 * @param string|callable $url_or_callback URL to check against or callback.
 	 */
-	public function assertRequestNotSent( $url_or_callback = null ) {
+	public function assertRequestNotSent( string|callable|null $url_or_callback = null ): void {
 		if ( is_string( $url_or_callback ) ) {
 			$url_or_callback = fn ( $request ) => Str::is( $url_or_callback, $request->url() );
 		}
@@ -393,7 +394,7 @@ trait Interacts_With_Requests {
 	 *
 	 * @return void
 	 */
-	public function assertNoRequestSent() {
+	public function assertNoRequestSent(): void {
 		PHPUnit::assertEmpty(
 			$this->recorded_requests,
 			'Requests were recorded',
@@ -406,7 +407,7 @@ trait Interacts_With_Requests {
 	 * @param int $count Request count.
 	 * @return void
 	 */
-	public function assertRequestCount( int $count ) {
+	public function assertRequestCount( int $count ): void {
 		PHPUnit::assertCount( $count, $this->recorded_requests );
 	}
 }

--- a/src/mantle/testing/concerns/trait-interacts-with-requests.php
+++ b/src/mantle/testing/concerns/trait-interacts-with-requests.php
@@ -34,14 +34,14 @@ trait Interacts_With_Requests {
 	/**
 	 * Storage of the callbacks to mock the requests.
 	 *
-	 * @var Collection
+	 * @var Collection<int, callable(string, array): Mock_Http_Response|Arrayable|WP_Error|null>
 	 */
 	protected Collection $stub_callbacks;
 
 	/**
 	 * Storage of request URLs.
 	 *
-	 * @var Collection
+	 * @var Collection<int, Request>
 	 */
 	protected Collection $recorded_requests;
 
@@ -49,14 +49,14 @@ trait Interacts_With_Requests {
 	 * Flag to prevent external requests from being made. By default, this is
 	 * false.
 	 *
-	 * @var Mock_Http_Response|Closure|bool
+	 * @var Mock_Http_Response|callable|bool
 	 */
 	protected mixed $preventing_stray_requests = false;
 
 	/**
 	 * Recorded actual HTTP requests made during the test.
 	 *
-	 * @var Collection
+	 * @var Collection<int, string>
 	 */
 	protected Collection $recorded_actual_requests;
 

--- a/src/mantle/testing/concerns/trait-prevent-remote-requests.php
+++ b/src/mantle/testing/concerns/trait-prevent-remote-requests.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Prevent_Remote_Requests trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Concerns;
+
+use Mantle\Testing\Mock_Http_Response;
+
+/**
+ * Prevent remote requests from being made by providing a default response to
+ * the remote request.
+ *
+ * @mixin \Mantle\Testing\Test_Case
+ */
+trait Prevent_Remote_Requests {
+	/**
+	 * Setup the trait.
+	 */
+	public function prevent_remote_requests_set_up(): void {
+		if ( ! $this->prevent_remote_requests ) {
+			$this->preventing_stray_requests = new Mock_Http_Response();
+		}
+	}
+}

--- a/src/mantle/testing/concerns/trait-prevent-remote-requests.php
+++ b/src/mantle/testing/concerns/trait-prevent-remote-requests.php
@@ -21,7 +21,7 @@ trait Prevent_Remote_Requests {
 	 */
 	public function prevent_remote_requests_set_up(): void {
 		if ( ! $this->prevent_remote_requests ) {
-			$this->preventing_stray_requests = new Mock_Http_Response();
+			$this->prevent_stray_requests( new Mock_Http_Response() );
 		}
 	}
 }

--- a/tests/testing/concerns/test-interacts-with-external-requests.php
+++ b/tests/testing/concerns/test-interacts-with-external-requests.php
@@ -5,6 +5,7 @@ use InvalidArgumentException;
 use Mantle\Facade\Http;
 use Mantle\Http_Client\Factory;
 use Mantle\Http_Client\Pending_Request;
+use Mantle\Testing\Concerns\Prevent_Remote_Requests;
 use Mantle\Testing\Mock_Http_Response;
 use Mantle\Testing\Framework_Test_Case;
 use Mantle\Testing\Mock_Http_Sequence;
@@ -16,6 +17,8 @@ use RuntimeException;
  * @group testing
  */
 class Test_Interacts_With_External_Requests extends Framework_Test_Case {
+	use Prevent_Remote_Requests;
+
 	public function test_fake_request() {
 		$this->fake_request( 'https://testing.com/*' )
 			->with_response_code( 404 )
@@ -227,6 +230,13 @@ class Test_Interacts_With_External_Requests extends Framework_Test_Case {
 		$this->prevent_stray_requests();
 
 		Http::get( 'https://example.org/path/' );
+	}
+
+	public function test_prevent_remote_requests_trait() {
+		// The trait sets up the default response.
+		$this->assertInstanceOf( Mock_Http_Response::class, $this->preventing_stray_requests );
+
+		wp_remote_get( 'https://example.com/' );
 	}
 
 	public function test_file_as_response() {


### PR DESCRIPTION
- Adds a trait that can easily silence and prevent remote HTTP requests during testing. Prevents the need to manually call `fake_request()` when porting over a legacy code base.
- Adds some types to `fake_request()`'s arguments to prevent bad arguments from getting through.