### PR TITLE
Allow anonymous models to define events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prevent sending mail during the install `wp_install()` call in unit tests by
   mocking the `$phpmailer` global earlier.
+- Allow anonymous models to define events via `Model::created()` methods.
 
 ## v1.0.6 - 2024-04-19
 

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -181,6 +181,9 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 	 */
 	public static function for( string $post_type ): self {
 		$instance = new class() extends Post {
+			/**
+			 * Constructor.
+			 */
 			public function __construct() {}
 
 			/**

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -181,6 +181,8 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 	 */
 	public static function for( string $post_type ): self {
 		$instance = new class() extends Post {
+			public function __construct() {}
+
 			/**
 			 * Post type for the model.
 			 */
@@ -192,9 +194,23 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 			public static function get_object_name(): ?string {
 				return static::$for_object_name;
 			}
+
+			/**
+			 * Boot the model if it has not been booted.
+			 *
+			 * Prevent booting the model unless the object name is set.
+			 */
+			public static function boot_if_not_booted(): void {
+				if ( empty( static::$for_object_name ) ) {
+					return;
+				}
+
+				parent::boot_if_not_booted();
+			}
 		};
 
 		$instance::$for_object_name = $post_type;
+		$instance::boot_if_not_booted();
 
 		return $instance;
 	}

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -60,6 +60,15 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	];
 
 	/**
+	 * Object type for the model when registering the taxonomy.
+	 *
+	 * Used to associate a taxonomy with another object (post type).
+	 *
+	 * @var string[]
+	 */
+	protected static $object_types = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @param mixed $object Model object.
@@ -112,24 +121,12 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 			public function __construct() {}
 
 			/**
-			 * Object name.
-			 */
-			public static string $for_object_name = '';
-
-			/**
-			 * Retrieve the object name.
-			 */
-			public static function get_object_name(): ?string {
-				return static::$for_object_name;
-			}
-
-			/**
 			 * Boot the model if it has not been booted.
 			 *
 			 * Prevent booting the model unless the object name is set.
 			 */
 			public static function boot_if_not_booted(): void {
-				if ( empty( static::$for_object_name ) ) {
+				if ( empty( static::$object_name ) ) {
 					return;
 				}
 
@@ -137,7 +134,7 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 			}
 		};
 
-		$instance::$for_object_name = $taxonomy;
+		$instance::$object_name = $taxonomy;
 		$instance::boot_if_not_booted();
 
 		return $instance;

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -106,6 +106,9 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	 */
 	public static function for( string $taxonomy ): self {
 		$instance = new class() extends Term {
+			/**
+			 * Constructor.
+			 */
 			public function __construct() {}
 
 			/**

--- a/src/mantle/database/model/class-term.php
+++ b/src/mantle/database/model/class-term.php
@@ -106,6 +106,8 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 	 */
 	public static function for( string $taxonomy ): self {
 		$instance = new class() extends Term {
+			public function __construct() {}
+
 			/**
 			 * Object name.
 			 */
@@ -117,9 +119,23 @@ class Term extends Model implements Core_Object, Model_Meta, Updatable {
 			public static function get_object_name(): ?string {
 				return static::$for_object_name;
 			}
+
+			/**
+			 * Boot the model if it has not been booted.
+			 *
+			 * Prevent booting the model unless the object name is set.
+			 */
+			public static function boot_if_not_booted(): void {
+				if ( empty( static::$for_object_name ) ) {
+					return;
+				}
+
+				parent::boot_if_not_booted();
+			}
 		};
 
 		$instance::$for_object_name = $taxonomy;
+		$instance::boot_if_not_booted();
 
 		return $instance;
 	}

--- a/src/mantle/database/model/events/trait-post-events.php
+++ b/src/mantle/database/model/events/trait-post-events.php
@@ -37,6 +37,7 @@ trait Post_Events {
 
 				$updating = ! empty( $postarr['ID'] );
 				$model    = static::find( $postarr['ID'] );
+
 				if ( ! $model ) {
 					return;
 				}

--- a/tests/Database/Model/PostModelEventsTest.php
+++ b/tests/Database/Model/PostModelEventsTest.php
@@ -15,6 +15,12 @@ class PostModelEventsTest extends Framework_Test_Case {
 		Testable_Model_Event::boot_post_events();
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unregister_post_type( 'test-post-type' );
+	}
+
 	public function test_closure_event() {
 		$_SERVER['__test_creating_event_fired'] = false;
 		$_SERVER['__test_created_event_fired'] = false;

--- a/tests/Database/Model/PostModelEventsTest.php
+++ b/tests/Database/Model/PostModelEventsTest.php
@@ -108,6 +108,40 @@ class PostModelEventsTest extends Framework_Test_Case {
 		$this->assertTrue( $_SERVER['__test_non_model_created_event_fired'] < $_SERVER['__test_non_model_updated_event_fired'] );
 		$this->assertTrue( $_SERVER['__test_non_model_updated_event_fired'] < $_SERVER['__test_non_model_deleted_event_fired'] );
 	}
+
+	public function test_model_event_via_for() {
+		$_SERVER['__test_model_event_via_for_created_event_fired'] = false;
+		$_SERVER['__test_model_event_via_for_updated_event_fired'] = false;
+		$_SERVER['__test_model_event_via_for_deleted_event_fired'] = false;
+
+		register_post_type( 'test-post-type', [ 'public' => true ] );
+
+		$model = Post::for( 'test-post-type' );
+
+		$model->created( fn () => $_SERVER['__test_model_event_via_for_created_event_fired'] = microtime( true ) );
+		$model->updated( fn () => $_SERVER['__test_model_event_via_for_updated_event_fired'] = microtime( true ) );
+		$model->deleted( fn () => $_SERVER['__test_model_event_via_for_deleted_event_fired'] = microtime( true ) );
+
+		$post_id = \wp_insert_post(
+			[
+				'post_type' => 'test-post-type',
+				'post_title' => 'Inserted By Hand',
+			]
+		);
+
+		wp_update_post(
+			[
+				'ID'         => $post_id,
+				'post_title' => 'Updated Title',
+			]
+		);
+
+		wp_delete_post( $post_id, true );
+
+		$this->assertNotEmpty( $_SERVER['__test_model_event_via_for_created_event_fired'] );
+		$this->assertNotEmpty( $_SERVER['__test_model_event_via_for_updated_event_fired'] );
+		$this->assertNotEmpty( $_SERVER['__test_model_event_via_for_deleted_event_fired'] );
+	}
 }
 
 class Testable_Model_Event extends Post {

--- a/tests/Database/Model/TermModelEventsTest.php
+++ b/tests/Database/Model/TermModelEventsTest.php
@@ -15,6 +15,12 @@ class TermModelEventsTest extends Framework_Test_Case {
 		Testable_Term_Model_Event::boot_term_events();
 	}
 
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unregister_taxonomy( 'test-taxonomy' );
+	}
+
 	public function test_closure_event() {
 		$_SERVER['__test_creating_event_fired'] = false;
 		$_SERVER['__test_created_event_fired'] = false;

--- a/tests/Database/Model/TermModelEventsTest.php
+++ b/tests/Database/Model/TermModelEventsTest.php
@@ -94,6 +94,37 @@ class TermModelEventsTest extends Framework_Test_Case {
 		$this->assertTrue( $_SERVER['__test_non_model_created_event_fired'] < $_SERVER['__test_non_model_updated_event_fired'] );
 		$this->assertTrue( $_SERVER['__test_non_model_updated_event_fired'] < $_SERVER['__test_non_model_deleted_event_fired'] );
 	}
+
+	public function test_model_event_via_for() {
+		$_SERVER['__test_model_event_via_for_created_event_fired'] = false;
+		$_SERVER['__test_model_event_via_for_updated_event_fired'] = false;
+		$_SERVER['__test_model_event_via_for_deleted_event_fired'] = false;
+
+		register_taxonomy( 'test-taxonomy', 'post' );
+
+		$model = Term::for( 'test-taxonomy' );
+
+		$model->created( fn () => $_SERVER['__test_model_event_via_for_created_event_fired'] = microtime( true ) );
+		$model->updated( fn () => $_SERVER['__test_model_event_via_for_updated_event_fired'] = microtime( true ) );
+		$model->deleted( fn () => $_SERVER['__test_model_event_via_for_deleted_event_fired'] = microtime( true ) );
+
+		$insert  = \wp_insert_term( 'Inserted Term', 'test-taxonomy' );
+		$term_id = $insert['term_id'];
+
+		\wp_update_term(
+			$term_id,
+			'test-taxonomy',
+			[
+				'name' => 'Updated Title',
+			]
+		);
+
+		wp_delete_term( $term_id, 'test-taxonomy' );
+
+		$this->assertNotEmpty( $_SERVER['__test_model_event_via_for_created_event_fired'] );
+		$this->assertNotEmpty( $_SERVER['__test_model_event_via_for_updated_event_fired'] );
+		$this->assertNotEmpty( $_SERVER['__test_model_event_via_for_deleted_event_fired'] );
+	}
 }
 
 class Testable_Term_Model_Event extends Term {

--- a/tests/Database/Model/registration/RegisterTaxonomyTest.php
+++ b/tests/Database/Model/registration/RegisterTaxonomyTest.php
@@ -14,6 +14,7 @@ class RegisterTaxonomyTest extends Framework_Test_Case {
 
 	protected function tearDown(): void {
 		parent::tearDown();
+		unregister_taxonomy( 'test-taxonomy' );
 		m::close();
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,8 @@ define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 // Enable debugging flag for local development on the testing framework.
 // define( 'MANTLE_TESTING_DEBUG', true );
 
+(new \NunoMaduro\Collision\Provider)->register();
+
 \Mantle\Testing\manager()
 	->maybe_rsync_plugin()
 	->with_vip_mu_plugins()


### PR DESCRIPTION
For use during testing, make it possible for anonymous models to define events.