### PR TITLE
Fix issue with model::for() not actually creating a post/term for the post type/taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed bad configuration file caling `env()` vs `environment()`.
+- Fixed bad configuration file calling `env()` vs `environment()`.
 
 ## v1.5.1 - 2025-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.5.4 - 2025-03-06
+
+### Fixed
+
+- Fix the `Post::for()`/`Term::for()` methods to properly set the post
+  type/taxonomy for the model when creating a new instance. Previously, the
+  model would always be created with the default post type/taxonomy.
+
 ## v1.5.3 - 2025-03-04
 
 ### Changed

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,6 +19,8 @@ parameters:
 		-
 			identifier: requireOnce.fileNotFound
 		-
+			identifier: unset.possiblyHookedProperty
+		-
 			identifier: function.alreadyNarrowedType
 			paths:
 				- src/mantle/support

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -8,12 +8,9 @@
 namespace Mantle\Database\Model;
 
 use Carbon\Carbon;
-use DateTime;
 use DateTimeInterface;
-use GuzzleHttp\Handler\Proxy;
 use Mantle\Contracts;
 use Mantle\Database\Model\Relations\Belongs_To;
-use Mantle\Database\Model\Relations\Has_One;
 use Mantle\Database\Query\Builder;
 use Mantle\Database\Query\Post_Query_Builder;
 use Mantle\Support\Helpers;

--- a/src/mantle/database/model/class-post.php
+++ b/src/mantle/database/model/class-post.php
@@ -10,12 +10,15 @@ namespace Mantle\Database\Model;
 use Carbon\Carbon;
 use DateTime;
 use DateTimeInterface;
+use GuzzleHttp\Handler\Proxy;
 use Mantle\Contracts;
 use Mantle\Database\Model\Relations\Belongs_To;
 use Mantle\Database\Model\Relations\Has_One;
 use Mantle\Database\Query\Builder;
 use Mantle\Database\Query\Post_Query_Builder;
 use Mantle\Support\Helpers;
+
+use function Mantle\Support\Helpers\stringable;
 
 /**
  * Post Model
@@ -182,43 +185,28 @@ class Post extends Model implements Contracts\Database\Core_Object, Contracts\Da
 	 *
 	 * @param string $post_type Post type to create the model for.
 	 */
-	public static function for( string $post_type ): self {
-		$instance = new class() extends Post {
-			/**
-			 * Constructor.
-			 */
-			public function __construct() {}
+	public static function for( string $post_type ): Post {
+		$post_type  = sanitize_key( $post_type );
+		$class_name = 'Post_' . stringable( $post_type )->studly()->replace( '-', '_' )->__toString();
+		$namespace  = __NAMESPACE__;
 
-			/**
-			 * Post type for the model.
-			 */
-			public static string $for_object_name = '';
+		if ( ! class_exists( "{$namespace}\\{$class_name}" ) ) {
+			// Similar to how Mockery creates classes on the fly for testing. No other
+			// solution was found to create a class on the fly.
+			eval( // phpcs:ignore Squiz.PHP.Eval.Discouraged
+				<<<PHP
+namespace {$namespace} {
+	class {$class_name} extends Post {
+		public static \$object_name = '{$post_type}';
+	}
+}
+PHP
+			);
+		}
 
-			/**
-			 * Retrieve the object name.
-			 */
-			public static function get_object_name(): string {
-				return self::$for_object_name;
-			}
+		$full_class_name = "{$namespace}\\{$class_name}";
 
-			/**
-			 * Boot the model if it has not been booted.
-			 *
-			 * Prevent booting the model unless the object name is set.
-			 */
-			public static function boot_if_not_booted(): void {
-				if ( empty( self::$for_object_name ) ) {
-					return;
-				}
-
-				parent::boot_if_not_booted();
-			}
-		};
-
-		$instance::$for_object_name = $post_type;
-		$instance::boot_if_not_booted();
-
-		return $instance;
+		return new $full_class_name();
 	}
 
 	/**

--- a/tests/Database/Model/PostObjectTest.php
+++ b/tests/Database/Model/PostObjectTest.php
@@ -253,13 +253,27 @@ class PostObjectTest extends Framework_Test_Case {
 
 		$this->assertEquals( 'foo_post_type', get_post_type( $post_id ) );
 
+		$dynamic_model = Post::for( 'foo_post_type' );
+
 		$this->assertEmpty( Post::find( $post_id ) );
-		$this->assertInstanceOf( Post::class, Post::for( 'foo_post_type' ) );
-		$this->assertEquals( $post_id, Post::for( 'foo_post_type' )->find( $post_id )->id() );
+		$this->assertInstanceOf( Post::class, $dynamic_model );
+		$this->assertEquals( $post_id, $dynamic_model->find( $post_id )->id() );
 		$this->assertEquals(
 			$post_two,
-			Post::for( 'foo_post_type' )->where( 'title', 'Post Two' )->first()->id(),
+			$dynamic_model->where( 'title', 'Post Two' )->first()->id(),
 		);
+
+		// Test creating a post via the dynamic model.
+		$new_post = $dynamic_model->create(
+			[
+				'post_title' => 'New Post',
+			]
+		);
+
+		$post = get_post( $new_post->id() );
+
+		$this->assertEquals( 'foo_post_type', $post->post_type );
+		$this->assertEquals( 'New Post', $post->post_title );
 	}
 
 	public function test_query_builder() {


### PR DESCRIPTION
Fixes an issue where `Post::for($post_type)` wouldn't create a post for an underlying post in that custom post type. This was due to a limitation with PHP's anonymous classes. I did spend a lot of time trying to find another way to write this that didn't need `eval()` but had no luck. The Mockery PHP package creates classes on-the-fly using `eval()` in a similar fashion to create mocks.