### PR TITLE
Assorted bugs when using WordPress core test framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.1 - 2024-04-09
+
+### Fixed
+
+- Changed the timing of the `set_up` method being called in tests to be after
+  the database transaction is started.
+- Allow other use of the `pre_http_request` filter when preventing external
+	requests during testing.
+- Fixed an issue with the streamed HTTP response not being converted to a
+  `WP_Error` when needed.
+
 ## v1.0.0 - 2024-04-04
 
 ### Added

--- a/src/mantle/console/concerns/trait-interacts-with-io.php
+++ b/src/mantle/console/concerns/trait-interacts-with-io.php
@@ -424,8 +424,6 @@ trait Interacts_With_IO {
 
 	/**
 	 * Retrieve the output interface.
-	 *
-	 * @return OutputInterface|Output_Style
 	 */
 	public function output(): OutputInterface|Output_Style {
 		return $this->output;

--- a/src/mantle/events/trait-wordpress-action.php
+++ b/src/mantle/events/trait-wordpress-action.php
@@ -176,7 +176,7 @@ trait WordPress_Action {
 			throw new RuntimeException( $type::class . ' is not a supported type-hint.' );
 		}
 
-		if ( $type instanceof ReflectionNamedType && $argument_type === $type->getName() ) {
+		if ( $argument_type === $type->getName() ) {
 			return $argument;
 		}
 

--- a/src/mantle/testing/class-test-case.php
+++ b/src/mantle/testing/class-test-case.php
@@ -141,11 +141,6 @@ abstract class Test_Case extends BaseTestCase {
 
 		parent::setUp();
 
-		// Call the PHPUnit 8 'set_up' method if it exists.
-		if ( method_exists( $this, 'set_up' ) ) {
-			$this->set_up();
-		}
-
 		if ( ! isset( $this->app ) ) {
 			$this->refresh_application();
 		}
@@ -171,6 +166,11 @@ abstract class Test_Case extends BaseTestCase {
 
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 		add_filter( 'wp_die_handler', [ WP_Die::class, 'get_handler' ] );
+
+		// Call the PHPUnit 8 'set_up' method if it exists.
+		if ( method_exists( $this, 'set_up' ) ) {
+			$this->set_up();
+		}
 	}
 
 	/**
@@ -231,6 +231,7 @@ abstract class Test_Case extends BaseTestCase {
 
 		parent::tearDown();
 
+		// Reset the application instance after everything else.
 		if ( $this->app ) {
 			$this->app = null;
 


### PR DESCRIPTION
## v1.0.1 - 2024-04-09

### Fixed

- Changed the timing of the `set_up` method being called in tests to be after
  the database transaction is started.
- Allow other use of the `pre_http_request` filter when preventing external
	requests during testing.
- Fixed an issue with the streamed HTTP response not being converted to a
  `WP_Error` when needed.