### PR TITLE
Adding block assertions to strings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0.1",
-        "alleyinteractive/wp-match-blocks": "^3.0",
+        "alleyinteractive/wp-match-blocks": "^1.0 || ^2.0 || ^3.0",
         "guzzlehttp/guzzle": "^7.7",
         "league/flysystem-aws-s3-v3": "^1.0",
         "mockery/mockery": "^1.6.6",

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     },
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0.1",
+        "alleyinteractive/wp-match-blocks": "^3.0",
         "guzzlehttp/guzzle": "^7.7",
         "league/flysystem-aws-s3-v3": "^1.0",
         "mockery/mockery": "^1.6.6",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,6 +28,7 @@
 		<exclude name="PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection" />
 		<exclude name="PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.Changed" />
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
+		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 	</rule>
 
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />

--- a/src/mantle/database/class-factory-service-provider.php
+++ b/src/mantle/database/class-factory-service-provider.php
@@ -46,7 +46,7 @@ class Factory_Service_Provider extends Service_Provider {
 				$locale = config( 'app.faker_locale', Factory::DEFAULT_LOCALE );
 
 				if ( ! isset( static::$fakers[ $locale ] ) ) {
-					static::$fakers[ $locale ] = Factory::create();
+					static::$fakers[ $locale ] = Factory::create( $locale );
 
 					static::$fakers[ $locale ]->addProvider(
 						new Faker_Provider( static::$fakers[ $locale ] )

--- a/src/mantle/database/factory/class-attachment-factory.php
+++ b/src/mantle/database/factory/class-attachment-factory.php
@@ -8,7 +8,6 @@
 namespace Mantle\Database\Factory;
 
 use Closure;
-use Faker\Generator;
 use Mantle\Contracts\Database\Core_Object;
 use Mantle\Database\Model\Attachment;
 use RuntimeException;
@@ -19,7 +18,11 @@ use function Mantle\Support\Helpers\get_post_object;
 /**
  * Attachment Factory
  *
- * @template TObject of \Mantle\Database\Model\Attachment
+ * @template TModel of \Mantle\Database\Model\Attachment
+ * @template TObject of \WP_Post
+ * @template TReturnValue
+ *
+ * @extends Factory<TModel, TObject, TReturnValue>
  */
 class Attachment_Factory extends Post_Factory {
 	use Concerns\Generates_Images;
@@ -27,7 +30,7 @@ class Attachment_Factory extends Post_Factory {
 	/**
 	 * Model to use when creating objects.
 	 *
-	 * @var class-string
+	 * @var class-string<TModel>
 	 */
 	protected string $model = Attachment::class;
 

--- a/src/mantle/database/factory/class-blog-factory.php
+++ b/src/mantle/database/factory/class-blog-factory.php
@@ -14,13 +14,17 @@ use function Mantle\Support\Helpers\get_site_object;
 /**
  * Blog Factory
  *
- * @template TObject of \Mantle\Database\Model\Site
+ * @template TModel of \Mantle\Database\Model\Site
+ * @template TObject of \WP_Site
+ * @template TReturnValue
+ *
+ * @extends Factory<TModel, TObject, TReturnValue>
  */
 class Blog_Factory extends Factory {
 	/**
 	 * Model to use when creating objects.
 	 *
-	 * @var class-string
+	 * @var class-string<TModel>
 	 */
 	protected string $model = Site::class;
 

--- a/src/mantle/database/factory/class-comment-factory.php
+++ b/src/mantle/database/factory/class-comment-factory.php
@@ -14,7 +14,11 @@ use function Mantle\Support\Helpers\get_comment_object;
 /**
  * Term Factory
  *
- * @template TObject of \Mantle\Database\Model\Comment
+ * @template TModel of \Mantle\Database\Model\Comment
+ * @template TObject of \WP_Comment
+ * @template TReturnValue
+ *
+ * @extends Factory<TModel, TObject, TReturnValue>
  */
 class Comment_Factory extends Factory {
 	/**

--- a/src/mantle/database/factory/class-factory-container.php
+++ b/src/mantle/database/factory/class-factory-container.php
@@ -21,72 +21,72 @@ class Factory_Container {
 	/**
 	 * Attachment Factory
 	 *
-	 * @var Attachment_Factory<\WP_Post|\Mantle\Database\Model\Attachment>
+	 * @var Attachment_Factory<\Mantle\Database\Model\Attachment, \WP_Post, \WP_Post>
 	 */
-	public $attachment;
+	public Attachment_Factory $attachment;
 
 	/**
 	 * Blog Factory
 	 *
-	 * @var Blog_Factory<\WP_Site|\Mantle\Database\Model\Site>
+	 * @var Blog_Factory<\Mantle\Database\Model\Site, \WP_Site, \WP_Site>
 	 */
-	public $blog;
+	public Blog_Factory $blog;
 
 	/**
 	 * Category Factory
 	 *
-	 * @var Term_Factory<\WP_Term|\Mantle\Database\Model\Term>
+	 * @var Term_Factory<\Mantle\Database\Model\Term, \WP_Term, \WP_Term>
 	 */
-	public $category;
+	public Term_Factory $category;
 
 	/**
 	 * Comment Factory
 	 *
-	 * @var Comment_Factory<\WP_Comment>
+	 * @var Comment_Factory<\Mantle\Database\Model\Comment, \WP_Comment, \WP_Comment>
 	 */
-	public $comment;
+	public Comment_Factory $comment;
 
 	/**
 	 * Network Factory
 	 *
-	 * @var Network_Factory<\WP_Network>
+	 * @var Network_Factory<null, \WP_Network>
 	 */
-	public $network;
+	public Network_Factory $network;
 
 	/**
 	 * Page Factory
 	 *
-	 * @var Post_Factory<\WP_Post|\Mantle\Database\Model\Post>
+	 * @var Post_Factory<\Mantle\Database\Model\Post, \WP_Post, \WP_Post>
 	 */
 	public $page;
 
 	/**
 	 * Post Factory
 	 *
-	 * @var Post_Factory<\WP_Post|\Mantle\Database\Model\Post>
+	 * @var Post_Factory<\Mantle\Database\Model\Post, \WP_Post, \WP_Post>
 	 */
-	public $post;
+	public Post_Factory $post;
 
 	/**
 	 * Tag Factory
 	 *
-	 * @var Term_Factory<\WP_Term|\Mantle\Database\Model\Term>
+	 * @var Term_Factory<\Mantle\Database\Model\Term, \WP_Term, \WP_Term>
 	 */
-	public $tag;
+	public Term_Factory $tag;
 
 	/**
 	 * Term Factory (alias for Tag Factory).
 	 *
-	 * @var Term_Factory<\WP_Term|\Mantle\Database\Model\Term>
+	 * @var Term_Factory<\Mantle\Database\Model\Term, \WP_Term, \WP_Term>
 	 */
-	public $term;
+	public Term_Factory $term;
 
 	/**
 	 * User Factory
 	 *
-	 * @var User_Factory<\WP_User|\Mantle\Database\Model\User>
+	 * @var User_Factory<\Mantle\Database\Model\User, \WP_User, \WP_User>
 	 */
-	public $user;
+	public User_Factory $user;
 
 	/**
 	 * Constructor.

--- a/src/mantle/database/factory/class-factory-container.php
+++ b/src/mantle/database/factory/class-factory-container.php
@@ -7,7 +7,9 @@
 
 namespace Mantle\Database\Factory;
 
+use Faker\Generator;
 use Mantle\Contracts\Container;
+use Mantle\Faker\Faker_Provider;
 
 /**
  * Collect all the Database Factories for IDE Support
@@ -94,6 +96,8 @@ class Factory_Container {
 	 * @param Container $container Container instance.
 	 */
 	public function __construct( Container $container ) {
+		$this->setup_faker( $container );
+
 		$this->attachment = $container->make( Attachment_Factory::class );
 		$this->category   = $container->make( Term_Factory::class, [ 'taxonomy' => 'category' ] );
 		$this->comment    = $container->make( Comment_Factory::class );
@@ -107,5 +111,28 @@ class Factory_Container {
 			$this->blog    = $container->make( Blog_Factory::class );
 			$this->network = $container->make( Network_Factory::class );
 		}
+	}
+
+	/**
+	 * Set up the Faker instance in the container.
+	 *
+	 * Primarily used when faker/factory is called from a data provider and the
+	 * application hasn't been setup yet.
+	 *
+	 * @param Container $container Container instance.
+	 */
+	protected function setup_faker( Container $container ): void {
+		$container->singleton_if(
+			Generator::class,
+			function () {
+				$generator = \Faker\Factory::create();
+
+				$generator->unique();
+
+				$generator->addProvider( new Faker_Provider( $generator ) );
+
+				return $generator;
+			},
+		);
 	}
 }

--- a/src/mantle/database/factory/class-factory.php
+++ b/src/mantle/database/factory/class-factory.php
@@ -24,9 +24,11 @@ use function Mantle\Support\Helpers\tap;
 /**
  * Base Factory
  *
- * @template TObject of \Mantle\Database\Model\Model
+ * @template TModel of \Mantle\Database\Model\Model
+ * @template TObject
+ * @template TReturnValue
  *
- * @method \Mantle\Database\Factory\Fluent_Factory<TObject> count(int $count)
+ * @method \Mantle\Database\Factory\Fluent_Factory<TModel, TObject, TReturnValue> count(int $count)
  */
 abstract class Factory {
 	use Concerns\Resolves_Factories,
@@ -74,7 +76,7 @@ abstract class Factory {
 	 * Retrieves an object by ID.
 	 *
 	 * @param int $object_id The object ID.
-	 * @return mixed
+	 * @return TModel|TObject|null
 	 */
 	abstract public function get_object_by_id( int $object_id );
 
@@ -91,7 +93,7 @@ abstract class Factory {
 	/**
 	 * Generate models from the factory.
 	 *
-	 * @return static
+	 * @return static<TModel, TObject, TModel>
 	 */
 	public function as_models() {
 		return tap(
@@ -103,7 +105,7 @@ abstract class Factory {
 	/**
 	 * Generate core WordPress objects from the factory.
 	 *
-	 * @return static
+	 * @return static<TModel, TObject, TObject>
 	 */
 	public function as_objects() {
 		return tap(
@@ -145,8 +147,10 @@ abstract class Factory {
 	 *
 	 * @throws \InvalidArgumentException If the model does not extend from the base model class.
 	 *
-	 * @param class-string<TObject> $model The model to use.
-	 * @return static
+	 * @template TNewModel of \Mantle\Database\Model\Model
+	 *
+	 * @param class-string<TNewModel> $model The model to use.
+	 * @return static<TNewModel, TObject, TReturnValue>
 	 */
 	public function with_model( string $model ) {
 		// Validate that model extends from the base model class.
@@ -210,7 +214,7 @@ abstract class Factory {
 	 * Creates an object and returns its object.
 	 *
 	 * @param array $args Optional. The arguments for the object to create. Default is empty array.
-	 * @return TObject The created object.
+	 * @return TReturnValue The created object.
 	 */
 	public function create_and_get( array $args = [] ) {
 		return $this->get_object_by_id( $this->create( $args ) );

--- a/src/mantle/database/factory/class-fluent-factory.php
+++ b/src/mantle/database/factory/class-fluent-factory.php
@@ -18,7 +18,11 @@ use function Mantle\Support\Helpers\collect;
  * Extends upon the factory that is included with Mantle (one that is designed
  * to mirror WordPress) and builds upon it to provide a fluent interface.
  *
- * @template TObject of \Mantle\Database\Model\Model
+ * @template TModel of \Mantle\Database\Model\Model
+ * @template TObject
+ * @template TReturnValue
+ *
+ * @extends Factory<TModel, TObject, TReturnValue>
  */
 class Fluent_Factory extends Factory {
 	/**
@@ -57,7 +61,7 @@ class Fluent_Factory extends Factory {
 	 * Create one or multiple objects and return the IDs.
 	 *
 	 * @param array $args Arguments to pass to the factory.
-	 * @return \Mantle\Support\Collection<int, mixed>|mixed
+	 * @return \Mantle\Support\Collection<int, TReturnValue>|mixed
 	 */
 	public function create( array $args = [] ): mixed {
 		if ( 1 === $this->count ) {
@@ -71,7 +75,7 @@ class Fluent_Factory extends Factory {
 	 * Create one or multiple objects and return the objects.
 	 *
 	 * @param array $args Arguments to pass to the factory.
-	 * @return \Mantle\Support\Collection<int, TObject>|TObject
+	 * @return \Mantle\Support\Collection<int, TReturnValue>|TReturnValue
 	 */
 	public function create_and_get( array $args = [] ): mixed {
 		if ( 1 === $this->count ) {
@@ -98,7 +102,7 @@ class Fluent_Factory extends Factory {
 	 * Retrieves an object by ID.
 	 *
 	 * @param mixed $object_id The object ID.
-	 * @return TObject
+	 * @return TReturnValue
 	 */
 	public function get_object_by_id( mixed $object_id ): mixed {
 		return $this->factory->get_object_by_id( $object_id );

--- a/src/mantle/database/factory/class-network-factory.php
+++ b/src/mantle/database/factory/class-network-factory.php
@@ -7,12 +7,14 @@
 
 namespace Mantle\Database\Factory;
 
-use Faker\Generator;
-
 /**
  * Network Factory
  *
- * @template TObject
+ * @template TModel
+ * @template TObject of \WP_Network
+ * @template TReturnValue
+ *
+ * @extends Factory<TModel, TObject, TReturnValue>
  */
 class Network_Factory extends Factory {
 	/**

--- a/src/mantle/database/factory/class-post-factory.php
+++ b/src/mantle/database/factory/class-post-factory.php
@@ -19,7 +19,11 @@ use function Mantle\Support\Helpers\get_post_object;
 /**
  * Post Factory
  *
- * @template TObject of \Mantle\Database\Model\Post
+ * @template TModel of \Mantle\Database\Model\Post
+ * @template TObject
+ * @template TReturnValue
+ *
+ * @extends Factory<TModel, TObject, TReturnValue>
  */
 class Post_Factory extends Factory {
 	use Concerns\With_Meta;
@@ -27,7 +31,7 @@ class Post_Factory extends Factory {
 	/**
 	 * Model to use when creating objects.
 	 *
-	 * @var class-string
+	 * @var class-string<TModel>
 	 */
 	protected string $model = Post::class;
 
@@ -44,7 +48,7 @@ class Post_Factory extends Factory {
 	/**
 	 * Create a new factory instance to create posts with a set of terms.
 	 *
-	 * @param array<int, \WP_Term|int|string>|\WP_Term|int|string ...$terms Terms to assign to the post.
+	 * @param array<int|string, \WP_Term|int|string|array<string, mixed>>|\WP_Term|int|string ...$terms Terms to assign to the post.
 	 * @return static
 	 */
 	public function with_terms( ...$terms ): static {
@@ -172,6 +176,7 @@ class Post_Factory extends Factory {
 	 *
 	 * @param int $object_id The object ID.
 	 * @return Post|WP_Post|null
+	 * @phpstan-return TModel|TObject|null
 	 */
 	public function get_object_by_id( int $object_id ) {
 		return $this->as_models

--- a/src/mantle/database/factory/class-term-factory.php
+++ b/src/mantle/database/factory/class-term-factory.php
@@ -16,7 +16,11 @@ use function Mantle\Support\Helpers\get_term_object;
 /**
  * Term Factory
  *
- * @template TObject of \Mantle\Database\Model\Term
+ * @template TModel of \Mantle\Database\Model\Term
+ * @template TObject of \WP_Term
+ * @template TReturnValue
+ *
+ * @extends Factory<TModel, TObject, TReturnValue>
  */
 class Term_Factory extends Factory {
 	use Concerns\With_Meta;
@@ -24,7 +28,7 @@ class Term_Factory extends Factory {
 	/**
 	 * Model to use when creating objects.
 	 *
-	 * @var class-string
+	 * @var class-string<TModel>
 	 */
 	protected string $model = Term::class;
 

--- a/src/mantle/database/factory/class-user-factory.php
+++ b/src/mantle/database/factory/class-user-factory.php
@@ -14,7 +14,11 @@ use function Mantle\Support\Helpers\get_user_object;
 /**
  * User Factory
  *
- * @template TObject of \Mantle\Database\Model\User
+ * @template TModel of \Mantle\Database\Model\User
+ * @template TObject of \WP_User
+ * @template TReturnValue
+ *
+ * @extends Factory<TModel, TObject, TReturnValue>
  */
 class User_Factory extends Factory {
 	use Concerns\With_Meta;
@@ -22,7 +26,7 @@ class User_Factory extends Factory {
 	/**
 	 * Model to use when creating objects.
 	 *
-	 * @var class-string
+	 * @var class-string<TModel>
 	 */
 	protected string $model = User::class;
 

--- a/src/mantle/database/model/class-attachment.php
+++ b/src/mantle/database/model/class-attachment.php
@@ -7,11 +7,12 @@
 
 namespace Mantle\Database\Model;
 
-use Mantle\Contracts;
 use Mantle\Facade\Storage;
 
 /**
  * Attachment Model
+ *
+ * @method static \Mantle\Database\Factory\Post_Factory<static, \WP_Post, static> factory( array|callable|null $state = null )
  */
 class Attachment extends Post {
 	/**

--- a/src/mantle/database/model/class-comment.php
+++ b/src/mantle/database/model/class-comment.php
@@ -12,6 +12,8 @@ use Mantle\Support\Helpers;
 
 /**
  * Comment Model
+ *
+ * @method static \Mantle\Database\Factory\Post_Factory<static, \WP_Comment, static> factory( array|callable|null $state = null )
  */
 class Comment extends Model implements Contracts\Database\Core_Object, Contracts\Database\Model_Meta, Contracts\Database\Updatable {
 	use Meta\Model_Meta,

--- a/src/mantle/database/model/class-model.php
+++ b/src/mantle/database/model/class-model.php
@@ -25,6 +25,8 @@ use function Mantle\Support\Helpers\tap;
 /**
  * Database Model
  *
+ * @template TModelObject of object
+ *
  * @method static \Mantle\Support\Collection all()
  * @method static static first()
  * @method static static first_or_fail()
@@ -41,6 +43,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
 		Concerns\Has_Aliases,
 		Concerns\Has_Attributes,
 		Concerns\Has_Events,
+		/** @use Concerns\Has_Factory<TModelObject> */
 		Concerns\Has_Factory,
 		Concerns\Has_Global_Scopes,
 		Concerns\Has_Relationships;

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -17,6 +17,8 @@ use Mantle\Support\Helpers;
 /**
  * Post Model
  *
+ * @extends Model<\WP_Post>
+ *
  * @property int $comment_count
  * @property int $ID
  * @property int $menu_order
@@ -49,6 +51,7 @@ use Mantle\Support\Helpers;
  * @property string $status Alias to post_status.
  * @property string $title Alias to post_title.
  *
+ * @method static \Mantle\Database\Factory\Post_Factory<static, \WP_Post, static> factory( array|callable|null $state = null )
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> anyStatus()
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> where( string|array $attribute, mixed $value )
  * @method static \Mantle\Database\Query\Post_Query_Builder<static> whereId( int $id )

--- a/src/mantle/database/model/class-site.php
+++ b/src/mantle/database/model/class-site.php
@@ -12,6 +12,8 @@ use Mantle\Support\Helpers;
 
 /**
  * Site Model
+ *
+ * @method static \Mantle\Database\Factory\Post_Factory<static, \WP_Site, static> factory( array|callable|null $state = null )
  */
 class Site extends Model implements Contracts\Database\Core_Object, Contracts\Database\Updatable {
 	/**

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -22,6 +22,7 @@ use Mantle\Support\Helpers;
  * @property string $slug
  * @property string $taxonomy
  *
+ * @method static \Mantle\Database\Factory\Term_Factory<static, \WP_Term, static> factory( array|callable|null $state = null )
  * @method static \Mantle\Database\Query\Term_Query_Builder<static> whereId( int $id )
  * @method static \Mantle\Database\Query\Term_Query_Builder<static> whereName(string $name)
  * @method static \Mantle\Database\Query\Term_Query_Builder<static> whereSlug(string $slug)

--- a/src/mantle/database/model/class-user.php
+++ b/src/mantle/database/model/class-user.php
@@ -12,6 +12,8 @@ use Mantle\Support\Helpers;
 
 /**
  * User Model
+ *
+ * @method static \Mantle\Database\Factory\User_Factory<static, \WP_User, static> factory( array|callable|null $state = null )
  */
 class User extends Model implements Contracts\Database\Core_Object, Contracts\Database\Model_Meta, Contracts\Database\Updatable {
 	use Meta\Model_Meta,

--- a/src/mantle/database/model/concerns/trait-has-factory.php
+++ b/src/mantle/database/model/concerns/trait-has-factory.php
@@ -12,14 +12,16 @@ use Mantle\Database\Factory\Post_Factory;
 use Mantle\Database\Factory\Term_Factory;
 
 /**
- * Model Database Factory
+ * Trait to add a factory to a model.
+ *
+ * @template TObject
  */
 trait Has_Factory {
 	/**
 	 * Create a builder for the model.
 	 *
 	 * @param array|callable $state Default state array or callable that will be invoked to set state.
-	 * @return \Mantle\Database\Factory\Factory<static>
+	 * @return \Mantle\Database\Factory\Factory<static, TObject, static>
 	 */
 	public static function factory( array|callable|null $state = null ): Factory {
 		$factory = static::new_factory() ?: Factory::factory_for_model( static::class );
@@ -43,7 +45,7 @@ trait Has_Factory {
 	 *
 	 * Optional: allows for the model factory to be overridden by application code.
 	 *
-	 * @return \Mantle\Database\Factory\Factory<static>|null
+	 * @return \Mantle\Database\Factory\Factory<static, TObject, static>|null
 	 */
 	protected static function new_factory(): ?Factory {
 		return null;

--- a/src/mantle/faker/class-faker-provider.php
+++ b/src/mantle/faker/class-faker-provider.php
@@ -51,22 +51,7 @@ class Faker_Provider extends Base {
 	 * @param array  $attributes Attributes for the block.
 	 * @return string
 	 */
-	public static function block( string $block_name, string $content = '', array $attributes = [] ) {
-		$attributes = ! empty( $attributes ) ? \wp_json_encode( $attributes ) . ' ' : '';
-
-		if ( empty( $content ) ) {
-			return sprintf(
-				'<!-- wp:%s %s/-->',
-				$block_name,
-				$attributes
-			);
-		}
-
-		return sprintf(
-			'<!-- wp:%1$s %2$s-->%3$s<!-- /wp:%1$s -->',
-			$block_name,
-			$attributes,
-			PHP_EOL . $content . PHP_EOL
-		);
+	public static function block( string $block_name, string $content = '', array $attributes = [] ): string {
+		return get_comment_delimited_block_content( $block_name, $attributes, $content );
 	}
 }

--- a/src/mantle/faker/class-faker-provider.php
+++ b/src/mantle/faker/class-faker-provider.php
@@ -52,6 +52,11 @@ class Faker_Provider extends Base {
 	 * @return string
 	 */
 	public static function block( string $block_name, string $content = '', array $attributes = [] ): string {
+		// Add a newline before and after the content.
+		if ( ! empty( $content ) ) {
+			$content = "\n{$content}\n";
+		}
+
 		return get_comment_delimited_block_content( $block_name, $attributes, $content );
 	}
 }

--- a/src/mantle/faker/class-faker-provider.php
+++ b/src/mantle/faker/class-faker-provider.php
@@ -15,6 +15,32 @@ use Faker\Provider\Lorem;
  */
 class Faker_Provider extends Base {
 	/**
+	 * Compile a set of blocks.
+	 *
+	 * @param array $blocks Blocks to compile.
+	 * @return string
+	 */
+	public static function blocks( array $blocks ): string {
+		return implode( "\n\n", $blocks );
+	}
+
+	/**
+	 * Build a heading block.
+	 *
+	 * @param int $level Heading level.
+	 * @return string
+	 */
+	public static function heading_block( int $level = 2 ): string {
+		return static::block(
+			'heading',
+			sprintf( '<h%d>%s</h%d>', $level, Lorem::sentence(), $level ),
+			[
+				'level' => $level,
+			],
+		);
+	}
+
+	/**
 	 * Build a paragraph block.
 	 *
 	 * @param int $sentences Number of sentences in the block.

--- a/src/mantle/testing/concerns/trait-assertions.php
+++ b/src/mantle/testing/concerns/trait-assertions.php
@@ -19,7 +19,8 @@ use function Mantle\Support\Helpers\get_term_object;
  * Assorted Test_Cast assertions.
  */
 trait Assertions {
-	use Asset_Assertions;
+	use Asset_Assertions,
+		Block_Assertions;
 
 	/**
 	 * Asserts that the given value is an instance of WP_Error.

--- a/src/mantle/testing/concerns/trait-block-assertions.php
+++ b/src/mantle/testing/concerns/trait-block-assertions.php
@@ -2,6 +2,8 @@
 /**
  * Block_Assertions trait file
  *
+ * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
+ *
  * @package Mantle
  */
 
@@ -69,7 +71,9 @@ trait Block_Assertions {
 					'name'  => $block_name,
 				],
 			),
-			"Failed asserting that string has block [{$block_name}]."
+			! empty( $attrs )
+				? "Failed asserting that string has block [{$block_name}] with attributes " . print_r( $attrs, true )
+				: "Failed asserting that string has block [{$block_name}]."
 		);
 	}
 
@@ -89,8 +93,9 @@ trait Block_Assertions {
 					'name'  => $block_name,
 				],
 			),
-			!
-			"Failed asserting that string does not have block [{$block_name}]."
+			! empty( $attrs )
+				? "Failed asserting that string does not have block [{$block_name}] with attributes " . print_r( $attrs, true )
+				: "Failed asserting that string does not have block [{$block_name}]",
 		);
 	}
 

--- a/src/mantle/testing/concerns/trait-block-assertions.php
+++ b/src/mantle/testing/concerns/trait-block-assertions.php
@@ -1,0 +1,147 @@
+<?php //phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+/**
+ * Block_Assertions trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Concerns;
+
+use Mantle\Database\Model\Post;
+use WP_Post;
+
+use function Alley\WP\match_blocks;
+use function Mantle\Support\Helpers\collect;
+
+/**
+ * Assorted Block assertions
+ *
+ * @mixin \PHPUnit\Framework\TestCase
+ */
+trait Block_Assertions {
+	/**
+	 * Assert that a string can match a block.
+	 *
+	 * The arguments are passed directly to `match_block()`.
+	 *
+	 * @see \Alley\WP\match_block()
+	 *
+	 * @param string $string The string to check.
+	 * @param array $args The arguments to pass to `match_block()`.
+	 */
+	public function assertStringMatchesBlock( string $string, array $args ): void {
+		$this->assertNotEmpty(
+			match_blocks( $string, $args ),
+			'Failed asserting that string matches block with arguments ' . print_r( $args, true ),
+		);
+	}
+
+	/**
+	 * Assert that a string does not match a block.
+	 *
+	 * The arguments are passed directly to `match_block()`.
+	 *
+	 * @see \Alley\WP\match_block()
+	 *
+	 * @param string $string The string to check.
+	 * @param array $args The arguments to pass to `match_block()`.
+	 */
+	public function assertStringNotMatchesBlock( string $string, array $args ): void {
+		$this->assertEmpty(
+			match_blocks( $string, $args ),
+			'Failed asserting that string does not match block with arguments ' . print_r( $args, true ),
+		);
+	}
+
+	/**
+	 * Assert that a string has a block.
+	 *
+	 * @param string          $string The string to check.
+	 * @param string|string[] $block_name The block name(s) to check for. Will attempt to match any of the names.
+	 * @param array           $attrs Optional. Attributes to check for.
+	 */
+	public function assertStringHasBlock( string $string, string|array $block_name, array $attrs = [] ): void {
+		$this->assertNotEmpty(
+			match_blocks(
+				$string,
+				[
+					'attrs' => $this->convert_arguments_for_matching( $attrs ),
+					'name'  => $block_name,
+				],
+			),
+			"Failed asserting that string has block [{$block_name}]."
+		);
+	}
+
+	/**
+	 * Assert that a string does not have a block.
+	 *
+	 * @param string          $string The string to check.
+	 * @param string|string[] $block_name The block name(s) to check for. Will attempt to match any of the names.
+	 * @param array           $attrs Optional. Attributes to check for.
+	 */
+	public function assertStringNotHasBlock( string $string, string|array $block_name, array $attrs = [] ): void {
+		$this->assertEmpty(
+			match_blocks(
+				$string,
+				[
+					'attrs' => $this->convert_arguments_for_matching( $attrs ),
+					'name'  => $block_name,
+				],
+			),
+			!
+			"Failed asserting that string does not have block [{$block_name}]."
+		);
+	}
+
+	/**
+	 * Assert that a post has a block in its content.
+	 *
+	 * @param Post|WP_Post    $post The post to check.
+	 * @param string|string[] $block_name The block name(s) to check for. Will attempt to match any of the names.
+	 * @param array           $attrs Optional. Attributes to check for.
+	 */
+	public function assertPostHasBlock( Post|WP_Post $post, string|array $block_name, array $attrs = [] ): void {
+		$this->assertStringHasBlock( $post->post_content, $block_name, $attrs );
+	}
+
+	/**
+	 * Assert that a post does not have a block in its content.
+	 *
+	 * @param Post|WP_Post    $post The post to check.
+	 * @param string|string[] $block_name The block name(s) to check for. Will attempt to match any of the names.
+	 * @param array           $attrs Optional. Attributes to check for.
+	 */
+	public function assertPostNotHasBlock( Post|WP_Post $post, string|array $block_name, array $attrs = [] ): void {
+		$this->assertStringNotHasBlock( $post->post_content, $block_name, $attrs );
+	}
+
+	/**
+	 * Convert the key/value arguments to an array that can be passed to
+	 * `match_block()`.
+	 *
+	 * @param array $args The arguments to convert.
+	 * @return array
+	 */
+	protected function convert_arguments_for_matching( array $args ): array {
+		return collect( $args )
+			->reduce(
+				function ( array $carry, $value, $key ) {
+					// Allow for passing an argument pair directly.
+					if ( is_array( $value ) && isset( $value['key'], $value['value'] )  ) {
+						$carry[] = $value;
+
+						return $carry;
+					}
+
+					$carry[] = [
+						$key   => $value,
+						'value' => $value,
+					];
+
+					return $carry;
+				},
+				[]
+			);
+	}
+}

--- a/src/mantle/testing/concerns/trait-block-assertions.php
+++ b/src/mantle/testing/concerns/trait-block-assertions.php
@@ -1,8 +1,8 @@
-<?php //phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+<?php
 /**
  * Block_Assertions trait file
  *
- * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
+ * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r, WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
  *
  * @package Mantle
  */
@@ -29,7 +29,7 @@ trait Block_Assertions {
 	 * @see \Alley\WP\match_block()
 	 *
 	 * @param string $string The string to check.
-	 * @param array $args The arguments to pass to `match_block()`.
+	 * @param array  $args The arguments to pass to `match_block()`.
 	 */
 	public function assertStringMatchesBlock( string $string, array $args ): void {
 		$this->assertNotEmpty(
@@ -46,7 +46,7 @@ trait Block_Assertions {
 	 * @see \Alley\WP\match_block()
 	 *
 	 * @param string $string The string to check.
-	 * @param array $args The arguments to pass to `match_block()`.
+	 * @param array  $args The arguments to pass to `match_block()`.
 	 */
 	public function assertStringNotMatchesBlock( string $string, array $args ): void {
 		$this->assertEmpty(
@@ -129,24 +129,28 @@ trait Block_Assertions {
 	 * @return array
 	 */
 	protected function convert_arguments_for_matching( array $args ): array {
-		return collect( $args )
-			->reduce(
-				function ( array $carry, $value, $key ) {
-					// Allow for passing an argument pair directly.
-					if ( is_array( $value ) && isset( $value['key'], $value['value'] )  ) {
-						$carry[] = $value;
+		// PHPCS is crashing on these lines for some reason. Disabling it for now
+		// until we've upgrading to WPCS 3.0.
 
-						return $carry;
-					}
-
-					$carry[] = [
-						$key   => $value,
-						'value' => $value,
-					];
+		/* phpcs:disable */
+		return collect( $args )->reduce(
+			function ( array $carry, $value, $key ) {
+				// Allow for passing an argument pair directly.
+				if ( is_array( $value ) && isset( $value['key'], $value['value'] )  ) {
+					$carry[] = $value;
 
 					return $carry;
-				},
-				[]
-			);
+				}
+
+				$carry[] = [
+					$key    => $value,
+					'value' => $value,
+				];
+
+				return $carry;
+			},
+			[]
+		);
+		/* phpcs:enable */
 	}
 }

--- a/src/mantle/testing/concerns/trait-with-faker.php
+++ b/src/mantle/testing/concerns/trait-with-faker.php
@@ -9,6 +9,7 @@ namespace Mantle\Testing\Concerns;
 
 use Faker\Generator;
 use Faker\Factory;
+use Mantle\Faker\Faker_Provider;
 
 /**
  * This trait sets up a faker instance for use in tests.
@@ -44,6 +45,10 @@ trait With_Faker {
 			return $this->app->make( Generator::class, [ 'locale' => $locale ] );
 		}
 
-		return Factory::create( $locale );
+		$generator = Factory::create( $locale );
+
+		$generator->addProvider( new Faker_Provider( $generator ) );
+
+		return $generator;
 	}
 }

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -11,6 +11,8 @@ use Mantle\Testing\WP_Die;
 
 use function Mantle\Testing\tests_add_filter;
 
+defined( 'MANTLE_IS_TESTING' ) || define( 'MANTLE_IS_TESTING', true );
+
 require_once __DIR__ . '/class-utils.php';
 require_once __DIR__ . '/class-wp-die.php';
 

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -176,6 +176,12 @@ tests_add_filter( 'wp_die_handler', [ WP_Die::class, 'get_toggled_handler' ] );
 // Use the Spy REST Server instead of default.
 tests_add_filter( 'wp_rest_server_class', [ Utils::class, 'wp_rest_server_class_filter' ], PHP_INT_MAX );
 
+// Prevent updating translations asynchronously.
+tests_add_filter( 'async_update_translation', '__return_false' );
+
+// Disable background updates.
+tests_add_filter( 'automatic_updater_disabled', '__return_true' );
+
 // Load WordPress.
 require_once ABSPATH . '/wp-settings.php';
 

--- a/tests/database/factory/test-factory.php
+++ b/tests/database/factory/test-factory.php
@@ -6,11 +6,13 @@ use Mantle\Database\Factory;
 use Mantle\Database\Model;
 use Mantle\Testing\Framework_Test_Case;
 
+/**
+ * @group factory
+ */
 class Test_Factory extends Framework_Test_Case {
 	public function test_create_basic_model() {
 		$factory = Testable_Post::factory();
 
-		$this->assertInstanceOf( Factory\Factory::class, $factory );
 		$this->assertInstanceOf( Factory\Post_Factory::class, $factory );
 
 		$post = $factory->create_and_get();
@@ -154,7 +156,7 @@ class Testable_Post extends Model\Post {
 }
 
 /**
- * @method static Testable_Post_Factory factory()
+ * @method static Testable_Post_Factory<static, \WP_Post, static> factory()
  */
 class Testable_Post_With_Factory extends Model\Post {
 	public static $object_name = 'post';

--- a/tests/database/factory/test-unit-testing-factory.php
+++ b/tests/database/factory/test-unit-testing-factory.php
@@ -272,6 +272,23 @@ class Test_Unit_Testing_Factory extends Framework_Test_Case {
 
 		$this->assertCount( 10, $object_ids );
 	}
+
+	/**
+	 * @dataProvider dataprovider_factory
+	 */
+	public function test_dataprovider_factory( $post ) {
+		$this->assertInstanceOf( \WP_Post::class, $post );
+		$this->assertStringContainsString(
+			'<!-- wp:paragraph',
+			$post->post_content,
+		);
+	}
+
+	public static function dataprovider_factory(): array {
+		return [
+			'example' => [ static::factory()->post->create_and_get() ],
+		];
+	}
 }
 
 class Testable_Post_Tag extends Term {

--- a/tests/database/factory/test-unit-testing-factory.php
+++ b/tests/database/factory/test-unit-testing-factory.php
@@ -14,6 +14,8 @@ use function Mantle\Support\Helpers\collect;
  * Test case with the focus of testing the unit testing factory that mirrors
  * WordPress core's factories. The factories here should be drop-in replacements
  * for core's factories with some sugar on top.
+ *
+ * @group factory
  */
 class Test_Unit_Testing_Factory extends Framework_Test_Case {
 	use With_Faker;
@@ -21,7 +23,7 @@ class Test_Unit_Testing_Factory extends Framework_Test_Case {
 	public function test_post_factory() {
 		$this->assertInstanceOf( \WP_Post::class, static::factory()->post->create_and_get() );
 
-		$posts = static::factory()->post->create_many(
+		$post_ids = static::factory()->post->create_many(
 			10,
 			[
 				'post_type'   => 'post',
@@ -29,12 +31,12 @@ class Test_Unit_Testing_Factory extends Framework_Test_Case {
 			]
 		);
 
-		$this->assertCount( 10, $posts );
-		foreach ( $posts as $post_id ) {
+		$this->assertCount( 10, $post_ids );
+		foreach ( $post_ids as $post_id ) {
 			$this->assertIsInt( $post_id );
 		}
 
-		$this->assertEquals( 'draft', get_post_status( array_shift( $posts ) ) );
+		$this->assertEquals( 'draft', get_post_status( array_shift( $post_ids ) ) );
 	}
 
 	public function test_post_create_with_thumbnail() {
@@ -93,6 +95,7 @@ class Test_Unit_Testing_Factory extends Framework_Test_Case {
 		$this->shim_test( \WP_Post::class, 'attachment' );
 
 		$attachment = static::factory()->attachment->create_and_get();
+
 		$this->assertEquals( 'attachment', get_post_type( $attachment ) );
 	}
 
@@ -104,7 +107,6 @@ class Test_Unit_Testing_Factory extends Framework_Test_Case {
 	public function test_blog_factory() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'This test requires multisite.' );
-			return;
 		}
 
 		$this->shim_test( \WP_Site::class, 'blog' );
@@ -113,7 +115,6 @@ class Test_Unit_Testing_Factory extends Framework_Test_Case {
 	public function test_network_factory() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'This test requires multisite.' );
-			return;
 		}
 
 		$this->shim_test( \WP_Network::class, 'network' );
@@ -148,7 +149,7 @@ class Test_Unit_Testing_Factory extends Framework_Test_Case {
 
 	public function test_as_models() {
 		$post = static::factory()->post->as_models()->create_and_get();
-		$term = static::factory()->term->as_models()->with_model( Testable_Post_Tag::class )->create_and_get();
+		$term = static::factory()->term->with_model( Testable_Post_Tag::class )->as_models()->create_and_get();
 
 		$this->assertInstanceOf( Post::class, $post );
 		$this->assertInstanceOf( Testable_Post_Tag::class, $term );

--- a/tests/testing/concerns/test-block-assertions.php
+++ b/tests/testing/concerns/test-block-assertions.php
@@ -1,0 +1,43 @@
+<?php
+namespace Mantle\Tests\Testing\Concerns;
+
+use Mantle\Testing\Concerns\With_Faker;
+use Mantle\Testing\Framework_Test_Case;
+use WP_Post;
+
+/**
+ * @group testing
+ */
+class Test_Block_Assertions extends Framework_Test_Case {
+	use With_Faker;
+
+	protected WP_Post $post;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->post = static::factory()->post->create_and_get( [
+			'post_content' => $this->faker->blocks( [
+				$this->faker->paragraph_block,
+				$this->faker->heading_block( 3 ),
+				$this->faker->paragraph_block,
+				$this->faker->heading_block( 4 ),
+				$this->faker->paragraph_block,
+			] ),
+		] );
+	}
+
+	public function test_string_has_content() {
+		$this->assertStringHasBlock( $this->post->post_content, 'core/paragraph' );
+		$this->assertStringHasBlock( $this->post->post_content, 'core/heading' );
+		$this->assertStringHasBlock( $this->post->post_content, 'core/heading', [ 'level' => 3 ] );
+		$this->assertStringNotHasBlock( $this->post->post_content, 'core/heading', [ 'level' => 5 ] );
+	}
+
+	public function test_post_has_content() {
+		$this->assertPostHasBlock( $this->post, 'core/paragraph' );
+		$this->assertPostHasBlock( $this->post, 'core/heading' );
+		$this->assertPostHasBlock( $this->post, 'core/heading', [ 'level' => 3 ] );
+		$this->assertPostNotHasBlock( $this->post, 'core/heading', [ 'level' => 5 ] );
+	}
+}


### PR DESCRIPTION
- Adds the following assertions to the framework test case via the https://github.com/alleyinteractive/wp-match-blocks/ package.
  - `assertStringMatchesBlock()`
  - `assertStringNotMatchesBlock()`
  - `assertStringHasBlock()`
  - `assertStringNotHasBlock()`
  - `assertPostHasBlock()`
  - `assertPostNotHasBlock()`

Hat tip to @dlh01 for the package.