### PR TITLE
Allow object-cache.php to not be being loaded locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add a `without_local_object_cache()` method to prevent the `object-cache.php` drop-in from being loaded locally.
+
 ### Changed
 
 - Disable `spatie/once`'s cache if found during unit testing.

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -438,6 +438,19 @@ class Utils {
 	}
 
 	/**
+	 * Check if we're running in a CI (Continuous Integration) environment.
+	 */
+	public static function is_ci(): bool {
+		return (
+			! empty( $_SERVER['GITHUB_ENV'] )
+			|| ( ! empty( $_SERVER['CI'] ) && in_array( $_SERVER['CI'], [ 'true', '1' ], true ) )
+			|| ! empty( $_SERVER['GITHUB_REPOSITORY_OWNER'] )
+			|| ! empty( $_SERVER['GITHUB_WORKFLOW'] )
+			|| ! empty( $_SERVER['GITHUB_EVENT_NAME'] )
+		);
+	}
+
+	/**
 	 * Run a system command and return the output.
 	 *
 	 * @param string|string[] $command Command to run.

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -216,6 +216,7 @@ trait Rsync_Installation {
 	 * Skip the local object cache when running the tests.
 	 *
 	 * Useful for local development where the object cache may be causing issues.
+	 * Will not disable the object cache drop-in when run in GitHub Actions.
 	 *
 	 * @param bool $skip Whether to skip the local object cache.
 	 */

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -213,6 +213,19 @@ trait Rsync_Installation {
 	}
 
 	/**
+	 * Skip the local object cache when running the tests.
+	 *
+	 * Useful for local development where the object cache may be causing issues.
+	 *
+	 * @param bool $skip Whether to skip the local object cache.
+	 */
+	public function without_local_object_cache( bool $skip = true ): static {
+		putenv( 'MANTLE_SKIP_LOCAL_OBJECT_CACHE=' . ( $skip ? '1' : '0' ) );
+
+		return $this;
+	}
+
+	/**
 	 * Install SQLite db.php drop-in into the codebase.
 	 *
 	 * This will only be applied if the codebase is being rsync-ed to a WordPress

--- a/src/mantle/testing/install-wordpress.php
+++ b/src/mantle/testing/install-wordpress.php
@@ -1,8 +1,6 @@
 <?php // phpcs:disable
 /**
- * Installs WordPress for the purpose of the unit-tests
- *
- * @todo Reuse the init/load code in init.php
+ * Installs WordPress for the purpose of the unit-tests.
  */
 
 use Mantle\Testing\Utils;

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -211,10 +211,13 @@ tests_add_filter( 'vip_mu_plugins_loaded', function (): void {
 } );
 
 // Disable the object-cache.php drop if the MANTLE_SKIP_LOCAL_OBJECT_CACHE
-// environment variable is set. This should only apply locally and not when run
-// through GitHub Actions.
+// environment variable is set.
 tests_add_filter( 'enable_loading_object_cache_dropin', function ( $enable_object_cache ) {
-	if ( Utils::env_bool( 'MANTLE_SKIP_LOCAL_OBJECT_CACHE', false ) ) {
+	if ( Utils::env_bool( 'MANTLE_SKIP_LOCAL_OBJECT_CACHE', false ) && ! Utils::is_ci() ) {
+		if ( Utils::is_debug_mode() ) {
+			Utils::info( 'Skipping local object cache drop-in.' );
+		}
+
 		return false;
 	}
 
@@ -234,7 +237,7 @@ if ( isset( $_SERVER['REQUEST_TIME_FLOAT'] ) ) {
 	$_SERVER['REQUEST_TIME_FLOAT'] = (float) $_SERVER['REQUEST_TIME_FLOAT'];
 }
 
-// Disable VIP's alloptions protections during unit testing.
+// Remove the disabling of VIP's alloptions protections during unit testing.
 remove_filter( 'pre_wp_load_alloptions', 'Automattic\\VIP\\Core\\OptionsAPI\\pre_wp_load_alloptions_protections', 999 );
 
 // Delete any default posts & related data.

--- a/src/mantle/testing/wordpress-bootstrap.php
+++ b/src/mantle/testing/wordpress-bootstrap.php
@@ -210,6 +210,17 @@ tests_add_filter( 'vip_mu_plugins_loaded', function (): void {
 	remove_filter( 'pre_wp_load_alloptions', 'Automattic\\VIP\\Core\\OptionsAPI\\pre_wp_load_alloptions_protections', 999 );
 } );
 
+// Disable the object-cache.php drop if the MANTLE_SKIP_LOCAL_OBJECT_CACHE
+// environment variable is set. This should only apply locally and not when run
+// through GitHub Actions.
+tests_add_filter( 'enable_loading_object_cache_dropin', function ( $enable_object_cache ) {
+	if ( Utils::env_bool( 'MANTLE_SKIP_LOCAL_OBJECT_CACHE', false ) ) {
+		return false;
+	}
+
+	return $enable_object_cache;
+} );
+
 // Load WordPress.
 require_once ABSPATH . '/wp-settings.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,9 +14,6 @@ define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 // Enable debugging flag for local development on the testing framework.
 // define( 'MANTLE_TESTING_DEBUG', true );
 
-// List all environment variables.
-dd( $_ENV, $_SERVER );
-
 \Mantle\Testing\manager()
 	->maybe_rsync_plugin()
 	->with_vip_mu_plugins()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,11 +14,13 @@ define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 // Enable debugging flag for local development on the testing framework.
 // define( 'MANTLE_TESTING_DEBUG', true );
 
-( new \NunoMaduro\Collision\Provider() )->register();
+// List all environment variables.
+dd( $_ENV, $_SERVER );
 
 \Mantle\Testing\manager()
 	->maybe_rsync_plugin()
 	->with_vip_mu_plugins()
 	->install_plugin( 'logger', 'https://github.com/alleyinteractive/logger/archive/refs/heads/develop.zip' )
 	->install_plugin( 'jetpack', '12.4' )
+	->without_local_object_cache()
 	->install();


### PR DESCRIPTION
Adds a `without_local_object_cache()` method to the installation manager that will prevent the `object-cache.php` drop-in from being loaded locally.

Resolves #609 