### PR TITLE
Allow WordPress authentication to be defined by an attribute

### DIFF
--- a/src/mantle/testing/attributes/class-acting-as.php
+++ b/src/mantle/testing/attributes/class-acting-as.php
@@ -5,7 +5,7 @@
  * @package Mantle
  */
 
-namespace Mantle\Testing\Authentication;
+namespace Mantle\Testing\Attributes;
 
 use Attribute;
 use Mantle\Database\Model\User;

--- a/src/mantle/testing/attributes/class-expected-deprecation.php
+++ b/src/mantle/testing/attributes/class-expected-deprecation.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Expected_Deprecation class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Attributes;
+
+use Attribute;
+
+/**
+ * Expected Deprecation
+ *
+ * Used to mark a test as expecting a deprecation notice.
+ */
+#[Attribute]
+class Expected_Deprecation {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $deprecation The expected deprecation method.
+	 */
+	public function __construct( public string $deprecation ) {}
+}

--- a/src/mantle/testing/attributes/class-expected-incorrect-usage.php
+++ b/src/mantle/testing/attributes/class-expected-incorrect-usage.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Expected_Incorrect_Usage class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Attributes;
+
+use Attribute;
+
+/**
+ * Expected Incorrect Usage
+ *
+ * Used to mark a test as expecting a specific doing it wrong call. Supports * as a wildcard.
+ */
+#[Attribute]
+class Expected_Incorrect_Usage {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $name Name of the function, method, or class that appears in
+	 *                     the first argument of the source `_doing_it_wrong()`
+	 *                     call. Supports * as a wildcard.
+	 */
+	public function __construct( public string $name = '*' ) {}
+}

--- a/src/mantle/testing/attributes/class-ignore-deprecation.php
+++ b/src/mantle/testing/attributes/class-ignore-deprecation.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Ignore_Deprecation class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Attributes;
+
+use Attribute;
+
+/**
+ * Ignore Deprecation
+ *
+ * Used to mark a test as ignoring a specific deprecation notice. Supports * as a wildcard.
+ */
+#[Attribute]
+class Ignore_Deprecation {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $deprecation The expected deprecation to ignore. Defaults to all deprecations.
+	 */
+	public function __construct( public string $deprecation = '*' ) {}
+}

--- a/src/mantle/testing/attributes/class-ignore-incorrect-usage.php
+++ b/src/mantle/testing/attributes/class-ignore-incorrect-usage.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Ignore_Incorrect_Usage class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Attributes;
+
+use Attribute;
+
+/**
+ * Ignore Incorrect Usage
+ *
+ * Used to mark a test as ignoring a specific doing it wrong call. Supports * as a wildcard.
+ */
+#[Attribute]
+class Ignore_Incorrect_Usage {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $name Name of the function, method, or class that appears in
+	 *                     the first argument of the source `_doing_it_wrong()`
+	 *                     call. Supports * as a wildcard.
+	 */
+	public function __construct( public string $name = '*' ) {}
+}

--- a/src/mantle/testing/authentication/class-acting-as.php
+++ b/src/mantle/testing/authentication/class-acting-as.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Acting_As class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Testing\Authentication;
+
+use Attribute;
+use Mantle\Database\Model\User;
+use WP_User;
+
+/**
+ * Acting As
+ *
+ * Used to authenticate a test suite/case as a specific user/role.
+ */
+#[Attribute]
+class Acting_As {
+	/**
+	 * Constructor.
+	 *
+	 * @param User|WP_User|string|int|null $user User to act as.
+	 */
+	public function __construct( public User|WP_User|string|int|null $user ) {}
+}

--- a/src/mantle/testing/concerns/trait-deprecations.php
+++ b/src/mantle/testing/concerns/trait-deprecations.php
@@ -10,6 +10,8 @@
 namespace Mantle\Testing\Concerns;
 
 use Mantle\Support\Str;
+use Mantle\Testing\Attributes\Expected_Deprecation;
+use Mantle\Testing\Attributes\Ignore_Deprecation;
 
 use function Mantle\Support\Helpers\collect;
 
