### PR TITLE
Add bootable trait to support package

### DIFF
--- a/src/mantle/support/attributes/class-filter.php
+++ b/src/mantle/support/attributes/class-filter.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Filter class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Support\Attributes;
+
+use Attribute;
+
+/**
+ * Hook Filter Attribute
+ *
+ * Used to hook a method to an WordPress hook at a specific priority.
+ */
+#[Attribute]
+class Filter {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $hook_name Hook name.
+	 * @param int    $priority Priority, defaults to 10.
+	 */
+	public function __construct( public string $hook_name, public int $priority = 10 ) {}
+}

--- a/src/mantle/support/class-service-provider.php
+++ b/src/mantle/support/class-service-provider.php
@@ -78,7 +78,7 @@ abstract class Service_Provider implements LoggerAwareInterface {
 			$this->setLogger( $this->app['log']->driver() );
 		}
 
-		$this->register_action_hooks();
+		$this->register_hooks();
 		$this->boot();
 	}
 

--- a/src/mantle/support/class-service-provider.php
+++ b/src/mantle/support/class-service-provider.php
@@ -7,10 +7,10 @@
 
 namespace Mantle\Support;
 
-use Mantle\Console\Command;
 use Mantle\Console\Application as Console_Application;
+use Mantle\Console\Command;
 use Mantle\Contracts\Application;
-use Mantle\Support\Traits\Action_Hooks;
+use Mantle\Support\Traits\Hookable;
 use Psr\Log\{LoggerAwareInterface, LoggerAwareTrait};
 
 use function Mantle\Support\Helpers\collect;
