### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,7 @@ No changes, just a re-release to fix a bad tag.
 
 ## v0.11.2 - 2023-07-21
 
-- Add back-support for Wordpress 6.0 when testing.
+- Add back-support for WordPress 6.0 when testing.
 
 ## v0.11.1 - 2023-05-31
 
@@ -222,7 +222,7 @@ No changes, just a re-release to fix a bad tag.
 - Cast the item to an array inside of only_children.
 - Adding keywords to trigger --dev.
 - Separate requires based on what they include.
-- Compatibility layer for Refresh_Database and Installs_Wordpress.
+- Compatibility layer for Refresh_Database and Installs_WordPress.
 
 ## v0.6.1 - 2022-09-20
 

--- a/src/mantle/container/class-bound-method.php
+++ b/src/mantle/container/class-bound-method.php
@@ -155,7 +155,7 @@ class Bound_Method {
 	 * Get the dependency for the given call parameter.
 	 *
 	 * @param  Container            $container Container instance.
-	 * @param  \ReflectionParameter $parameter Reflect Paramater.
+	 * @param  \ReflectionParameter $parameter Reflect Parameter.
 	 * @param  array                $parameters Parameters to pass.
 	 * @param  array                $dependencies Class dependencies.
 	 * @return void

--- a/src/mantle/contracts/interface-application.php
+++ b/src/mantle/contracts/interface-application.php
@@ -191,7 +191,7 @@ interface Application extends Container {
 	public function terminating( callable $callback ): static;
 
 	/**
-	 * Termine the application.
+	 * Terminate the application.
 	 *
 	 * @return void
 	 */

--- a/src/mantle/events/trait-wordpress-action.php
+++ b/src/mantle/events/trait-wordpress-action.php
@@ -157,7 +157,7 @@ trait WordPress_Action {
 			 * to that event will pass the argument down to the callback for the action/filter.
 			 *
 			 * @param mixed               $argument Argument value.
-			 * @param ReflectionParameter $parameter Callback paramater.
+			 * @param ReflectionParameter $parameter Callback parameter.
 			 */
 			$modified_argument = $this->dispatch( 'mantle-typehint-resolve:' . $type->getName(), [ null, $argument, $parameter ] );
 

--- a/src/mantle/framework/console/class-hook-usage-command.php
+++ b/src/mantle/framework/console/class-hook-usage-command.php
@@ -212,7 +212,7 @@ class Hook_Usage_Command extends Command {
 	}
 
 	/**
-	 * Detrmine if the cache should be used.
+	 * Determine if the cache should be used.
 	 *
 	 * @return bool
 	 */

--- a/src/mantle/framework/console/generators/class-block-make-command.php
+++ b/src/mantle/framework/console/generators/class-block-make-command.php
@@ -309,7 +309,7 @@ class Block_Make_Command extends Generator_Command {
 	}
 
 	/**
-	 * Get the base path for the genereated block.
+	 * Get the base path for the generated block.
 	 *
 	 * @param string $name The block name.
 	 * @return string
@@ -328,7 +328,7 @@ class Block_Make_Command extends Generator_Command {
 	}
 
 	/**
-	 * Get the base path for the genereated block.
+	 * Get the base path for the generated block.
 	 *
 	 * @param string $namespace The block namespace.
 	 * @return string

--- a/src/mantle/framework/events/class-discover-events.php
+++ b/src/mantle/framework/events/class-discover-events.php
@@ -128,7 +128,7 @@ class Discover_Events {
 				}
 
 				$listener_events[ $listener->name . '@' . $method->name ] = [
-					Reflector::get_paramater_class_names(
+					Reflector::get_parameter_class_names(
 						$method->getParameters()[0]
 					),
 					$priority,

--- a/src/mantle/support/class-arr.php
+++ b/src/mantle/support/class-arr.php
@@ -126,7 +126,7 @@ class Arr {
 	 * Get all of the given array except for a specified array of keys.
 	 *
 	 * @param  array        $array Array to process.
-	 * @param  array|string $keys Keys toi filter by.
+	 * @param  array|string $keys Keys to filter by.
 	 * @return array
 	 */
 	public static function except( array $array, $keys ): array {

--- a/src/mantle/support/class-driver-manager.php
+++ b/src/mantle/support/class-driver-manager.php
@@ -11,7 +11,7 @@ use Closure;
 use InvalidArgumentException;
 
 /**
- * Driver Manager for managing multiple stores and plugable drivers.
+ * Driver Manager for managing multiple stores and pluggable drivers.
  */
 abstract class Driver_Manager {
 	/**

--- a/src/mantle/support/class-reflector.php
+++ b/src/mantle/support/class-reflector.php
@@ -50,7 +50,7 @@ class Reflector {
 	 * @param  \ReflectionParameter $parameter
 	 * @return array
 	 */
-	public static function get_paramater_class_names( $parameter ) {
+	public static function get_parameter_class_names( $parameter ) {
 		$type = $parameter->getType();
 
 		if ( ! $type instanceof ReflectionUnionType ) {

--- a/src/mantle/testing/concerns/trait-interacts-with-cron.php
+++ b/src/mantle/testing/concerns/trait-interacts-with-cron.php
@@ -38,7 +38,7 @@ trait Interacts_With_Cron {
 	}
 
 	/**
-	 * Assert tha an action is not in a cron queue.
+	 * Assert that an action is not in a cron queue.
 	 *
 	 * @param string $action Action hook of the event.
 	 * @param array  $args Arguments for the cron queue event.

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -136,7 +136,7 @@ trait Rsync_Installation {
 	 * Maybe rsync the codebase to the wp-content within WordPress.
 	 *
 	 * Will attempt to locate the wp-content directory relative to the current
-	 * directory. As a fallback, it will assumme it is being called from either
+	 * directory. As a fallback, it will assume it is being called from either
 	 * /wp-content/plugin/:plugin/tests OR /wp-content/themes/:theme/tests. Will
 	 * rsync the codebase from the wp-content level to the root of the WordPress
 	 * installation. Also will attempt to locate the wp-content directory relative
@@ -349,7 +349,7 @@ trait Rsync_Installation {
 		// Install WordPress at the base installation if it doesn't exist yet.
 		if ( ! is_dir( $base_install_path ) || ! is_file( "{$base_install_path}/wp-load.php" ) ) {
 			Utils::info(
-				"Installating WordPress at <em>{$base_install_path}</em> ...",
+				"Installing WordPress at <em>{$base_install_path}</em> ...",
 				'Install Rsync'
 			);
 
@@ -484,7 +484,7 @@ trait Rsync_Installation {
 			// Use the first argument and translate it to the rsync-ed path.
 			$executable = $this->translate_location( $args[0] );
 
-			// Attempt to fallback to the phpunit binrary reference in PHP_SELF. This
+			// Attempt to fallback to the phpunit binary reference in PHP_SELF. This
 			// would be the one used to invoke the current script. With that, we can
 			// translate it to the new location in the rsync-ed WordPress
 			// installation.

--- a/tests/support/test-collection.php
+++ b/tests/support/test-collection.php
@@ -77,8 +77,8 @@ class Test_Collection extends Framework_Test_Case {
 
 		$this->assertSame('book', $data->first_where('material', 'paper')['type']);
 		$this->assertSame('gasket', $data->first_where('material', 'rubber')['type']);
-		$this->assertNull($data->first_where('material', 'nonexistant'));
-		$this->assertNull($data->first_where('nonexistant', 'key'));
+		$this->assertNull($data->first_where('material', 'nonexistent'));
+		$this->assertNull($data->first_where('nonexistent', 'key'));
 	}
 
 	/**
@@ -3623,7 +3623,7 @@ class Test_Collection extends Framework_Test_Case {
 	/**
 	 * @dataProvider collectionClassProvider
 	 */
-	public function testSplitCollectionWithADivisableCount($collection)
+	public function testSplitCollectionWithADivisibleCount($collection)
 	{
 		$data = new $collection(['a', 'b', 'c', 'd']);
 


### PR DESCRIPTION
Found some misspellings.

I let you handle the function name change.
Maybe
```php
	/**
	 * Get the class names of the given parameter's type, including union types.
	 *
	 * @param  \ReflectionParameter $parameter
	 * @return array
	 */
	public static function get_paramater_class_names( $parameter ) {
		return self::get_parameter_class_names( $parameter );
	}
```