@@ -62,6 +64,15 @@ trait Deprecations {
 		add_action( 'deprecated_function_trigger_error', '__return_false' ); // @phpstan-ignore-line Action callback returns false
 		add_action( 'deprecated_argument_trigger_error', '__return_false' ); // @phpstan-ignore-line Action callback returns false
 		add_action( 'deprecated_hook_trigger_error', '__return_false' ); // @phpstan-ignore-line Action callback returns false
+
+		// Allow attributes to define the expected and ignored deprecations.
+		foreach ( $this->get_attributes_for_method( Expected_Deprecation::class ) as $attribute ) {
+			$this->setExpectedDeprecated( $attribute->newInstance()->deprecation );
+		}
+
+		foreach ( $this->get_attributes_for_method( Ignore_Deprecation::class ) as $attribute ) {
+			$this->ignoreDeprecated( $attribute->newInstance()->deprecation );
+		}
 	}
 
 	/**
@@ -134,7 +145,7 @@ trait Deprecations {
 	 *                           parameter of the `_deprecated_function()` or
 	 *                           `_deprecated_argument()` call.
 	 */
-	public function setExpectedDeprecated( $deprecated ) {
+	public function setExpectedDeprecated( string $deprecated ) {
 		$this->expected_deprecated[] = $deprecated;
 	}
 

--- a/src/mantle/testing/concerns/trait-incorrect-usage.php
+++ b/src/mantle/testing/concerns/trait-incorrect-usage.php
@@ -10,6 +10,8 @@
 namespace Mantle\Testing\Concerns;
 
 use Mantle\Support\Str;
+use Mantle\Testing\Attributes\Expected_Incorrect_Usage;
+use Mantle\Testing\Attributes\Ignore_Incorrect_Usage;
 
 use function Mantle\Support\Helpers\collect;
 
@@ -64,6 +66,15 @@ trait Incorrect_Usage {
 
 		add_action( 'doing_it_wrong_run', [ $this, 'doing_it_wrong_run' ] ); // @phpstan-ignore-line Action callback returns false
 		add_action( 'doing_it_wrong_trigger_error', '__return_false' ); // @phpstan-ignore-line Action callback returns false
+
+		// Allow attributes to define the expected and ignored incorrect usages.
+		foreach ( $this->get_attributes_for_method( Expected_Incorrect_Usage::class ) as $attribute ) {
+			$this->setExpectedIncorrectUsage( $attribute->newInstance()->name );
+		}
+
+		foreach ( $this->get_attributes_for_method( Ignore_Incorrect_Usage::class ) as $attribute ) {
+			$this->ignoreIncorrectUsage( $attribute->newInstance()->name );
+		}
 	}
 
 	/**

--- a/src/mantle/testing/concerns/trait-reads-annotations.php
+++ b/src/mantle/testing/concerns/trait-reads-annotations.php
@@ -10,6 +10,7 @@ namespace Mantle\Testing\Concerns;
 use PHPUnit\Metadata\Annotation\Parser\DocBlock;
 use PHPUnit\Metadata\Annotation\Parser\Registry;
 use PHPUnit\Util\Test;
+use ReflectionClass;
 
 /**
  * Read annotations for testing that supports multiple versions of PHPUnit.
@@ -18,7 +19,7 @@ use PHPUnit\Util\Test;
  */
 trait Reads_Annotations {
 	/**
-	 * Read annotations for the current test case and method.
+	 * Read docblock annotations for the current test case and method.
 	 *
 	 * @return array
 	 */
@@ -53,5 +54,23 @@ trait Reads_Annotations {
 		);
 
 		return [];
+	}
+
+	/**
+	 * Read the attributes for the current test case and method.
+	 *
+	 * @param class-string<\Attribute> $name Filter the results to include only ReflectionAttribute instances for attributes matching this class name.
+	 * @return array<\ReflectionAttribute>
+	 */
+	public function get_attributes_for_method( ?string $name = null ): array {
+		$class = new ReflectionClass( $this );
+
+		// Use either the PHPUnit 9.5+ method or the PHPUnit 10.x method to get the method.
+		$method = $class->getMethod( method_exists( $this, 'getName' ) ? $this->getName() : $this->name() );
+
+		return [
+			...$class->getAttributes( $name ),
+			...$method->getAttributes( $name ),
+		];
 	}
 }

