### PR TITLE
Close output buffer when exception occurs during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v1.3.1 - 2024-12-13
+
+### Fixed
+
+- Fixed issue where output buffers were left open when an exception occurred during setup.
+
 ## v1.3.0 - 2024-12-02
 
 ### Added

--- a/src/mantle/testing/class-pending-testable-request.php
+++ b/src/mantle/testing/class-pending-testable-request.php
@@ -219,12 +219,14 @@ class Pending_Testable_Request {
 	/**
 	 * Call the given URI and return the Response.
 	 *
+	 * @throws \Exception Exceptions thrown while setting up the WordPress query are re-thrown to the caller.
+	 *
 	 * @param string      $method     Request method.
 	 * @param mixed       $uri        Request URI.
 	 * @param array       $parameters Request params.
 	 * @param array       $server     Server vars.
-	 * @param array       $cookies Cookies to be sent with the request.
-	 * @param string|null $content Request content.
+	 * @param array       $cookies    Cookies to be sent with the request.
+	 * @param string|null $content    Request content.
 	 */
 	public function call( string $method, mixed $uri, array $parameters = [], array $server = [], array $cookies = [], ?string $content = null ): Test_Response {
 		$this->reset_request_state();
@@ -323,7 +325,13 @@ class Pending_Testable_Request {
 
 			ob_start();
 
-			$this->setup_wordpress_query();
+			try {
+				$this->setup_wordpress_query();
+			} catch ( \Exception $e ) {
+				// If an exception occurs, make sure the output buffer is closed before the exception continues to the caller.
+				ob_end_clean();
+				throw $e;
+			}
 
 			if ( $this->rest_api_response ) {
 				// Use the response from the REST API server.


### PR DESCRIPTION
We have a test that makes a `GET` request and expects an exception to be thrown during the `parse_request` action, which fires as part of`Pending_Testable_Request::setup_wordpress_query()`. 

The exception is thrown, but the output buffer started just before then remains open, leading to a PHPUnit "risky test" warning: `Test code or tested code did not (only) close its own output buffers`. This PR makes sure the buffer is closed.