### PR TITLE
Extend support to wp-filter-side-effects 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.12.11 - 2023-12-11
+
+### Added
+
+- Adding support back for `alleyinteractive/wp-filter-side-effects` 1.0.
+
 ## v0.12.10 - 2023-11-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.12.9 - 2023-11-27
+## v0.12.10 - 2023-11-27
 
 ### Changed
 
 - Removed PHPUnit 10 support to prevent a breaking change. Moved to 1.x.
 
-## v0.12.8 - 2023-11-21
+## v0.12.9 - 2023-11-21
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
-        "alleyinteractive/wp-asset-manager": "^1.3.3",
+        "alleyinteractive/wp-asset-manager": "^1.3.6",
         "alleyinteractive/wp-caper": "^2.0.1",
         "alleyinteractive/wp-concurrent-remote-requests": "^1.0.2",
         "alleyinteractive/wp-filter-side-effects": "^1.0 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "alleyinteractive/wp-asset-manager": "^1.3.3",
         "alleyinteractive/wp-caper": "^2.0.1",
         "alleyinteractive/wp-concurrent-remote-requests": "^1.0.2",
-        "alleyinteractive/wp-filter-side-effects": "^2.0",
+        "alleyinteractive/wp-filter-side-effects": "^1.0 || ^2.0",
         "doctrine/inflector": "^2.0.8",
         "dragonmantank/cron-expression": "^3.3.3",
         "fakerphp/faker": "^1.23",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,6 +28,7 @@
 		<exclude name="PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection" />
 		<exclude name="PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.Changed" />
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
+		<exclude name="Generic.Commenting.DocComment.SpacingAfterTagGroup" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 	</rule>
 

--- a/src/mantle/database/composer.json
+++ b/src/mantle/database/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^8.0",
         "alleyinteractive/composer-wordpress-autoloader": "^1.0",
-        "alleyinteractive/wp-filter-side-effects": "^2.0",
+        "alleyinteractive/wp-filter-side-effects": "^1.0 || ^2.0",
         "mantle-framework/contracts": "^0.12",
         "mantle-framework/support": "^0.12",
         "psr/container": "^1.1.1 || ^2.0.2",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for the `alleyinteractive/wp-filter-side-effects` plugin version 1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->