--- a/src/mantle/testing/concerns/trait-reads-annotations.php
+++ b/src/mantle/testing/concerns/trait-reads-annotations.php
@@ -59,7 +59,7 @@ trait Reads_Annotations {
 	/**
 	 * Read the attributes for the current test case and method.
 	 *
-	 * @param class-string<\Attribute> $name Filter the results to include only ReflectionAttribute instances for attributes matching this class name.
+	 * @param class-string $name Filter the results to include only ReflectionAttribute instances for attributes matching this class name.
 	 * @return array<\ReflectionAttribute>
 	 */
 	public function get_attributes_for_method( ?string $name = null ): array {

--- a/src/mantle/testing/concerns/trait-wordpress-authentication.php
+++ b/src/mantle/testing/concerns/trait-wordpress-authentication.php
@@ -11,11 +11,11 @@ namespace Mantle\Testing\Concerns;
 
 use Mantle\Database\Model\Model_Exception;
 use Mantle\Database\Model\User;
-use Mantle\Testing\Authentication\Acting_As;
+use Mantle\Testing\Attributes\Acting_As;
 use Mantle\Testing\Exceptions\Exception;
 use PHPUnit\Framework\Assert;
-use ReflectionClass;
 use WP_User;
+
 use function Mantle\Support\Helpers\get_user_object;
 
 /**

--- a/src/mantle/testing/concerns/trait-wordpress-authentication.php
+++ b/src/mantle/testing/concerns/trait-wordpress-authentication.php
@@ -11,15 +11,21 @@ namespace Mantle\Testing\Concerns;
 
 use Mantle\Database\Model\Model_Exception;
 use Mantle\Database\Model\User;
+use Mantle\Testing\Authentication\Acting_As;
 use Mantle\Testing\Exceptions\Exception;
 use PHPUnit\Framework\Assert;
+use ReflectionClass;
 use WP_User;
 use function Mantle\Support\Helpers\get_user_object;
 
 /**
  * Trait to provide authentication-related testing functionality.
+ *
+ * @mixin \PHPUnit\Framework\TestCase
  */
 trait WordPress_Authentication {
+	use Reads_Annotations;
+
 	/**
 	 * Backed up global user ID.
 	 *
@@ -32,6 +38,11 @@ trait WordPress_Authentication {
 	 */
 	public function wordpress_authentication_set_up() {
 		$this->backup_user = get_current_user_id();
+
+		// Set the test case up using the user from the attribute in descending order (class -> method).
+		foreach ( $this->get_attributes_for_method( Acting_As::class ) as $attribute ) {
+			$this->acting_as( $attribute->newInstance()->user );
+		}
 	}
 
 	/**

--- a/tests/Testing/Concerns/DeprecationsTest.php
+++ b/tests/Testing/Concerns/DeprecationsTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Mantle\Tests\Testing\Concerns;
 
+use Mantle\Testing\Attributes\Expected_Deprecation;
+use Mantle\Testing\Attributes\Ignore_Deprecation;
 use Mantle\Testing\Framework_Test_Case;
 
 /**
@@ -22,12 +24,27 @@ class DeprecationsTest extends Framework_Test_Case {
 		_deprecated_function( 'set_expected_within', '1.0.0', 'test_deprecation_within_test' );
 	}
 
+	#[Expected_Deprecation( 'expected_deprecation' )]
+	public function test_deprecation_expected_attribute() {
+		_deprecated_function( 'expected_deprecation', '1.0.0', 'test_deprecation_expected_attribute' );
+	}
+
 	public function test_ignore_specific_deprecation() {
 		$this->ignoreDeprecated( 'ignored_deprecation' );
 		$this->setExpectedDeprecated( 'expected_deprecation' );
 
 		_deprecated_function( 'ignored_deprecation', '1.0.0', 'test_ignore_specific_deprecation' );
 		_deprecated_function( 'expected_deprecation', '1.0.0', 'test_ignore_specific_deprecation' );
+	}
+
+	#[Ignore_Deprecation]
+	public function test_ignore_al_deprecation_attribute() {
+		_deprecated_function( 'ignored_deprecation', '1.0.0', 'test_ignore_specific_deprecation_attribute' );
+	}
+
+	#[Ignore_Deprecation( 'ignored_deprecation' )]
+	public function test_ignore_specific_deprecation_attribute() {
+		_deprecated_function( 'ignored_deprecation', '1.0.0', 'test_ignore_specific_deprecation_attribute' );
 	}
 
 	public function test_ignore_by_prefix() {

--- a/tests/Testing/Concerns/IncorrectUsageTest.php
+++ b/tests/Testing/Concerns/IncorrectUsageTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Mantle\Tests\Testing\Concerns;
 
+use Mantle\Testing\Attributes\Expected_Incorrect_Usage;
+use Mantle\Testing\Attributes\Ignore_Incorrect_Usage;
 use Mantle\Testing\Framework_Test_Case;
 
 /**
@@ -45,5 +47,20 @@ class IncorrectUsageTest extends Framework_Test_Case {
 
 		_doing_it_wrong( 'ignored_incorrect_usage', 'This is a test', '1.0.0' );
 		_doing_it_wrong( 'expected_incorrect_usage', 'This is a test', '1.0.0' );
+	}
+
+	#[Expected_Incorrect_Usage( 'expected_incorrect_usage' )]
+	public function test_expected_by_attribute() {
+		_doing_it_wrong( 'expected_incorrect_usage', 'This is a test', '1.0.0' );
+	}
+
+	#[Ignore_Incorrect_Usage]
+	public function test_ignore_by_attribute() {
+		_doing_it_wrong( 'ignored_incorrect_usage', 'This is a test', '1.0.0' );
+	}
+
+	#[Ignore_Incorrect_Usage( 'ignored_incorrect_usage' )]
+	public function test_ignore_specific_by_attribute() {
+		_doing_it_wrong( 'ignored_incorrect_usage', 'This is a test', '1.0.0' );
 	}
 }

--- a/tests/Testing/Concerns/WordPressAuthenticationTest.php
+++ b/tests/Testing/Concerns/WordPressAuthenticationTest.php
@@ -1,9 +1,7 @@
 <?php
 namespace Mantle\Tests\Concerns;
 
-use Mantle\Console\Command;
-use Mantle\Facade\Console;
-use Mantle\Testing\Authentication\Acting_As;
+use Mantle\Testing\Attributes\Acting_As;
 use Mantle\Testing\Framework_Test_Case;
 
 /**

--- a/tests/Testing/Concerns/WordPressAuthenticationTest.php
+++ b/tests/Testing/Concerns/WordPressAuthenticationTest.php
@@ -3,6 +3,7 @@ namespace Mantle\Tests\Concerns;
 
 use Mantle\Console\Command;
 use Mantle\Facade\Console;
+use Mantle\Testing\Authentication\Acting_As;
 use Mantle\Testing\Framework_Test_Case;
 
 /**
@@ -36,5 +37,11 @@ class WordPressAuthenticationTest extends Framework_Test_Case {
 	public function test_acting_as_anonymous() {
 		$this->assertNotAuthenticated();
 		$this->assertGuest();
+	}
+
+	#[Acting_As( 'administrator' )]
+	public function test_attribute_authentication() {
+		$this->assertAuthenticated();
+		$this->assertAuthenticated( 'administrator' );
 	}
 }


### PR DESCRIPTION
Allows for WP Authentication, Deprecated Usage, and Incorrect Usage to be defined on a class/method with an attribute during testing.