### PR TITLE
Abstract HTTP requests in testing to standalone class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for PHP 8.3.
 - PHPUnit 10 support added and `nunomaduro/collision` depend on to v6-7.
 
 	**Upgrade Note:** When upgrading to Mantle v1 projects will receive PHPUnit 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Overhauled queue performance and added admin interface.
+- Tests that make requests using `$this->get()` and other HTTP methods will now
+  use a fluent pending request class `Mantle\Testing\Pending_Testable_Request`
+  to allow for more complex request building.
 
 ### Removed
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
 	backupGlobals="false"
 	colors="true"
 	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
 >
 	<testsuites>
 		<testsuite name="mantle-framework">

--- a/src/mantle/support/traits/trait-enumerates-values.php
+++ b/src/mantle/support/traits/trait-enumerates-values.php
@@ -743,10 +743,17 @@ trait Enumerates_Values {
 	 */
 	public function to_array() {
 		return $this->map(
-			function ( $value ) {
-				return $value instanceof Arrayable ? $value->to_array() : $value;
-			}
+			fn ( $value ) => $value instanceof Arrayable ? $value->to_array() : $value,
 		)->all();
+	}
+
+	/**
+	 * Alias for the "to_array" method.
+	 *
+	 * @return array<TKey, TValue>
+	 */
+	public function toArray() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $this->to_array();
 	}
 
 	/**

--- a/src/mantle/testing/class-pending-testable-request.php
+++ b/src/mantle/testing/class-pending-testable-request.php
@@ -1,0 +1,740 @@
+<?php
+/**
+ * Pending_Testable_Request class file
+ *
+ * phpcs:disable WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing;
+
+use Mantle\Database\Model\Model;
+use Mantle\Framework\Http\Kernel as HttpKernel;
+use Mantle\Http\Request;
+use Mantle\Support\Str;
+use Mantle\Testing\Doubles\Spy_REST_Server;
+use Mantle\Testing\Exceptions\Exception;
+use Mantle\Testing\Exceptions\WP_Redirect_Exception;
+use Mantle\Testing\Test_Case;
+use Mantle\Testing\Test_Response;
+use Mantle\Testing\Utils;
+use PHPUnit\Framework\Assert;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\InputBag;
+use WP_Query;
+use WP;
+
+/**
+ * Pending Testable Request
+ *
+ * A fluent request that is being made to the application. Performs a SUT
+ * (System Under Test) operation on WordPress and returns a response.
+ */
+class Pending_Testable_Request {
+	/**
+	 * Indicates whether redirects should be followed.
+	 *
+	 * @var bool
+	 */
+	public bool $follow_redirects = false;
+
+	/**
+	 * The headers for the request.
+	 *
+	 * @var HeaderBag
+	 */
+	public HeaderBag $headers;
+
+	/**
+	 * The cookies for the request.
+	 *
+	 * @var InputBag
+	 */
+	public InputBag $cookies;
+
+	/**
+	 * Store flag if the request was for the REST API.
+	 *
+	 * @var array{body: string, headers: array<string, string>}|null
+	 */
+	protected ?array $rest_api_response = null;
+
+	/**
+	 * Create a new pending testable request instance.
+	 *
+	 * @param Test_Case $test_case Test case instance.
+	 */
+	public function __construct( public Test_Case $test_case ) {
+		$this->headers = new HeaderBag();
+		$this->cookies = new InputBag();
+	}
+
+	/**
+	 * Define additional headers to be sent with the request.
+	 *
+	 * @param array $headers Headers for the request.
+	 * @return static
+	 */
+	public function with_headers( array $headers ): static {
+		$this->headers->add( $headers );
+
+		return $this;
+	}
+
+	/**
+	 * Define additional header to be sent with the request.
+	 *
+	 * @param string $name  Header name (key).
+	 * @param string $value Header value.
+	 * @return static
+	 */
+	public function with_header( string $name, string $value ): static {
+		return $this->with_headers( [ $name => $value ] );
+	}
+
+	/**
+	 * Set the referer header and previous URL session value in order to simulate
+	 * a previous request.
+	 *
+	 * @param string $url URL for the referer header.
+	 * @return static
+	 */
+	public function from( string $url ): static {
+		return $this->with_header( 'referer', $url );
+	}
+
+	/**
+	 * Make a request with a set of cookies.
+	 *
+	 * @param array<string, string> $cookies Cookies to be sent with the request.
+	 * @return static
+	 */
+	public function with_cookies( array $cookies ): static {
+		$this->cookies->add( $cookies );
+
+		return $this;
+	}
+
+	/**
+	 * Make a request with a specific cookie.
+	 *
+	 * @param string $name  Cookie name.
+	 * @param string $value Cookie value.
+	 * @return static
+	 */
+	public function with_cookie( string $name, string $value ): static {
+		return $this->with_cookies( [ $name => $value ] );
+	}
+
+	/**
+	 * Automatically follow any redirects returned from the response.
+	 *
+	 * @param bool $value Whether to follow redirects.
+	 * @return static
+	 */
+	public function following_redirects( bool $value = true ): static {
+		$this->follow_redirects = $value;
+
+		return $this;
+	}
+
+	/**
+	 * Visit the given URI with a GET request.
+	 *
+	 * @param mixed $uri     Request URI.
+	 * @param array $headers Request headers.
+	 * @return Test_Response
+	 */
+	public function get( $uri, array $headers = [] ): Test_Response {
+		$server = $this->transform_headers_to_server_vars( $headers );
+
+		return $this->call( 'GET', $uri, [], $server );
+	}
+
+	/**
+	 * Legacy support for the WordPress core unit test's `go_to()` method.
+	 *
+	 * @deprecated Use {@see Mantle\Testing\Concerns\Makes_Http_Requests::get()} instead.
+	 * @param string $url The URL for the request.
+	 */
+	public function go_to( string $url ): Test_Response {
+		return $this->get( $url );
+	}
+
+	/**
+	 * Infer the request URL from an object like a post or term.
+	 *
+	 * @param mixed $source Source from which to infer the URL.
+	 * @return string
+	 */
+	protected function infer_url( mixed $source ): string {
+		return match ( true ) {
+			$source instanceof \WP_Post => get_permalink( $source ),
+			$source instanceof \WP_Term => get_term_link( $source ),
+			$source instanceof \WP_User => \get_author_posts_url( $source->ID ),
+			$source instanceof Model && method_exists( $source, 'permalink' ) => $source->permalink(),
+			default => '',
+		};
+	}
+
+	/**
+	 * Transform headers array to array of $_SERVER vars with HTTP_* format.
+	 *
+	 * @param array $headers Headers to convert to $_SERVER vars.
+	 * @return array
+	 */
+	protected function transform_headers_to_server_vars( array $headers ) {
+		$headers           = array_merge( $this->headers->all(), $headers );
+		$formatted_headers = [];
+		foreach ( $headers as $name => $value ) {
+			$name = strtr( strtoupper( $name ), '-', '_' );
+
+			$formatted_headers[ $this->format_server_header_key( $name ) ] = $value;
+		}
+
+		return $formatted_headers;
+	}
+
+	/**
+	 * Format the header name for the server array.
+	 *
+	 * @param string $name Header name.
+	 * @return string
+	 */
+	protected function format_server_header_key( $name ) {
+		if ( ! Str::starts_with( $name, 'HTTP_' ) && 'CONTENT_TYPE' !== $name && 'REMOTE_ADDR' !== $name ) {
+			return 'HTTP_' . $name;
+		}
+
+		return $name;
+	}
+
+	/**
+	 * Call the given URI and return the Response.
+	 *
+	 * @param string      $method     Request method.
+	 * @param mixed       $uri        Request URI.
+	 * @param array       $parameters Request params.
+	 * @param array       $server     Server vars.
+	 * @param array       $cookies Cookies to be sent with the request.
+	 * @param string|null $content Request content.
+	 * @return Test_Response
+	 */
+	public function call( string $method, mixed $uri, array $parameters = [], array $server = [], array $cookies = [], ?string $content = null ): Test_Response {
+		$this->reset_request_state();
+
+		if ( ! is_string( $uri ) ) {
+			$uri = $this->infer_url( $uri );
+		}
+
+		// Build a full URL from partial URIs.
+		if ( '/' === $uri[0] ) {
+			$url = 'https://' . WP_TESTS_DOMAIN . $uri;
+		} elseif ( false === strpos( $uri, '://' ) ) {
+			$url = 'https://' . WP_TESTS_DOMAIN . '/' . $uri;
+		} else {
+			$url = $uri;
+		}
+
+		$this->set_server_state(
+			$method,
+			$url,
+			$server,
+			$parameters,
+			array_merge( $this->cookies->all(), $cookies ),
+		);
+
+		$response_status  = null;
+		$response_headers = [];
+
+		$intercept_status = function( $status_header, $code ) use ( &$response_status ): int {
+			if ( ! $response_status ) {
+				$response_status = $code;
+			}
+
+			return $code;
+		};
+
+		$intercept_headers = function( $send_headers ) use ( &$response_headers ): array {
+			$response_headers = $send_headers;
+
+			return $send_headers;
+		};
+
+		$intercept_redirect = function( $location, $status ) use ( &$response_status, &$response_headers ) {
+			$response_status              = $status;
+			$response_headers['Location'] = $location;
+			throw new WP_Redirect_Exception();
+		};
+
+		add_filter( 'exit_on_http_head', '__return_false', 9999 );
+		add_filter( 'wp_using_themes', '__return_true', 9999 );
+
+		$this->test_case->call_before_callbacks();
+
+		// Attempt to run the query through the Mantle router.
+		if ( isset( $this->test_case->app['router'] ) ) {
+			$kernel = new HttpKernel( $this->test_case->app, $this->test_case->app['router'] );
+
+			// Setup the current request object.
+			$request = new Request(
+				$_GET,
+				$_POST,
+				[],
+				$_COOKIE,
+				$_FILES,
+				$_SERVER,
+				$content
+			);
+
+			// Mirror the logic from Request::createFromGlobals().
+			if (
+				str_starts_with( $request->headers->get( 'CONTENT_TYPE', '' ), 'application/x-www-form-urlencoded' )
+			&& \in_array( strtoupper( $request->server->get( 'REQUEST_METHOD', 'GET' ) ), [ 'PUT', 'DELETE', 'PATCH' ] )
+			) {
+				parse_str( $request->getContent(), $data );
+
+				$request->request = new InputBag( $data );
+			}
+
+			$this->test_case->app->instance( 'request', $request );
+
+			$response = $kernel->send_request_through_router( $request );
+
+			if ( $response ) {
+				$response = new Test_Response(
+					$response->getContent(),
+					$response->getStatusCode(),
+					$response->headers->all(),
+					$this->test_case,
+				);
+			}
+		}
+
+		// Attempt to run the query through the Mantle router.
+		if ( empty( $response ) ) {
+			add_filter( 'status_header', $intercept_status, 9999, 2 );
+			add_filter( 'wp_headers', $intercept_headers, 9999 );
+			add_filter( 'wp_redirect', $intercept_redirect, 9999, 2 ); // @phpstan-ignore-line Filter callback
+
+			ob_start();
+
+			$this->setup_wordpress_query();
+
+			if ( $this->rest_api_response ) {
+				// Use the response from the REST API server.
+				ob_end_clean();
+
+				$response_content = $this->rest_api_response['body'];
+				$response_headers = array_merge( (array) $response_headers, (array) $this->rest_api_response['headers'] );
+			} else {
+				try {
+					// Execute the request, inasmuch as WordPress would.
+					require ABSPATH . WPINC . '/template-loader.php';
+				} catch ( Exception $e ) { // phpcs:ignore
+					// Mantle Exceptions are thrown to prevent some code from running, e.g.
+					// the tail end of wp_redirect().
+				}
+
+				$response_content = ob_get_clean();
+			}
+
+			remove_filter( 'status_header', $intercept_status, 9999 );
+			remove_filter( 'wp_headers', $intercept_headers, 9999 );
+			remove_filter( 'wp_redirect', $intercept_redirect, 9999 );
+
+			$response = new Test_Response(
+				$response_content,
+				$response_status ?? 200,
+				$response_headers,
+				$this->test_case,
+			);
+		}
+
+		$response->set_app( $this->test_case->app );
+
+		$this->test_case->call_after_callbacks( $response );
+
+		remove_filter( 'exit_on_http_head', '__return_false', 9999 );
+		remove_filter( 'wp_using_themes', '__return_true', 9999 );
+
+		if ( $this->follow_redirects ) {
+			return $this->follow_redirects( $response );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Reset the global state related to requests.
+	 */
+	protected function reset_request_state() {
+		// phpcs:disable
+
+		/*
+		 * Note: the WP and WP_Query classes like to silently fetch parameters
+		 * from all over the place (globals, GET, etc), which makes it tricky
+		 * to run them more than once without very carefully clearing everything.
+		 */
+		$_GET    = [];
+		$_POST   = [];
+		$_COOKIE = [];
+		foreach (
+			[
+				'query_string',
+				'id',
+				'postdata',
+				'authordata',
+				'day',
+				'currentmonth',
+				'page',
+				'pages',
+				'multipage',
+				'more',
+				'numpages',
+				'pagenow',
+				'current_screen',
+			] as $v
+		) {
+			if ( isset( $GLOBALS[ $v ] ) ) {
+				unset( $GLOBALS[ $v ] );
+			}
+		}
+
+		$this->rest_api_response = null;
+
+		// phpcs:enable
+	}
+
+	/**
+	 * Set $_SERVER keys for the request.
+	 *
+	 * @param string $method HTTP method.
+	 * @param string $url    Request URI.
+	 * @param array  $server Additional $_SERVER args to set.
+	 * @param array  $data   POST data to set.
+	 * @param array  $cookies Cookies to be sent with the request.
+	 */
+	protected function set_server_state( $method, $url, $server, $data, array $cookies = [] ) {
+		// phpcs:disable WordPress.Security.NonceVerification
+		$_SERVER['REQUEST_METHOD'] = strtoupper( $method );
+		$_SERVER['SERVER_NAME']    = WP_TESTS_DOMAIN;
+		$_SERVER['SERVER_PORT']    = '80';
+		unset( $_SERVER['PATH_INFO'] );
+
+		$parts = wp_parse_url( $url );
+		if ( isset( $parts['scheme'] ) ) {
+			$req = isset( $parts['path'] ) ? $parts['path'] : '';
+			if ( isset( $parts['query'] ) ) {
+				$req .= '?' . $parts['query'];
+				// Parse the URL query vars into $_GET.
+				parse_str( $parts['query'], $_GET );
+			}
+		} else {
+			$req = $url;
+		}
+		$_SERVER['REQUEST_URI'] = $req;
+
+		$_POST = $data;
+
+		// The ini setting variable_order determines order; assume GP for simplicity.
+		$_REQUEST = array_merge( $_GET, $_POST );
+		$_SERVER  = array_merge( $_SERVER, $server );
+
+		// Set the cookies for the request.
+		$_COOKIE = $cookies; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		// phpcs:enable
+	}
+
+	/**
+	 * Sets the WordPress query as if a given URL has been requested.
+	 *
+	 * This sets:
+	 * - The super globals.
+	 * - The globals.
+	 * - The query variables.
+	 * - The main query.
+	 */
+	protected function setup_wordpress_query() {
+		Test_Case::flush_cache();
+
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride
+		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
+		$GLOBALS['wp_the_query'] = new WP_Query();
+		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+
+		$public_query_vars  = $GLOBALS['wp']->public_query_vars;
+		$private_query_vars = $GLOBALS['wp']->private_query_vars;
+
+		$GLOBALS['wp']                     = new WP();
+		$GLOBALS['wp']->public_query_vars  = $public_query_vars;
+		$GLOBALS['wp']->private_query_vars = $private_query_vars;
+
+		Utils::cleanup_query_vars();
+
+		$this->replace_rest_api();
+
+		$GLOBALS['wp']->main();
+
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride
+	}
+
+	/**
+	 * Replace the REST API request.
+	 *
+	 * This will:
+	 * - Initiate the REST API.
+	 * - Set the WordPress REST Server to use the Mantle Spy REST Server to allow
+	 *   for the responses to be read.
+	 * - Replace the REST API `rest_api_loaded` method to allow the REST response
+	 *   to be read without terminating the script.
+	 */
+	protected function replace_rest_api() {
+		// Ensure the Mantle REST Spy Server is used.
+		add_filter( 'wp_rest_server_class', [ Utils::class, 'wp_rest_server_class_filter' ], PHP_INT_MAX );
+
+		rest_api_init();
+
+		// Replace the `rest_api_loaded()` method with one we can control.
+		remove_filter( 'parse_request', 'rest_api_loaded' );
+		add_action( 'parse_request', [ $this, 'serve_rest_api_request' ] );
+	}
+
+	/**
+	 * Server the REST API request if applicable.
+	 *
+	 * Mirroring `{@see rest_api_loaded()}`, this method fires the REST API
+	 * request and stores the response.
+	 */
+	public function serve_rest_api_request() {
+		if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+			return;
+		}
+
+		$server = rest_get_server();
+
+		if ( $server instanceof Spy_REST_Server ) {
+			$route = untrailingslashit( $GLOBALS['wp']->query_vars['rest_route'] );
+
+			if ( empty( $route ) ) {
+				$route = '/';
+			}
+
+			$server->serve_request( $route );
+
+			if ( isset( $server->sent_body ) ) {
+				$this->rest_api_response = [
+					'body'    => $server->sent_body,
+					'headers' => $server->sent_headers,
+				];
+			}
+		} else {
+			Assert::fail( 'Expected the Mantle Spy REST Server to be used.' );
+		}
+	}
+
+	/**
+	 * Turn the given URI into a fully qualified URL.
+	 *
+	 * @param string $uri URI to fully-qualify.
+	 * @return string
+	 */
+	protected function prepare_url_for_request( $uri ) {
+		return Str::trailing_slash( home_url( $uri ) );
+	}
+
+	/**
+	 * Follow a redirect chain until a non-redirect is received.
+	 *
+	 * @param Test_Response $response Test response.
+	 * @return Test_Response
+	 */
+	protected function follow_redirects( $response ) {
+		while ( $response->is_redirect() ) {
+			$response = $this->get( $response->get_header( 'Location' ) );
+		}
+
+		$this->follow_redirects = false;
+
+		return $response;
+	}
+
+	/**
+	 * Visit the given URI with a GET request, expecting a JSON response.
+	 *
+	 * @param string $uri     URI to "get".
+	 * @param array  $headers Request headers.
+	 * @param int    $options JSON encoding options.
+	 * @return Test_Response
+	 */
+	public function get_json( $uri, array $headers = [], int $options = 0 ): Test_Response {
+		return $this->json( 'GET', $uri, [], $headers, $options );
+	}
+
+	/**
+	 * Call the given URI with a JSON request.
+	 *
+	 * @param string $method  Request method.
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @param int    $options JSON encoding options.
+	 * @return Test_Response
+	 *
+	 * @throws RuntimeException If not implemented.
+	 */
+	public function json( string $method, string $uri, array $data = [], array $headers = [], int $options = 1 ): Test_Response {
+		$content = json_encode( $data, $options ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+
+		$headers = array_merge(
+			$headers,
+			[
+				'Accept'         => 'application/json',
+				'Content-Length' => mb_strlen( $content, '8bit' ),
+				'Content-Type'   => 'application/json',
+			]
+		);
+
+		$server = $this->transform_headers_to_server_vars( $headers );
+
+		return $this->call( $method, $uri, $data, $server, [], $content );
+	}
+
+	/**
+	 * Visit the given URI with a POST request.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @return Test_Response
+	 */
+	public function post( string $uri, array $data = [], array $headers = [] ): Test_Response {
+		$server = $this->transform_headers_to_server_vars( $headers );
+
+		return $this->call( 'POST', $uri, $data, $server );
+	}
+
+	/**
+	 * Visit the given URI with a POST request, expecting a JSON response.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @param int    $options JSON encoding options.
+	 * @return Test_Response
+	 */
+	public function post_json( string $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
+		return $this->json( 'POST', $uri, $data, $headers, $options );
+	}
+
+	/**
+	 * Visit the given URI with a PUT request.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @return Test_Response
+	 */
+	public function put( string $uri, array $data = [], array $headers = [] ): Test_Response {
+		$server = $this->transform_headers_to_server_vars( $headers );
+
+		return $this->call( 'PUT', $uri, $data, $server );
+	}
+
+	/**
+	 * Visit the given URI with a PUT request, expecting a JSON response.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @param int    $options JSON encoding options.
+	 * @return Test_Response
+	 */
+	public function put_json( string $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
+		return $this->json( 'PUT', $uri, $data, $headers, $options );
+	}
+
+	/**
+	 * Visit the given URI with a PATCH request.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @return Test_Response
+	 */
+	public function patch( $uri, array $data = [], array $headers = [] ): Test_Response {
+		$server = $this->transform_headers_to_server_vars( $headers );
+
+		return $this->call( 'PATCH', $uri, $data, $server );
+	}
+
+	/**
+	 * Visit the given URI with a PATCH request, expecting a JSON response.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @param int    $options JSON encoding options.
+	 * @return Test_Response
+	 */
+	public function patch_json( $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
+		return $this->json( 'PATCH', $uri, $data, $headers, $options );
+	}
+
+	/**
+	 * Visit the given URI with a DELETE request.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @return Test_Response
+	 */
+	public function delete( $uri, array $data = [], array $headers = [] ): Test_Response {
+		$server = $this->transform_headers_to_server_vars( $headers );
+
+		return $this->call( 'DELETE', $uri, $data, $server );
+	}
+
+	/**
+	 * Visit the given URI with a DELETE request, expecting a JSON response.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @param int    $options JSON encoding options.
+	 * @return Test_Response
+	 */
+	public function delete_json( $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
+		return $this->json( 'DELETE', $uri, $data, $headers, $options );
+	}
+
+	/**
+	 * Visit the given URI with a OPTIONS request.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @return Test_Response
+	 */
+	public function options( $uri, array $data = [], array $headers = [] ): Test_Response {
+		$server = $this->transform_headers_to_server_vars( $headers );
+
+		return $this->call( 'OPTIONS', $uri, $data, $server );
+	}
+
+	/**
+	 * Visit the given URI with a OPTIONS request, expecting a JSON response.
+	 *
+	 * @param string $uri     Request URI.
+	 * @param array  $data    Request data.
+	 * @param array  $headers Request headers.
+	 * @param int    $options JSON encoding options.
+	 * @return Test_Response
+	 */
+	public function options_json( $uri, array $data = [], array $headers = [], int $options = 0 ) {
+		return $this->json( 'OPTIONS', $uri, $data, $headers, $options );
+	}
+}

--- a/src/mantle/testing/class-pending-testable-request.php
+++ b/src/mantle/testing/class-pending-testable-request.php
@@ -13,6 +13,7 @@ use Mantle\Database\Model\Model;
 use Mantle\Framework\Http\Kernel as HttpKernel;
 use Mantle\Http\Request;
 use Mantle\Support\Str;
+use Mantle\Support\Traits\Conditionable;
 use Mantle\Testing\Doubles\Spy_REST_Server;
 use Mantle\Testing\Exceptions\Exception;
 use Mantle\Testing\Exceptions\WP_Redirect_Exception;
@@ -33,6 +34,8 @@ use WP;
  * (System Under Test) operation on WordPress and returns a response.
  */
 class Pending_Testable_Request {
+	use Conditionable;
+
 	/**
 	 * Indicates whether redirects should be followed.
 	 *

--- a/src/mantle/testing/class-pending-testable-request.php
+++ b/src/mantle/testing/class-pending-testable-request.php
@@ -188,9 +188,10 @@ class Pending_Testable_Request {
 	 * @param array $headers Headers to convert to $_SERVER vars.
 	 * @return array
 	 */
-	protected function transform_headers_to_server_vars( array $headers ) {
+	protected function transform_headers_to_server_vars( array $headers ): array {
 		$headers           = array_merge( $this->headers->all(), $headers );
 		$formatted_headers = [];
+
 		foreach ( $headers as $name => $value ) {
 			$name = strtr( strtoupper( $name ), '-', '_' );
 
@@ -373,7 +374,7 @@ class Pending_Testable_Request {
 	/**
 	 * Reset the global state related to requests.
 	 */
-	protected function reset_request_state() {
+	protected function reset_request_state(): void {
 		// phpcs:disable
 
 		/*
@@ -420,7 +421,7 @@ class Pending_Testable_Request {
 	 * @param array  $data   POST data to set.
 	 * @param array  $cookies Cookies to be sent with the request.
 	 */
-	protected function set_server_state( $method, $url, $server, $data, array $cookies = [] ) {
+	protected function set_server_state( $method, $url, $server, $data, array $cookies = [] ): void {
 		// phpcs:disable WordPress.Security.NonceVerification
 		$_SERVER['REQUEST_METHOD'] = strtoupper( $method );
 		$_SERVER['SERVER_NAME']    = WP_TESTS_DOMAIN;
@@ -461,7 +462,7 @@ class Pending_Testable_Request {
 	 * - The query variables.
 	 * - The main query.
 	 */
-	protected function setup_wordpress_query() {
+	protected function setup_wordpress_query(): void {
 		Test_Case::flush_cache();
 
 		// phpcs:disable WordPress.WP.GlobalVariablesOverride
@@ -495,7 +496,7 @@ class Pending_Testable_Request {
 	 * - Replace the REST API `rest_api_loaded` method to allow the REST response
 	 *   to be read without terminating the script.
 	 */
-	protected function replace_rest_api() {
+	protected function replace_rest_api(): void {
 		// Ensure the Mantle REST Spy Server is used.
 		add_filter( 'wp_rest_server_class', [ Utils::class, 'wp_rest_server_class_filter' ], PHP_INT_MAX );
 
@@ -512,7 +513,7 @@ class Pending_Testable_Request {
 	 * Mirroring `{@see rest_api_loaded()}`, this method fires the REST API
 	 * request and stores the response.
 	 */
-	public function serve_rest_api_request() {
+	public function serve_rest_api_request(): void {
 		if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
 			return;
 		}
@@ -545,7 +546,7 @@ class Pending_Testable_Request {
 	 * @param string $uri URI to fully-qualify.
 	 * @return string
 	 */
-	protected function prepare_url_for_request( $uri ) {
+	protected function prepare_url_for_request( $uri ): string {
 		return Str::trailing_slash( home_url( $uri ) );
 	}
 
@@ -555,7 +556,7 @@ class Pending_Testable_Request {
 	 * @param Test_Response $response Test response.
 	 * @return Test_Response
 	 */
-	protected function follow_redirects( $response ) {
+	protected function follow_redirects( $response ): Test_Response {
 		while ( $response->is_redirect() ) {
 			$response = $this->get( $response->get_header( 'Location' ) );
 		}
@@ -737,7 +738,7 @@ class Pending_Testable_Request {
 	 * @param int    $options JSON encoding options.
 	 * @return Test_Response
 	 */
-	public function options_json( $uri, array $data = [], array $headers = [], int $options = 0 ) {
+	public function options_json( $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
 		return $this->json( 'OPTIONS', $uri, $data, $headers, $options );
 	}
 }

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -99,7 +99,6 @@ abstract class Test_Case extends BaseTestCase {
 		static::register_traits();
 
 		if ( ! empty( static::$test_uses ) ) {
-
 			static::get_test_case_traits()
 				->each(
 					function( $trait ) {
@@ -268,7 +267,7 @@ abstract class Test_Case extends BaseTestCase {
 	/**
 	 * Get an array of priority traits.
 	 *
-	 * @return array
+	 * @return array<class-string>
 	 */
 	protected static function get_priority_traits(): array {
 		return [
@@ -282,14 +281,14 @@ abstract class Test_Case extends BaseTestCase {
 	/**
 	 * Register the traits that this test case uses.
 	 */
-	public static function register_traits() {
+	public static function register_traits(): void {
 		static::$test_uses = array_flip( class_uses_recursive( static::class ) );
 	}
 
 	/**
 	 * Refresh the application instance.
 	 */
-	protected function refresh_application() {
+	protected function refresh_application(): void {
 		$this->app = $this->create_application();
 
 		if ( class_exists( Facade::class ) ) {
@@ -323,7 +322,7 @@ abstract class Test_Case extends BaseTestCase {
 	 * @param string $name Property name.
 	 * @return boolean
 	 */
-	public function __isset( $name ) {
+	public function __isset( $name ): bool {
 		return 'factory' === $name || 'app' === $name;
 	}
 

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -45,7 +45,7 @@ use function Mantle\Support\Helpers\collect;
  *
  * Not designed for external use. Use {@see Mantle\Testkit\Test_Case} instead.
  *
- * @property Application|null $app
+ * @property-read Application|null $app
  */
 abstract class Test_Case extends BaseTestCase {
 	use Assertions,

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -44,6 +44,8 @@ use function Mantle\Support\Helpers\collect;
  * Root Test Case for Mantle sites.
  *
  * Not designed for external use. Use {@see Mantle\Testkit\Test_Case} instead.
+ *
+ * @property Application|null $app
  */
 abstract class Test_Case extends BaseTestCase {
 	use Assertions,
@@ -316,24 +318,26 @@ abstract class Test_Case extends BaseTestCase {
 	}
 
 	/**
-	 * Allow the factory to be checked against.
+	 * Allow the factory/app to be checked against.
 	 *
 	 * @param string $name Property name.
 	 * @return boolean
 	 */
 	public function __isset( $name ) {
-		return 'factory' === $name;
+		return 'factory' === $name || 'app' === $name;
 	}
 
 	/**
-	 * Retrieve the factory instance non-statically.
+	 * Retrieve the factory/app instance non-statically.
 	 *
 	 * @param string $name Property name.
 	 * @return mixed
 	 */
 	public function __get( $name ) {
-		if ( 'factory' === $name ) {
-			return self::factory();
-		}
+		return match ( $name ) {
+			'factory' => self::factory(),
+			'app' => $this->app,
+			default => null,
+		};
 	}
 }

--- a/src/mantle/testing/concerns/trait-makes-http-requests.php
+++ b/src/mantle/testing/concerns/trait-makes-http-requests.php
@@ -12,6 +12,7 @@ namespace Mantle\Testing\Concerns;
 use Mantle\Database\Model\Model;
 use Mantle\Framework\Http\Kernel as HttpKernel;
 use Mantle\Http\Request;
+use Mantle\Testing\Pending_Testable_Request;
 use Mantle\Support\Str;
 use Mantle\Testing\Doubles\Spy_REST_Server;
 use Mantle\Testing\Exceptions\Exception;
@@ -24,6 +25,8 @@ use Symfony\Component\HttpFoundation\InputBag;
 use WP;
 use WP_Query;
 
+use function Mantle\Support\Helpers\tap;
+
 /**
  * Trait for Test_Case classes which want to make http-like requests against
  * WordPress.
@@ -32,44 +35,30 @@ trait Makes_Http_Requests {
 	/**
 	 * Additional headers for the request.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	protected array $default_headers = [];
 
 	/**
 	 * Additional cookies for the request.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	protected array $default_cookies = [];
-
-	/**
-	 * Indicates whether redirects should be followed.
-	 *
-	 * @var bool
-	 */
-	protected bool $follow_redirects = false;
-
-	/**
-	 * Store flag if the request was for the REST API.
-	 *
-	 * @var array{body: string, headers: array<string, string>}|null
-	 */
-	protected ?array $rest_api_response = null;
 
 	/**
 	 * The array of callbacks to be run before the event is started.
 	 *
 	 * @var array<callable>
 	 */
-	protected array $before_callbacks = [];
+	public array $before_callbacks = [];
 
 	/**
 	 * The array of callbacks to be run after the event is finished.
 	 *
 	 * @var array<callable>
 	 */
-	protected array $after_callbacks = [];
+	public array $after_callbacks = [];
 
 	/**
 	 * Setup the trait in the test case.
@@ -89,49 +78,90 @@ trait Makes_Http_Requests {
 	}
 
 	/**
-	 * Define additional headers to be sent with the request.
+	 * Create a new request instance with the default headers and cookies.
 	 *
-	 * @param array $headers Headers for the request.
-	 * @return $this
+	 * @return Pending_Testable_Request
 	 */
-	public function with_headers( array $headers ) {
-		$this->default_headers = array_merge( $this->default_headers, $headers );
+	protected function create_pending_request(): Pending_Testable_Request {
+		return tap(
+			new Pending_Testable_Request( $this ),
+			function ( Pending_Testable_Request $request ) {
+				$request->cookies->add( $this->default_cookies );
+				$request->headers->add( $this->default_headers );
+			},
+		);
+	}
 
-		return $this;
+	/**
+	 * Add default headers to all requests.
+	 *
+	 * @param array<string, string>|string $headers Headers to be added to all requests.
+	 * @param string|null                  $value   Header value.
+	 */
+	public function add_default_header( array|string $headers, ?string $value = null ): void {
+		if ( is_array( $headers ) ) {
+			$this->default_headers = array_merge( $this->default_headers, $headers );
+		} else {
+			$this->default_headers[ $headers ] = $value;
+		}
 	}
 
 	/**
 	 * Flush all the configured headers.
 	 *
-	 * @return $this
+	 * @return static
 	 */
-	public function flush_headers() {
+	public function flush_default_headers(): static {
 		$this->default_headers = [];
 
 		return $this;
 	}
 
 	/**
-	 * Make a request with a set of cookies.
+	 * Define additional headers to be sent with the request.
 	 *
-	 * @param array $cookies Cookies to be sent with the request.
-	 * @return static
+	 * @param array $headers Headers for the request.
+	 * @return Pending_Testable_Request
 	 */
-	public function with_cookies( array $cookies ) {
-		$this->default_cookies = array_merge( $this->default_cookies, $cookies );
-
-		return $this;
+	public function with_headers( array $headers ): Pending_Testable_Request {
+		return $this->create_pending_request()->with_headers( $headers );
 	}
 
 	/**
-	 * Make a request with a specific cookie.
+	 * Define additional header to be sent with the request.
 	 *
-	 * @param string $name  Cookie name.
-	 * @param string $value Cookie value.
+	 * @param string $name  Header name (key).
+	 * @param string $value Header value.
+	 * @return Pending_Testable_Request
+	 */
+	public function with_header( string $name, string $value ): Pending_Testable_Request {
+		return $this->with_headers( [ $name => $value ] );
+	}
+
+	/**
+	 * Set the referer header and previous URL session value in order to simulate
+	 * a previous request.
+	 *
+	 * @param string $url URL for the referer header.
+	 * @return Pending_Testable_Request
+	 */
+	public function from( string $url ): Pending_Testable_Request {
+		return $this->with_header( 'referer', $url );
+	}
+
+	/**
+	 * Make a request with a set of cookies.
+	 *
+	 * @param array<string, string>|string $cookies Cookies to be sent with the request.
+	 * @param string|null                  $value   Cookie value.
 	 * @return static
 	 */
-	public function with_cookie( string $name, string $value ) {
-		$this->default_cookies[ $name ] = $value;
+	public function add_default_cookie( array|string $cookies, ?string $value = null ): static {
+		if ( is_array( $cookies ) ) {
+			$this->default_cookies = array_merge( $this->default_cookies, $cookies );
+		} else {
+			$this->default_cookies[ $cookies ] = $value;
+		}
 
 		return $this;
 	}
@@ -141,45 +171,41 @@ trait Makes_Http_Requests {
 	 *
 	 * @return static
 	 */
-	public function flush_cookies() {
+	public function flush_default_cookies(): static {
 		$this->default_cookies = [];
 
 		return $this;
 	}
 
 	/**
+	 * Make a request with a set of cookies.
+	 *
+	 * @param array<string, string> $cookies Cookies to be sent with the request.
+	 * @return Pending_Testable_Request
+	 */
+	public function with_cookies( array $cookies ): Pending_Testable_Request {
+		return $this->create_pending_request()->with_cookies( $cookies );
+	}
+
+	/**
+	 * Make a request with a specific cookie.
+	 *
+	 * @param string $name  Cookie name.
+	 * @param string $value Cookie value.
+	 * @return Pending_Testable_Request
+	 */
+	public function with_cookie( string $name, string $value ): Pending_Testable_Request {
+		return $this->with_cookies( [ $name => $value ] );
+	}
+
+	/**
 	 * Automatically follow any redirects returned from the response.
 	 *
-	 * @return $this
+	 * @param bool $value Whether to follow redirects.
+	 * @return Pending_Testable_Request
 	 */
-	public function following_redirects() {
-		$this->follow_redirects = true;
-
-		return $this;
-	}
-
-	/**
-	 * Set the referer header and previous URL session value in order to simulate
-	 * a previous request.
-	 *
-	 * @param string $url URL for the referer header.
-	 * @return $this
-	 */
-	public function from( string $url ) {
-		return $this->with_header( 'referer', $url );
-	}
-
-	/**
-	 * Add a header to be sent with the request.
-	 *
-	 * @param string $name  Header name (key).
-	 * @param string $value Header value.
-	 * @return $this
-	 */
-	public function with_header( string $name, string $value ) {
-		$this->default_headers[ $name ] = $value;
-
-		return $this;
+	public function following_redirects( bool $value = true ): Pending_Testable_Request {
+		return $this->create_pending_request()->following_redirects( $value );
 	}
 
 	/**
@@ -189,10 +215,8 @@ trait Makes_Http_Requests {
 	 * @param array $headers Request headers.
 	 * @return Test_Response
 	 */
-	public function get( $uri, array $headers = [] ) {
-		$server = $this->transform_headers_to_server_vars( $headers );
-
-		return $this->call( 'GET', $uri, [], $server );
+	public function get( $uri, array $headers = [] ): Test_Response {
+		return $this->create_pending_request()->get( $uri, $headers );
 	}
 
 	/**
@@ -200,408 +224,10 @@ trait Makes_Http_Requests {
 	 *
 	 * @deprecated Use {@see Mantle\Testing\Concerns\Makes_Http_Requests::get()} instead.
 	 * @param string $url The URL for the request.
-	 */
-	public function go_to( string $url ) {
-		$this->get( $url );
-	}
-
-	/**
-	 * Infer the request URL from an object like a post or term.
-	 *
-	 * @param mixed $source Source from which to infer the URL.
-	 * @return string
-	 */
-	protected function infer_url( mixed $source ): string {
-		return match ( true ) {
-			$source instanceof \WP_Post => get_permalink( $source ),
-			$source instanceof \WP_Term => get_term_link( $source ),
-			$source instanceof \WP_User => \get_author_posts_url( $source->ID ),
-			$source instanceof Model && method_exists( $source, 'permalink' ) => $source->permalink(),
-			default => '',
-		};
-	}
-
-	/**
-	 * Transform headers array to array of $_SERVER vars with HTTP_* format.
-	 *
-	 * @param array $headers Headers to convert to $_SERVER vars.
-	 * @return array
-	 */
-	protected function transform_headers_to_server_vars( array $headers ) {
-		$headers           = array_merge( $this->default_headers, $headers );
-		$formatted_headers = [];
-		foreach ( $headers as $name => $value ) {
-			$name = strtr( strtoupper( $name ), '-', '_' );
-
-			$formatted_headers[ $this->format_server_header_key( $name ) ] = $value;
-		}
-
-		return $formatted_headers;
-	}
-
-	/**
-	 * Format the header name for the server array.
-	 *
-	 * @param string $name Header name.
-	 * @return string
-	 */
-	protected function format_server_header_key( $name ) {
-		if ( ! Str::starts_with( $name, 'HTTP_' ) && 'CONTENT_TYPE' !== $name && 'REMOTE_ADDR' !== $name ) {
-			return 'HTTP_' . $name;
-		}
-
-		return $name;
-	}
-
-	/**
-	 * Call the given URI and return the Response.
-	 *
-	 * @param string      $method     Request method.
-	 * @param mixed       $uri        Request URI.
-	 * @param array       $parameters Request params.
-	 * @param array       $server     Server vars.
-	 * @param array       $cookies Cookies to be sent with the request.
-	 * @param string|null $content Request content.
 	 * @return Test_Response
 	 */
-	public function call( string $method, mixed $uri, array $parameters = [], array $server = [], array $cookies = [], ?string $content = null ): Test_Response {
-		$this->reset_request_state();
-
-		if ( ! is_string( $uri ) ) {
-			$uri = $this->infer_url( $uri );
-		}
-
-		// Build a full URL from partial URIs.
-		if ( '/' === $uri[0] ) {
-			$url = 'https://' . WP_TESTS_DOMAIN . $uri;
-		} elseif ( false === strpos( $uri, '://' ) ) {
-			$url = 'https://' . WP_TESTS_DOMAIN . '/' . $uri;
-		} else {
-			$url = $uri;
-		}
-
-		$this->set_server_state(
-			$method,
-			$url,
-			$server,
-			$parameters,
-			array_merge( $this->default_cookies, $cookies ),
-		);
-
-		$response_status  = null;
-		$response_headers = [];
-
-		$intercept_status = function( $status_header, $code ) use ( &$response_status ): int {
-			if ( ! $response_status ) {
-				$response_status = $code;
-			}
-
-			return $code;
-		};
-
-		$intercept_headers = function( $send_headers ) use ( &$response_headers ): array {
-			$response_headers = $send_headers;
-
-			return $send_headers;
-		};
-
-		$intercept_redirect = function( $location, $status ) use ( &$response_status, &$response_headers ) {
-			$response_status              = $status;
-			$response_headers['Location'] = $location;
-			throw new WP_Redirect_Exception();
-		};
-
-		add_filter( 'exit_on_http_head', '__return_false', 9999 );
-		add_filter( 'wp_using_themes', '__return_true', 9999 );
-
-		$this->call_before_callbacks();
-
-		// Attempt to run the query through the Mantle router.
-		if ( isset( $this->app['router'] ) ) {
-			$kernel = new HttpKernel( $this->app, $this->app['router'] );
-
-			// Setup the current request object.
-			$request = new Request(
-				$_GET,
-				$_POST,
-				[],
-				$_COOKIE,
-				$_FILES,
-				$_SERVER,
-				$content
-			);
-
-			// Mirror the logic from Request::createFromGlobals().
-			if (
-				str_starts_with( $request->headers->get( 'CONTENT_TYPE', '' ), 'application/x-www-form-urlencoded' )
-			&& \in_array( strtoupper( $request->server->get( 'REQUEST_METHOD', 'GET' ) ), [ 'PUT', 'DELETE', 'PATCH' ] )
-			) {
-				parse_str( $request->getContent(), $data );
-
-				$request->request = new InputBag( $data );
-			}
-
-			$this->app->instance( 'request', $request );
-
-			$response = $kernel->send_request_through_router( $request );
-
-			if ( $response ) {
-				$response = new Test_Response(
-					$response->getContent(),
-					$response->getStatusCode(),
-					$response->headers->all(),
-					$this,
-				);
-			}
-		}
-
-		// Attempt to run the query through the Mantle router.
-		if ( empty( $response ) ) {
-			add_filter( 'status_header', $intercept_status, 9999, 2 );
-			add_filter( 'wp_headers', $intercept_headers, 9999 );
-			add_filter( 'wp_redirect', $intercept_redirect, 9999, 2 ); // @phpstan-ignore-line Filter callback
-
-			ob_start();
-
-			$this->setup_wordpress_query();
-
-			if ( $this->rest_api_response ) {
-				// Use the response from the REST API server.
-				ob_end_clean();
-
-				$response_content = $this->rest_api_response['body'];
-				$response_headers = array_merge( (array) $response_headers, (array) $this->rest_api_response['headers'] );
-			} else {
-				try {
-					// Execute the request, inasmuch as WordPress would.
-					require ABSPATH . WPINC . '/template-loader.php';
-				} catch ( Exception $e ) { // phpcs:ignore
-					// Mantle Exceptions are thrown to prevent some code from running, e.g.
-					// the tail end of wp_redirect().
-				}
-
-				$response_content = ob_get_clean();
-			}
-
-			remove_filter( 'status_header', $intercept_status, 9999 );
-			remove_filter( 'wp_headers', $intercept_headers, 9999 );
-			remove_filter( 'wp_redirect', $intercept_redirect, 9999 );
-
-			$response = new Test_Response(
-				$response_content,
-				$response_status ?? 200,
-				$response_headers,
-				$this,
-			);
-		}
-
-		$response->set_app( $this->app );
-
-		$this->call_after_callbacks( $response );
-
-		remove_filter( 'exit_on_http_head', '__return_false', 9999 );
-		remove_filter( 'wp_using_themes', '__return_true', 9999 );
-
-		if ( $this->follow_redirects ) {
-			return $this->follow_redirects( $response );
-		}
-
-		return $response;
-	}
-
-	/**
-	 * Reset the global state related to requests.
-	 */
-	protected function reset_request_state() {
-		// phpcs:disable
-
-		/*
-		 * Note: the WP and WP_Query classes like to silently fetch parameters
-		 * from all over the place (globals, GET, etc), which makes it tricky
-		 * to run them more than once without very carefully clearing everything.
-		 */
-		$_GET    = [];
-		$_POST   = [];
-		$_COOKIE = [];
-		foreach (
-			[
-				'query_string',
-				'id',
-				'postdata',
-				'authordata',
-				'day',
-				'currentmonth',
-				'page',
-				'pages',
-				'multipage',
-				'more',
-				'numpages',
-				'pagenow',
-				'current_screen',
-			] as $v
-		) {
-			if ( isset( $GLOBALS[ $v ] ) ) {
-				unset( $GLOBALS[ $v ] );
-			}
-		}
-
-		$this->rest_api_response = null;
-
-		// phpcs:enable
-	}
-
-	/**
-	 * Set $_SERVER keys for the request.
-	 *
-	 * @param string $method HTTP method.
-	 * @param string $url    Request URI.
-	 * @param array  $server Additional $_SERVER args to set.
-	 * @param array  $data   POST data to set.
-	 * @param array  $cookies Cookies to be sent with the request.
-	 */
-	protected function set_server_state( $method, $url, $server, $data, array $cookies = [] ) {
-		// phpcs:disable WordPress.Security.NonceVerification
-		$_SERVER['REQUEST_METHOD'] = strtoupper( $method );
-		$_SERVER['SERVER_NAME']    = WP_TESTS_DOMAIN;
-		$_SERVER['SERVER_PORT']    = '80';
-		unset( $_SERVER['PATH_INFO'] );
-
-		$parts = wp_parse_url( $url );
-		if ( isset( $parts['scheme'] ) ) {
-			$req = isset( $parts['path'] ) ? $parts['path'] : '';
-			if ( isset( $parts['query'] ) ) {
-				$req .= '?' . $parts['query'];
-				// Parse the URL query vars into $_GET.
-				parse_str( $parts['query'], $_GET );
-			}
-		} else {
-			$req = $url;
-		}
-		$_SERVER['REQUEST_URI'] = $req;
-
-		$_POST = $data;
-
-		// The ini setting variable_order determines order; assume GP for simplicity.
-		$_REQUEST = array_merge( $_GET, $_POST );
-		$_SERVER  = array_merge( $_SERVER, $server );
-
-		// Set the cookies for the request.
-		$_COOKIE = $cookies; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
-
-		// phpcs:enable
-	}
-
-	/**
-	 * Sets the WordPress query as if a given URL has been requested.
-	 *
-	 * This sets:
-	 * - The super globals.
-	 * - The globals.
-	 * - The query variables.
-	 * - The main query.
-	 */
-	protected function setup_wordpress_query() {
-		self::flush_cache();
-
-		// phpcs:disable WordPress.WP.GlobalVariablesOverride
-		unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
-		$GLOBALS['wp_the_query'] = new WP_Query();
-		$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
-
-		$public_query_vars  = $GLOBALS['wp']->public_query_vars;
-		$private_query_vars = $GLOBALS['wp']->private_query_vars;
-
-		$GLOBALS['wp']                     = new WP();
-		$GLOBALS['wp']->public_query_vars  = $public_query_vars;
-		$GLOBALS['wp']->private_query_vars = $private_query_vars;
-
-		Utils::cleanup_query_vars();
-
-		$this->replace_rest_api();
-
-		$GLOBALS['wp']->main();
-
-		// phpcs:enable WordPress.WP.GlobalVariablesOverride
-	}
-
-	/**
-	 * Replace the REST API request.
-	 *
-	 * This will:
-	 * - Initiate the REST API.
-	 * - Set the WordPress REST Server to use the Mantle Spy REST Server to allow
-	 *   for the responses to be read.
-	 * - Replace the REST API `rest_api_loaded` method to allow the REST response
-	 *   to be read without terminating the script.
-	 */
-	protected function replace_rest_api() {
-		// Ensure the Mantle REST Spy Server is used.
-		add_filter( 'wp_rest_server_class', [ Utils::class, 'wp_rest_server_class_filter' ], PHP_INT_MAX );
-
-		rest_api_init();
-
-		// Replace the `rest_api_loaded()` method with one we can control.
-		remove_filter( 'parse_request', 'rest_api_loaded' );
-		add_action( 'parse_request', [ $this, 'serve_rest_api_request' ] );
-	}
-
-	/**
-	 * Server the REST API request if applicable.
-	 *
-	 * Mirroring `{@see rest_api_loaded()}`, this method fires the REST API
-	 * request and stores the response.
-	 */
-	public function serve_rest_api_request() {
-		if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
-			return;
-		}
-
-		$server = rest_get_server();
-
-		if ( $server instanceof Spy_REST_Server ) {
-			$route = untrailingslashit( $GLOBALS['wp']->query_vars['rest_route'] );
-
-			if ( empty( $route ) ) {
-				$route = '/';
-			}
-
-			$server->serve_request( $route );
-
-			if ( isset( $server->sent_body ) ) {
-				$this->rest_api_response = [
-					'body'    => $server->sent_body,
-					'headers' => $server->sent_headers,
-				];
-			}
-		} else {
-			Assert::fail( 'Expected the Mantle Spy REST Server to be used.' );
-		}
-	}
-
-	/**
-	 * Turn the given URI into a fully qualified URL.
-	 *
-	 * @param string $uri URI to fully-qualify.
-	 * @return string
-	 */
-	protected function prepare_url_for_request( $uri ) {
-		return Str::trailing_slash( home_url( $uri ) );
-	}
-
-	/**
-	 * Follow a redirect chain until a non-redirect is received.
-	 *
-	 * @param Test_Response $response Test response.
-	 * @return Test_Response
-	 */
-	protected function follow_redirects( $response ) {
-		while ( $response->is_redirect() ) {
-			$response = $this->get( $response->get_header( 'Location' ) );
-		}
-
-		$this->follow_redirects = false;
-
-		return $response;
+	public function go_to( string $url ): Test_Response {
+		return $this->create_pending_request()->get( $url );
 	}
 
 	/**
@@ -613,7 +239,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function get_json( $uri, array $headers = [], int $options = 0 ): Test_Response {
-		return $this->json( 'GET', $uri, [], $headers, $options );
+		return $this->create_pending_request()->get_json( $uri, $headers, $options );
 	}
 
 	/**
@@ -629,20 +255,7 @@ trait Makes_Http_Requests {
 	 * @throws RuntimeException If not implemented.
 	 */
 	public function json( string $method, string $uri, array $data = [], array $headers = [], int $options = 1 ): Test_Response {
-		$content = json_encode( $data, $options ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
-
-		$headers = array_merge(
-			$headers,
-			[
-				'Accept'         => 'application/json',
-				'Content-Length' => mb_strlen( $content, '8bit' ),
-				'Content-Type'   => 'application/json',
-			]
-		);
-
-		$server = $this->transform_headers_to_server_vars( $headers );
-
-		return $this->call( $method, $uri, $data, $server, [], $content );
+		return $this->create_pending_request()->json( $method, $uri, $data, $headers, $options );
 	}
 
 	/**
@@ -654,9 +267,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function post( string $uri, array $data = [], array $headers = [] ): Test_Response {
-		$server = $this->transform_headers_to_server_vars( $headers );
-
-		return $this->call( 'POST', $uri, $data, $server );
+		return $this->create_pending_request()->post( $uri, $data, $headers );
 	}
 
 	/**
@@ -669,7 +280,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function post_json( string $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
-		return $this->json( 'POST', $uri, $data, $headers, $options );
+		return $this->create_pending_request()->json( 'POST', $uri, $data, $headers );
 	}
 
 	/**
@@ -681,9 +292,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function put( string $uri, array $data = [], array $headers = [] ): Test_Response {
-		$server = $this->transform_headers_to_server_vars( $headers );
-
-		return $this->call( 'PUT', $uri, $data, $server );
+		return $this->create_pending_request()->put( $uri, $data, $headers );
 	}
 
 	/**
@@ -696,7 +305,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function put_json( string $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
-		return $this->json( 'PUT', $uri, $data, $headers, $options );
+		return $this->create_pending_request()->json( 'PUT', $uri, $data, $headers, $options );
 	}
 
 	/**
@@ -708,9 +317,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function patch( $uri, array $data = [], array $headers = [] ): Test_Response {
-		$server = $this->transform_headers_to_server_vars( $headers );
-
-		return $this->call( 'PATCH', $uri, $data, $server );
+		return $this->create_pending_request()->patch( $uri, $data, $headers );
 	}
 
 	/**
@@ -723,7 +330,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function patch_json( $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
-		return $this->json( 'PATCH', $uri, $data, $headers, $options );
+		return $this->create_pending_request()->json( 'PATCH', $uri, $data, $headers, $options );
 	}
 
 	/**
@@ -735,9 +342,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function delete( $uri, array $data = [], array $headers = [] ): Test_Response {
-		$server = $this->transform_headers_to_server_vars( $headers );
-
-		return $this->call( 'DELETE', $uri, $data, $server );
+		return $this->create_pending_request()->delete( $uri, $data, $headers );
 	}
 
 	/**
@@ -750,7 +355,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function delete_json( $uri, array $data = [], array $headers = [], int $options = 0 ): Test_Response {
-		return $this->json( 'DELETE', $uri, $data, $headers, $options );
+		return $this->create_pending_request()->json( 'DELETE', $uri, $data, $headers, $options );
 	}
 
 	/**
@@ -762,9 +367,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function options( $uri, array $data = [], array $headers = [] ): Test_Response {
-		$server = $this->transform_headers_to_server_vars( $headers );
-
-		return $this->call( 'OPTIONS', $uri, $data, $server );
+		return $this->create_pending_request()->options( $uri, $data, $headers );
 	}
 
 	/**
@@ -777,7 +380,7 @@ trait Makes_Http_Requests {
 	 * @return Test_Response
 	 */
 	public function options_json( $uri, array $data = [], array $headers = [], int $options = 0 ) {
-		return $this->json( 'OPTIONS', $uri, $data, $headers, $options );
+		return $this->create_pending_request()->json( 'OPTIONS', $uri, $data, $headers, $options );
 	}
 
 	/**
@@ -809,7 +412,7 @@ trait Makes_Http_Requests {
 	/**
 	 * Call all of the "before" callbacks for the requests.
 	 */
-	protected function call_before_callbacks() {
+	public function call_before_callbacks() {
 		foreach ( $this->before_callbacks as $callback ) {
 			$this->app->call( $callback );
 		}
@@ -820,7 +423,7 @@ trait Makes_Http_Requests {
 	 *
 	 * @param Test_Response $response Response object.
 	 */
-	protected function call_after_callbacks( Test_Response $response ) {
+	public function call_after_callbacks( Test_Response $response ) {
 		foreach ( $this->after_callbacks as $callback ) {
 			$this->app->call(
 				$callback,

--- a/src/mantle/testing/concerns/trait-makes-http-requests.php
+++ b/src/mantle/testing/concerns/trait-makes-http-requests.php
@@ -9,21 +9,9 @@
 
 namespace Mantle\Testing\Concerns;
 
-use Mantle\Database\Model\Model;
-use Mantle\Framework\Http\Kernel as HttpKernel;
-use Mantle\Http\Request;
 use Mantle\Testing\Pending_Testable_Request;
-use Mantle\Support\Str;
-use Mantle\Testing\Doubles\Spy_REST_Server;
-use Mantle\Testing\Exceptions\Exception;
-use Mantle\Testing\Exceptions\WP_Redirect_Exception;
 use Mantle\Testing\Test_Response;
-use Mantle\Testing\Utils;
-use PHPUnit\Framework\Assert;
 use RuntimeException;
-use Symfony\Component\HttpFoundation\InputBag;
-use WP;
-use WP_Query;
 
 use function Mantle\Support\Helpers\tap;
 

--- a/tests/Queue/providers/WordPressCronQueueTest.php
+++ b/tests/Queue/providers/WordPressCronQueueTest.php
@@ -81,9 +81,9 @@ class WordPressCronQueueTest extends Framework_Test_Case {
 	}
 
 	public function test_job_failure() {
-		$_SERVER['__failed_run'] = false;
+		$_SERVER['__failed_run'] = 0;
 
-		$this->app['events']->listen( Job_Failed::class, fn () => $_SERVER['__failed_run'] = true );
+		$this->app['events']->listen( Job_Failed::class, fn () => $_SERVER['__failed_run']++ );
 
 		$this->assertNotInCronQueue( Job_To_Fail::class );
 
@@ -94,7 +94,7 @@ class WordPressCronQueueTest extends Framework_Test_Case {
 		$this->dispatch_queue();
 
 		$this->assertNotInCronQueue( Job_To_Fail::class );
-		$this->assertTrue( $_SERVER['__failed_run'] );
+		$this->assertEquals( 2, $_SERVER['__failed_run'] );
 
 		// Ensure that the post does not exist.
 		$this->assertPostExists( [

--- a/tests/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Testing/Concerns/MakesHttpRequestsTest.php
@@ -32,6 +32,29 @@ class MakesHttpRequestsTest extends Framework_Test_Case {
 			->assertQueriedObjectId( $post_id );
 	}
 
+	public function test_fluent() {
+		$_SERVER['__request_headers'] = [];
+
+		add_filter(
+			'template_redirect',
+			function() {
+				$_SERVER['__request_headers'] = collect( getallheaders() )->to_array();
+			},
+		);
+
+		$this->add_default_header( 'x-default', 'default' );
+
+		$this->with_header( 'x-test', 'test' )
+			->get( home_url( '/' ) )
+			->assertQueryTrue( 'is_home', 'is_front_page' );
+
+		$this->assertNotEmpty( $_SERVER['__request_headers']['X-Test'] );
+		$this->assertEquals( 'test', $_SERVER['__request_headers']['X-Test'][0] );
+
+		$this->assertNotEmpty( $_SERVER['__request_headers']['X-Default'] );
+		$this->assertEquals( 'default', $_SERVER['__request_headers']['X-Default'][0] );
+	}
+
 	public function test_get_term() {
 		$category_id = static::factory()->category->create();
 


### PR DESCRIPTION
Abstract the HTTP requests in testing (`$this->get()`) to a standalone class to prevent conflicts when chaining `$this->with_cookies()` and so on. Mirrors a similar move in the HTTP Client for added code clarity. 