### PR TITLE
[1.x] Allow queue jobs to be run in-admin, allow delays for closure jobs

### DIFF
--- a/src/mantle/queue/class-closure-job.php
+++ b/src/mantle/queue/class-closure-job.php
@@ -2,6 +2,8 @@
 /**
  * Closure_Job class file
  *
+ * phpcs:disable Squiz.Commenting.VariableComment.Missing
+ *
  * @package Mantle
  */
 
@@ -15,9 +17,9 @@ use ReflectionFunction;
 use Throwable;
 
 /**
- * Abstract Queue Job
+ * Closure Job
  *
- * To be extended by provider-specific queue job classes.
+ * Storage of the closure-based queue job.
  */
 class Closure_Job implements Can_Queue {
 	/**

--- a/src/mantle/queue/class-closure-job.php
+++ b/src/mantle/queue/class-closure-job.php
@@ -8,6 +8,7 @@
 namespace Mantle\Queue;
 
 use Closure;
+use DateTimeInterface;
 use Laravel\SerializableClosure\SerializableClosure;
 use Mantle\Contracts\Queue\Can_Queue;
 use ReflectionFunction;
@@ -19,6 +20,13 @@ use Throwable;
  * To be extended by provider-specific queue job classes.
  */
 class Closure_Job implements Can_Queue {
+	/**
+	 * The delay before the job will be run.
+	 *
+	 * @var int|DateTimeInterface
+	 */
+	public int|DateTimeInterface $delay;
+
 	/**
 	 * The callbacks that should be run on failure.
 	 *
@@ -51,6 +59,18 @@ class Closure_Job implements Can_Queue {
 		$callback = $this->closure->getClosure();
 
 		$callback();
+	}
+
+	/**
+	 * Set the delay before the job will be run.
+	 *
+	 * @param DateTimeInterface|int $delay Delay in seconds or DateTime instance.
+	 * @return static
+	 */
+	public function delay( DateTimeInterface|int $delay ) {
+		$this->delay = $delay;
+
+		return $this;
 	}
 
 	/**

--- a/src/mantle/queue/console/class-cleanup-jobs-command.php
+++ b/src/mantle/queue/console/class-cleanup-jobs-command.php
@@ -37,7 +37,6 @@ class Cleanup_Jobs_Command extends Command {
 		Queue_Record::query()
 			->whereStatus( [ Post_Status::RUNNING->value, Post_Status::FAILED->value, Post_Status::COMPLETED->value ] )
 			->olderThan( now()->subSeconds( (int) $this->container['config']->get( 'queue.delete_after', 60 ) ) )
-			->take( -1 )
 			->each_by_id(
 				function ( Queue_Record $record ) use ( &$count ) {
 					if ( ! $record->is_locked() ) {

--- a/src/mantle/queue/providers/wordpress/admin/class-queue-job-admin-page.php
+++ b/src/mantle/queue/providers/wordpress/admin/class-queue-job-admin-page.php
@@ -10,6 +10,7 @@ namespace Mantle\Queue\Providers\WordPress\Admin;
 use Mantle\Queue\Providers\WordPress\Post_Status;
 use Mantle\Queue\Providers\WordPress\Queue_Record;
 use Mantle\Queue\Providers\WordPress\Queue_Worker_Job;
+use Mantle\Queue\Worker;
 
 /**
  * Renders the queue admin page screen.
@@ -59,32 +60,87 @@ class Queue_Job_Admin_Page {
 			wp_die( 'Invalid nonce.' );
 		}
 
-		$action  = sanitize_text_field( wp_unslash( $_GET['action'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$job     = Queue_Record::find( $job_id );
-		$message = '';
+		$action = sanitize_text_field( wp_unslash( $_GET['action'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$record = Queue_Record::find( $job_id );
 
-		if ( empty( $job ) ) {
+		$message      = '';
+		$message_link = '';
+
+		if ( empty( $record ) ) {
 			wp_die( esc_html__( 'Invalid job ID.', 'mantle' ) );
 		}
 
-		if ( 'retry' === $action ) {
-			if ( Post_Status::FAILED->value !== $job->status ) {
-				wp_die( esc_html__( 'Job is not in a failed state.', 'mantle' ) );
+		$return_link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url(
+				add_query_arg(
+					[
+						'action' => null,
+						'job'    => null,
+					],
+				),
+			),
+			esc_html__( 'Return to queue jobs.', 'mantle' ),
+		);
+
+		if ( 'run' === $action ) {
+			if ( Post_Status::PENDING->value !== $record->status ) {
+				wp_die( esc_html__( 'Job is not in a pending state.', 'mantle' ) . ' ' . $return_link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 
-			( new Queue_Worker_Job( $job ) )->retry();
+			// Check if the job is locked.
+			if ( $record->is_locked() ) {
+				wp_die( esc_html__( 'Job is currently locked.', 'mantle' ) . ' ' . $return_link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+
+			$job = new Queue_Worker_Job( $record );
+
+			// Lock the job before it is run.
+			$record->set_lock_until( $job->get_job()->timeout ?? 600 );
+
+			// Run the queue job through the queue worker and refresh the record.
+			app( Worker::class )->run_single( $job );
+
+			$message = match ( $record->refresh()?->status ) {
+				Post_Status::FAILED->value => esc_html__( 'Job has failed.', 'mantle' ),
+				Post_Status::COMPLETED->value => esc_html__( 'Job has completed successfully.', 'mantle' ),
+				default => esc_html__( 'Job has been run but the status is unknown.', 'mantle' ),
+			};
+
+			$message_status = Post_Status::FAILED->value === $record->status ? 'error' : 'success';
+
+			$message_link = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url(
+					add_query_arg(
+						[
+							'action' => null,
+							'filter' => null,
+							'job'    => $record->id(),
+						],
+					),
+				),
+				esc_html__( 'View Details', 'mantle' ),
+			);
+		} elseif ( 'retry' === $action ) {
+			if ( Post_Status::FAILED->value !== $record->status ) {
+				wp_die( esc_html__( 'Job is not in a failed state and cannot be retried.', 'mantle' ) );
+			}
+
+			( new Queue_Worker_Job( $record ) )->retry();
 
 			$message = esc_html__( 'Job has been scheduled to be retried.', 'mantle' );
 		} elseif ( 'delete' === $action ) {
-			$job->delete( true );
+			$record->delete( true );
 
 			$message = esc_html__( 'Job has been deleted.', 'mantle' );
 		}
 
 		if ( ! empty( $message ) ) {
 			printf(
-				'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
-				esc_html( $message )
+				'<div class="notice notice-%s is-dismissible"><p>%s</p></div>',
+				esc_attr( $message_status ?? 'success' ),
+				esc_html( $message ) . " {$message_link}", // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			);
 		}
 

--- a/src/mantle/queue/providers/wordpress/admin/class-queue-job-admin-page.php
+++ b/src/mantle/queue/providers/wordpress/admin/class-queue-job-admin-page.php
@@ -114,9 +114,10 @@ class Queue_Job_Admin_Page {
 				esc_url(
 					add_query_arg(
 						[
-							'action' => null,
-							'filter' => null,
-							'job'    => $record->id(),
+							'action'   => null,
+							'filter'   => null,
+							'job'      => $record->id(),
+							'_wpnonce' => null,
 						],
 					),
 				),

--- a/src/mantle/queue/providers/wordpress/admin/class-queue-jobs-table.php
+++ b/src/mantle/queue/providers/wordpress/admin/class-queue-jobs-table.php
@@ -91,7 +91,13 @@ class Queue_Jobs_Table extends WP_List_Table {
 						),
 					)
 					->toString(),
-				'url'     => add_query_arg( 'filter', $status->value ),
+				'url'     => add_query_arg(
+					[
+						'action' => null,
+						'job'    => null,
+						'filter' => $status->value,
+					] 
+				),
 			];
 		}
 
@@ -192,6 +198,22 @@ class Queue_Jobs_Table extends WP_List_Table {
 				esc_attr__( 'View details about this job', 'mantle' ),
 				esc_html__( 'View', 'mantle' ),
 			),
+			Post_Status::PENDING->value === $item['status']
+				? sprintf(
+					'<a href="%s" aria-label="%s">%s</a>',
+					esc_url(
+						add_query_arg(
+							[
+								'_wpnonce' => wp_create_nonce( 'queue-job-action-' . $item['id'] ),
+								'job'      => (int) $item['id'],
+								'action'   => 'run',
+							]
+						)
+					),
+					esc_attr__( 'Run this job', 'mantle' ),
+					esc_html__( 'Run', 'mantle' ),
+				)
+				: null,
 			Post_Status::FAILED->value === $item['status']
 				? sprintf(
 					'<a href="%s" aria-label="%s">%s</a>',
@@ -199,7 +221,6 @@ class Queue_Jobs_Table extends WP_List_Table {
 						add_query_arg(
 							[
 								'_wpnonce' => wp_create_nonce( 'queue-job-action-' . $item['id'] ),
-								'filter'   => false,
 								'job'      => (int) $item['id'],
 								'action'   => 'retry',
 							]
@@ -216,7 +237,6 @@ class Queue_Jobs_Table extends WP_List_Table {
 						add_query_arg(
 							[
 								'_wpnonce' => wp_create_nonce( 'queue-job-action-' . $item['id'] ),
-								'filter'   => false,
 								'job'      => (int) $item['id'],
 								'action'   => 'delete',
 							]

--- a/src/mantle/queue/providers/wordpress/admin/class-queue-jobs-table.php
+++ b/src/mantle/queue/providers/wordpress/admin/class-queue-jobs-table.php
@@ -13,6 +13,7 @@ use Mantle\Queue\Providers\WordPress\Post_Status;
 use Mantle\Queue\Providers\WordPress\Provider;
 use Mantle\Queue\Providers\WordPress\Queue_Record;
 use Mantle\Queue\Providers\WordPress\Queue_Worker_Job;
+use Mantle\Support\Str;
 use WP_List_Table;
 
 use function Mantle\Support\Helpers\str;
@@ -290,6 +291,10 @@ class Queue_Jobs_Table extends WP_List_Table {
 
 			case Post_Status::FAILED->value:
 				echo '<span class="dashicons dashicons-no-alt"></span>' . esc_html__( 'Failed', 'mantle' );
+				break;
+
+			case Post_Status::COMPLETED->value:
+				echo '<span class="dashicons dashicons-yes"></span>' . esc_html__( 'Completed', 'mantle' );
 				break;
 		}
 	}

--- a/src/mantle/queue/providers/wordpress/admin/template/single.php
+++ b/src/mantle/queue/providers/wordpress/admin/template/single.php
@@ -37,6 +37,11 @@ $log = is_array( $log ) ? $log : [];
 		);
 		?>
 	</h1>
+	<p>
+		<a href="<?php menu_page_url( 'mantle-queue', true ); ?>">
+			<?php esc_html_e( 'Back to Queue Jobs', 'mantle' ); ?>
+		</a>
+	</p>
 
 	<hr class="wp-header-end">
 
@@ -65,7 +70,7 @@ $log = is_array( $log ) ? $log : [];
 						<?php esc_html_e( 'Retry', 'mantle' ); ?>
 					</a>
 				<?php endif; ?>
-				<?php if ( Post_Status::RUNNING->value !== $job->status ) : ?>
+				<?php if ( Post_Status::RUNNING->value !== $job->status && ! $job->is_locked() ) : ?>
 					<a
 						href="
 						<?php

--- a/src/mantle/queue/providers/wordpress/class-queue-record.php
+++ b/src/mantle/queue/providers/wordpress/class-queue-record.php
@@ -13,6 +13,10 @@ use function Mantle\Support\Helpers\collect;
 
 /**
  * Queue Job Record
+ *
+ * Used to store the queued jobs as posts in the database. Post statuses are
+ * used to track the job state and the post meta is used to store the job
+ * details/lock.
  */
 class Queue_Record extends Post {
 	/**

--- a/src/mantle/queue/providers/wordpress/class-queue-worker-job.php
+++ b/src/mantle/queue/providers/wordpress/class-queue-worker-job.php
@@ -18,7 +18,8 @@ use Throwable;
 /**
  * WordPress Cron Queue Job
  *
- * Class to perform the actual queue job.
+ * Class to perform the actual queue job from the data stored in the queue
+ * record from the database.
  */
 class Queue_Worker_Job extends \Mantle\Queue\Queue_Worker_Job {
 


### PR DESCRIPTION
<img width="1252" alt="Screenshot 2023-11-30 at 4 12 12 PM" src="https://github.com/alleyinteractive/mantle-framework/assets/346399/d45b4aab-77c3-470b-bafc-f4fa344e221c">

- Allow queue jobs to be run from the admin page.
- Fix issues with `add_query_arg()` causing the filter to fall off.
- Allow closure jobs to be delayed.