@@ -19,7 +19,7 @@ use function Mantle\Support\Helpers\collect;
  * Application Service Provider
  */
 abstract class Service_Provider implements LoggerAwareInterface {
-	use Action_Hooks;
+	use Hookable;
 	use LoggerAwareTrait;
 
 	/**

--- a/src/mantle/support/class-service-provider.php
+++ b/src/mantle/support/class-service-provider.php
@@ -10,17 +10,16 @@ namespace Mantle\Support;
 use Mantle\Console\Command;
 use Mantle\Console\Application as Console_Application;
 use Mantle\Contracts\Application;
-use Mantle\Support\Attributes\Action;
-use Mantle\Support\Str;
+use Mantle\Support\Traits\Action_Hooks;
 use Psr\Log\{LoggerAwareInterface, LoggerAwareTrait};
-use ReflectionClass;
-use function Mantle\Support\Helpers\add_action;
+
 use function Mantle\Support\Helpers\collect;
 
 /**
  * Application Service Provider
  */
 abstract class Service_Provider implements LoggerAwareInterface {
+	use Action_Hooks;
 	use LoggerAwareTrait;
 
 	/**
@@ -79,83 +78,8 @@ abstract class Service_Provider implements LoggerAwareInterface {
 			$this->setLogger( $this->app['log']->driver() );
 		}
 
-		$this->boot_action_hooks();
+		$this->register_action_hooks();
 		$this->boot();
-	}
-
-	/**
-	 * Boot all actions and attribute methods on the service provider.
-	 *
-	 * Collects all of the `on_{hook}` and `on_{hook}_at_{priority}` methods as
-	 * well as the attribute based `#[Action]` methods and registers them with
-	 * the respective WordPress hooks.
-	 */
-	protected function boot_action_hooks(): void {
-		$this->collect_action_methods()
-			->merge( $this->collect_attribute_hooks() )
-			->unique()
-			->each(
-				fn ( array $item ) => add_action( $item['hook'], [ $this, $item['method'] ], $item['priority'] ),
-			);
-	}
-
-	/**
-	 * Collect all action methods from the service provider.
-	 *
-	 * @return Collection<int, array{hook: string, method: string, priority: int}>
-	 */
-	protected function collect_action_methods(): Collection {
-		return collect( get_class_methods( static::class ) )
-			->filter(
-				fn ( string $method ) => Str::starts_with( $method, 'on_' )
-			)
-			->map(
-				function( string $method ) {
-					$hook     = Str::after( $method, 'on_' );
-					$priority = 10;
-
-					if ( Str::contains( $hook, '_at_' ) ) {
-						// Strip the priority from the hook name.
-						$priority = (int) Str::after_last( $hook, '_at_' );
-						$hook     = Str::before_last( $hook, '_at_' );
-					}
-
-					return [
-						'hook'     => $hook,
-						'method'   => $method,
-						'priority' => $priority,
-					];
-				}
-			);
-	}
-
-	/**
-	 * Collect all attribute actions on the service provider.
-	 *
-	 * Allow methods with the `#[Action]` attribute to automatically register
-	 * WordPress hooks.
-	 *
-	 * @return Collection<int, array{hook: string, method: string, priority: int}>
-	 */
-	protected function collect_attribute_hooks(): Collection {
-		$items = new Collection();
-		$class = new ReflectionClass( static::class );
-
-		foreach ( $class->getMethods() as $method ) {
-			foreach ( $method->getAttributes( Action::class ) as $attribute ) {
-				$instance = $attribute->newInstance();
-
-				$items->push(
-					[
-						'hook'     => $instance->hook_name,
-						'method'   => $method->getName(),
-						'priority' => $instance->priority,
-					]
-				);
-			}
-		}
-
-		return $items;
 	}
 
 	/**

--- a/src/mantle/support/helpers/helpers-general.php
+++ b/src/mantle/support/helpers/helpers-general.php
@@ -385,7 +385,11 @@ function with( $value, callable $callback = null ) {
  * @return void
  */
 function add_action( string $hook, callable $callable, int $priority = 10 ): void {
-	Container::get_instance()->make( Dispatcher::class )->listen( $hook, $callable, $priority );
+	if ( ! class_exists( Dispatcher::class ) ) {
+		\add_action( $hook, $callable, $priority, 99 );
+	} else {
+		Container::get_instance()->make( Dispatcher::class )->listen( $hook, $callable, $priority );
+	}
 }
 
 /**
@@ -397,7 +401,11 @@ function add_action( string $hook, callable $callable, int $priority = 10 ): voi
  * @return void
  */
 function add_filter( string $hook, callable $callable, int $priority = 10 ): void {
-	Container::get_instance()->make( Dispatcher::class )->listen( $hook, $callable, $priority );
+	if ( ! class_exists( Dispatcher::class ) ) {
+		\add_filter( $hook, $callable, $priority, 99 );
+	} else {
+		Container::get_instance()->make( Dispatcher::class )->listen( $hook, $callable, $priority );
+	}
 }
 
 /**

--- a/src/mantle/support/traits/trait-action-hooks.php
+++ b/src/mantle/support/traits/trait-action-hooks.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Action_Hooks trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Support\Traits;
+
+use Mantle\Support\Attributes\Action;
+use Mantle\Support\Attributes\Filter;
+use Mantle\Support\Collection;
+use Mantle\Support\Service_Provider;
+use Mantle\Support\Str;
+use ReflectionClass;
+
+use function Mantle\Support\Helpers\add_action;
+use function Mantle\Support\Helpers\add_filter;
+use function Mantle\Support\Helpers\collect;
+
+/**
+ * Register all hooks on a class.
+ *
+ * Collects all of the `on_{hook}` and `on_{hook}_at_{priority}` methods as
+ * well as the attribute based `#[Action]` methods and registers them with
+ * the respective WordPress hooks.
+ */
+trait Action_Hooks {
+	/**
+	 * Boot all actions and attribute methods on the service provider.
+	 *
+	 * Collects all of the `on_{hook}`, `on_{hook}_at_{priority}`,
+	 * `action__{hook}`, and `filter__{hook}` methods as well as the attribute
+	 * based `#[Action]` and `#[Filter]` methods and registers them with the
+	 * respective WordPress hooks.
+	 */
+	protected function register_action_hooks(): void {
+		$this->collect_action_methods()
+			->merge( $this->collect_attribute_hooks() )
+			->unique()
+			->each(
+				function ( array $item ) {
+					if ( $this->use_event_dispatcher() ) {
+						if ( 'action' === $item['type'] ) {
+							\Mantle\Support\Helpers\add_action( $item['hook'], [ $this, $item['method'] ], $item['priority'] );
+						} else {
+							\Mantle\Support\Helpers\add_filter( $item['hook'], [ $this, $item['method'] ], $item['priority'] );
+						}
+					} else {
+						// Use the default WordPress action/filter methods.
+						if ( 'action' === $item['type'] ) {
+							\add_action( $item['hook'], [ $this, $item['method'] ], $item['priority'] );
+						} else {
+							\add_filter( $item['hook'], [ $this, $item['method'] ], $item['priority'] );
+						}
+					}
+				},
+			);
+	}
+
+	/**
+	 * Collect all action methods from the service provider.
+	 *
+	 * @return Collection<int, array{type: string, hook: string, method: string, priority: int}>
+	 */
+	protected function collect_action_methods(): Collection {
+		return collect( get_class_methods( static::class ) )
+			->filter(
+				fn ( string $method ) => Str::starts_with( $method, [ 'on_', 'action__', 'filter__' ] )
+			)
+			->map(
+				function( string $method ) {
+					$type = match ( true ) {
+						Str::starts_with( $method, 'filter__' ) => 'filter',
+						default => 'action',
+					};
+
+					$hook = match ( true ) {
+						Str::starts_with( $method, 'on_' ) => Str::after( $method, 'on_' ),
+						default => Str::after( $method, $type . '__' ),
+					};
+
+					$priority = 10;
+
+					if ( Str::contains( $hook, '_at_' ) ) {
+						// Strip the priority from the hook name.
+						$priority = (int) Str::after_last( $hook, '_at_' );
+						$hook     = Str::before_last( $hook, '_at_' );
+					}
+
+					return [
+						'type'     => $type,
+						'hook'     => $hook,
+						'method'   => $method,
+						'priority' => $priority,
+					];
+				}
+			);
+	}
+
+	/**
+	 * Collect all attribute actions on the service provider.
+	 *
+	 * Allow methods with the `#[Action]` attribute to automatically register
+	 * WordPress hooks.
+	 *
+	 * @return Collection<int, array{type: string, hook: string, method: string, priority: int}>
+	 */
+	protected function collect_attribute_hooks(): Collection {
+		$items = new Collection();
+		$class = new ReflectionClass( static::class );
+
+		foreach ( $class->getMethods() as $method ) {
+			foreach ( $method->getAttributes( Action::class ) as $attribute ) {
+				$instance = $attribute->newInstance();
+
+				$items->push(
+					[
+						'type'     => 'action',
+						'hook'     => $instance->hook_name,
+						'method'   => $method->getName(),
+						'priority' => $instance->priority,
+					]
+				);
+			}
+
+			foreach ( $method->getAttributes( Filter::class ) as $attribute ) {
+				$instance = $attribute->newInstance();
+
+				$items->push(
+					[
+						'type'     => 'filter',
+						'hook'     => $instance->hook_name,
+						'method'   => $method->getName(),
+						'priority' => $instance->priority,
+					]
+				);
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Determine if the service provider should use the event dispatcher or the
+	 * core WordPress hooks.
+	 *
+	 * @return bool
+	 */
+	public function use_event_dispatcher(): bool {
+		// By default, it is only enabled if the class is an instance of the
+		// `Service_Provider` class. For external uses of this trait, the
+		// event dispatcher won't be used.
+		return $this instanceof Service_Provider;
+	}
+}

--- a/src/mantle/support/traits/trait-action-hooks.php
+++ b/src/mantle/support/traits/trait-action-hooks.php
@@ -34,7 +34,7 @@ trait Action_Hooks {
 	 * based `#[Action]` and `#[Filter]` methods and registers them with the
 	 * respective WordPress hooks.
 	 */
-	protected function register_action_hooks(): void {
+	protected function register_hooks(): void {
 		$this->collect_action_methods()
 			->merge( $this->collect_attribute_hooks() )
 			->unique()

--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -145,12 +145,13 @@ trait Hookable {
 	 * Determine if the service provider should use the event dispatcher or the
 	 * core WordPress hooks.
 	 *
+	 * By default, it is only enabled if the class is an instance of the
+	 * `Service_Provider` class. For external uses of this trait, the event
+	 * dispatcher won't be used.
+	 *
 	 * @return bool
 	 */
 	public function use_event_dispatcher(): bool {
-		// By default, it is only enabled if the class is an instance of the
-		// `Service_Provider` class. For external uses of this trait, the
-		// event dispatcher won't be used.
 		return $this instanceof Service_Provider;
 	}
 }

--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Action_Hooks trait file
+ * Hookable trait file
  *
  * @package Mantle
  */
@@ -25,7 +25,7 @@ use function Mantle\Support\Helpers\collect;
  * well as the attribute based `#[Action]` methods and registers them with
  * the respective WordPress hooks.
  */
-trait Action_Hooks {
+trait Hookable {
 	/**
 	 * Boot all actions and attribute methods on the service provider.
 	 *


### PR DESCRIPTION
Add the "magic" bootable trait to the support package.

```php
<?php

use Mantle\Support\Attributes\Action;
use Mantle\Support\Traits\Hookable;

class Example_Feature {
  use Hookable;

  public function __construct() {
    $this->register_hooks();
  }

  public function action__init() {
    // This is done on the init hook
  }

  public function action__wp_enqueue_scripts() {
    // This is done on the wp_enqueue_scripts hook
  }

  #[Action('my_custom_hook')]
  public function register_scripts() {
    // This is done on the my_custom_hook hook
  }
}
```