### PR TITLE
Remove `--no-compress` option

### DIFF
--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -436,7 +436,7 @@ trait Rsync_Installation {
 		// Rsync the from folder to the destination.
 		$output = Utils::command(
 			[
-				'rsync -aWq --no-compress',
+				'rsync -aWq',
 				collect( $this->rsync_exclusions )->map( fn ( $exclusion ) => "--exclude '{$exclusion}'" )->implode( ' ' ),
 				'--delete',
 				"{$this->rsync_from} {$this->rsync_to}",


### PR DESCRIPTION
The `--no-compress` flag for the `rsync` command does not exist in newer versions of rsync on OSX 10.x.

See https://github.com/saltstack/salt/issues/36829