### PR TITLE
Allow on-the-fly Blade rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `Blade` facade with `Blade::render_string()` method to render a string
+  using the Blade templating engine.
+
 ### Changed
 
 - Various types added to the framework to support increasing PHPStan to level 6.

--- a/src/mantle/contracts/http/view/interface-factory.php
+++ b/src/mantle/contracts/http/view/interface-factory.php
@@ -70,7 +70,7 @@ interface Factory {
 	 *                           $variables is not used.
 	 * @param array        $variables Variables for the view, optional.
 	 */
-	public function make( string $slug, $name = null, array $variables = [] ): View;
+	public function make( string $slug, array|string|null $name = null, array $variables = [] ): View;
 
 	/**
 	 * Get a variable from the current view.

--- a/src/mantle/contracts/http/view/interface-factory.php
+++ b/src/mantle/contracts/http/view/interface-factory.php
@@ -17,20 +17,18 @@ interface Factory {
 	/**
 	 * Add a piece of shared data to the environment.
 	 *
-	 * @param array|string $key Key to share.
-	 * @param mixed|null   $value Value to share.
-	 * @return mixed
+	 * @param array<string, mixed>|string $key Key to share.
+	 * @param mixed|null                  $value Value to share.
 	 */
-	public function share( $key, $value = null );
+	public function share( array|string $key, mixed $value = null ): void;
 
 	/**
 	 * Get an item from the shared data.
 	 *
 	 * @param string $key Key to get item by.
 	 * @param mixed  $default Default value.
-	 * @return mixed
 	 */
-	public function shared( $key, $default = null );
+	public function shared( string $key, mixed $default = null ): mixed;
 
 	/**
 	 * Get all of the shared data for the environment.

--- a/src/mantle/facade/class-blade.php
+++ b/src/mantle/facade/class-blade.php
@@ -12,7 +12,6 @@ use Mantle\View\Engines\Blade_Engine;
 /**
  * Blade Facade
  *
- * @method static void compile(string|null $path = null)
  * @method static string getPath()
  * @method static void setPath(string $path)
  * @method static string compileString(string $value)
@@ -64,7 +63,6 @@ class Blade extends Facade {
 	 * Alias for compileString().
 	 *
 	 * @param string $value The string to compile.
-	 * @return string
 	 */
 	public static function compile_string( string $value ): string {
 		return static::compileString( $value );
@@ -77,7 +75,11 @@ class Blade extends Facade {
 	 * @param array<string, mixed> $data The data to pass to the view.
 	 */
 	public static function render_string( string $template, array $data = [] ): string {
-		$blade_engine = static::$app['view.engine.resolver']->resolve( 'blade' );
+		$resolver = static::$app['view.engine.resolver'];
+
+		assert( $resolver instanceof \Mantle\View\Engines\Engine_Resolver );
+
+		$blade_engine = $resolver->resolve( 'blade' );
 
 		assert( $blade_engine instanceof Blade_Engine );
 

--- a/src/mantle/facade/class-blade.php
+++ b/src/mantle/facade/class-blade.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Cache Facade class file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Facade;
+
+use Mantle\View\Engines\Blade_Engine;
+
+/**
+ * Blade Facade
+ *
+ * @method static void compile(string|null $path = null)
+ * @method static string getPath()
+ * @method static void setPath(string $path)
+ * @method static string compileString(string $value)
+ * @method static string stripParentheses(string $expression)
+ * @method static void extend(callable $compiler)
+ * @method static array getExtensions()
+ * @method static void if(string $name, callable $callback)
+ * @method static bool check(string $name, mixed ...$parameters)
+ * @method static array getClassComponentAliases()
+ * @method static void anonymousComponentPath(string $path, string|null $prefix = null)
+ * @method static void anonymousComponentNamespace(string $directory, string|null $prefix = null)
+ * @method static array getAnonymousComponentPaths()
+ * @method static array getAnonymousComponentNamespaces()
+ * @method static array getClassComponentNamespaces()
+ * @method static void aliasComponent(string $path, string|null $alias = null)
+ * @method static void include(string $path, string|null $alias = null)
+ * @method static void aliasInclude(string $path, string|null $alias = null)
+ * @method static void bindDirective(string $name, callable $handler)
+ * @method static void directive(string $name, callable $handler, bool $bind = false)
+ * @method static array getCustomDirectives()
+ * @method static \Illuminate\View\Compilers\BladeCompiler prepareStringsForCompilationUsing(callable $callback)
+ * @method static void precompiler(callable $precompiler)
+ * @method static void setEchoFormat(string $format)
+ * @method static void withDoubleEncoding()
+ * @method static void withoutDoubleEncoding()
+ * @method static void withoutComponentTags()
+ * @method static string getCompiledPath(string $path)
+ * @method static bool isExpired(string $path)
+ * @method static string newComponentHash(string $component)
+ * @method static string compileClassComponentOpening(string $component, string $alias, string $data, string $hash)
+ * @method static string compileEndComponentClass()
+ * @method static mixed sanitizeComponentAttribute(mixed $value)
+ * @method static string compileEndOnce()
+ * @method static void stringable(string|callable $class, callable|null $handler = null)
+ * @method static string compileEchos(string $value)
+ * @method static string applyEchoHandler(string $value)
+ *
+ * @see \Illuminate\View\Compilers\BladeCompiler
+ */
+class Blade extends Facade {
+	/**
+	 * Facade Accessor
+	 */
+	protected static function get_facade_accessor(): string {
+		return 'blade.compiler';
+	}
+
+	/**
+	 * Alias for compileString().
+	 *
+	 * @param string $value The string to compile.
+	 * @return string
+	 */
+	public static function compile_string( string $value ): string {
+		return static::compileString( $value );
+	}
+
+	/**
+	 * Render a Blade template dynamically from a string.
+	 *
+	 * @param string               $template The uncompiled Blade template.
+	 * @param array<string, mixed> $data The data to pass to the view.
+	 */
+	public static function render_string( string $template, array $data = [] ): string {
+		$blade_engine = static::$app['view.engine.resolver']->resolve( 'blade' );
+
+		assert( $blade_engine instanceof Blade_Engine );
+
+		return $blade_engine->render_string( $template, $data );
+	}
+}

--- a/src/mantle/facade/class-route.php
+++ b/src/mantle/facade/class-route.php
@@ -51,7 +51,7 @@ namespace Mantle\Facade;
  * @method static \Mantle\Http\Routing\Route_Registrar attribute(string $key, mixed $value)
  * @method static \Mantle\Http\Routing\Route_Registrar as(string $value)
  * @method static \Mantle\Http\Routing\Route_Registrar domain(string $value)
- * @method static \Mantle\Http\Routing\Route_Registrar middleware(array|string|null $middleware)
+ * @method static \Mantle\Http\Routing\Route_Registrar middleware(array<class-string>|string|callable|null $middleware)
  * @method static \Mantle\Http\Routing\Route_Registrar name(string $value)
  * @method static \Mantle\Http\Routing\Route_Registrar namespace(string $value)
  * @method static \Mantle\Http\Routing\Route_Registrar prefix(string $value)

--- a/src/mantle/facade/class-view-loader.php
+++ b/src/mantle/facade/class-view-loader.php
@@ -12,14 +12,12 @@ namespace Mantle\Facade;
  *
  * @method static \Mantle\Http\View\View_Finder add_extension(string $extension)
  * @method static string[] get_extensions()
- * @method static void set_default_paths()
  * @method static \Mantle\Http\View\View_Finder add_path(string $path, string $alias = null)
  * @method static \Mantle\Http\View\View_Finder remove_path(string $path)
- * @method static array get_paths()
+ * @method static array<string> get_paths()
  * @method static \Mantle\Http\View\View_Finder clear_paths()
  * @method static string find(string $slug, string $name = null)
- * @method static string locate_template(array $templates, string $alias = null)
- * @method static string[] get_possible_view_files(string $name)
+ * @method static bool has_hint_information(string $alias)
  *
  * @see \Mantle\Http\View\View_Finder
  */

--- a/src/mantle/filesystem/class-filesystem.php
+++ b/src/mantle/filesystem/class-filesystem.php
@@ -210,7 +210,7 @@ class Filesystem {
 	 * @param  string   $path
 	 * @param  int|null $mode
 	 */
-	public function chmod( $path, $mode = null ): bool|string {
+	public function chmod( string $path, ?int $mode = null ): bool|string {
 		if ( $mode ) {
 			return chmod( $path, $mode );
 		}
@@ -481,10 +481,12 @@ class Filesystem {
 	 * @param  int    $mode
 	 * @param  bool   $recursive
 	 */
-	public function ensure_directory_exists( string $path, int $mode = 0755, bool $recursive = true ): void {
+	public function ensure_directory_exists( string $path, int $mode = 0755, bool $recursive = true ): bool {
 		if ( ! $this->is_directory( $path ) ) {
-			$this->make_directory( $path, $mode, $recursive );
+			return $this->make_directory( $path, $mode, $recursive );
 		}
+
+		return true;
 	}
 
 	/**

--- a/src/mantle/filesystem/class-filesystem.php
+++ b/src/mantle/filesystem/class-filesystem.php
@@ -88,8 +88,8 @@ class Filesystem {
 	/**
 	 * Get the returned value of a file.
 	 *
-	 * @param  string $path
-	 * @param  array<string, mixed>  $data
+	 * @param  string               $path
+	 * @param  array<string, mixed> $data
 	 * @return mixed
 	 *
 	 * @throws File_Not_Found_Exception Thrown on missing file.

--- a/src/mantle/filesystem/class-filesystem.php
+++ b/src/mantle/filesystem/class-filesystem.php
@@ -89,7 +89,7 @@ class Filesystem {
 	 * Get the returned value of a file.
 	 *
 	 * @param  string $path
-	 * @param  array  $data
+	 * @param  array<string, mixed>  $data
 	 * @return mixed
 	 *
 	 * @throws File_Not_Found_Exception Thrown on missing file.
@@ -100,6 +100,8 @@ class Filesystem {
 			$__data = $data;
 
 			return ( static function () use ( $__path, $__data ) {
+				global $posts, $post, $wp_did_header, $wp_query, $wp_rewrite, $wpdb, $wp_version, $wp, $id, $comment, $user_ID;
+
 				extract( $__data, EXTR_SKIP ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract, WordPress.PHP.DiscouragedPHPFunctions.extract_extract
 
 				return require $__path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable

--- a/src/mantle/framework/console/class-view-cache-command.php
+++ b/src/mantle/framework/console/class-view-cache-command.php
@@ -69,7 +69,7 @@ class View_Cache_Command extends Command {
 			return Command::FAILURE;
 		}
 
-		$this->blade  = $this->container['view.engine.resolver']->resolve( 'blade' )->getCompiler();
+		$this->blade  = $this->container['view.engine.resolver']->resolve( 'blade' )->get_compiler();
 		$this->finder = $finder;
 
 		// Clear the compiled views first.

--- a/src/mantle/framework/console/class-view-cache-command.php
+++ b/src/mantle/framework/console/class-view-cache-command.php
@@ -47,45 +47,45 @@ class View_Cache_Command extends Command {
 	protected View_Finder $finder;
 
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		parent::__construct();
-
-		// Hide the command in isolation mode.
-		if ( app()->is_running_in_console_isolation() ) {
-			$this->setHidden( true );
-		}
-	}
-
-	/**
 	 * Compile all blade views.
-	 *
-	 * @param View_Finder $finder Finder instance.
 	 */
-	public function handle( View_Finder $finder ): int {
+	public function handle(): int {
 		if ( ! isset( $this->container['view.engine.resolver'] ) ) {
 			$this->error( 'Missing view engine resolver from the view service provider.' );
+
 			return Command::FAILURE;
 		}
 
-		$this->blade  = $this->container['view.engine.resolver']->resolve( 'blade' )->get_compiler();
-		$this->finder = $finder;
+		$this->blade = $this->container['view.engine.resolver']->resolve( 'blade' )->get_compiler();
 
 		// Clear the compiled views first.
 		$this->call( 'mantle view:clear' );
 
-		$paths = $this->finder->get_paths();
+		$compiled_path = $this->container['config']['view.compiled'] ?? null;
 
-		$dir        = $this->container['config']['view.compiled'] ?? null;
-		$filesystem = new Filesystem();
+		if ( empty( $compiled_path ) ) {
+			$this->error( 'No compiled view path found.' );
 
-		// Ensure cache directory exists.
-		if ( $dir && ! $filesystem->is_directory( $dir ) && ! $filesystem->make_directory( $dir ) ) {
-			$this->error( 'Unable to create the compiled view directory.' );
+			return self::FAILURE;
+		}
+
+		if ( ! ( new Filesystem() )->ensure_directory_exists( $compiled_path ) ) {
+			$this->error( "Unable to create the compiled view directory [{$compiled_path}]" );
 
 			return Command::FAILURE;
 		}
+
+		if ( $this->container->is_running_in_console_isolation() ) {
+			return $this->handle_console_isolation();
+		}
+
+		// Cannot be moved to method type hint because it is not compatible with
+		// console isolation mode.
+		$this->finder = $this->container->make( View_Finder::class );
+
+		$paths = $this->finder->get_paths();
+
+
 
 		if ( empty( $paths ) ) {
 			$this->error( 'No view paths found.' );
@@ -102,12 +102,14 @@ class View_Cache_Command extends Command {
 	/**
 	 * Compile all views from a collection.
 	 *
-	 * @param Collection $views Collection of view paths.
+	 * @param Finder $finder Finder instance.
 	 */
-	protected function compile_views( Collection $views ): void {
-		$views->map(
-			fn ( SplFileInfo $file ) => $this->blade->compile( $file->getRealPath() ),
-		);
+	protected function compile_views( Finder $finder ): void {
+		foreach ( $finder as $file ) {
+			$this->info( "Compiling [{$file->getRealPath()}]", 'vvv' );
+
+			$this->blade->compile( $file->getRealPath() );
+		}
 	}
 
 	/**
@@ -115,13 +117,24 @@ class View_Cache_Command extends Command {
 	 *
 	 * @param string[] $paths File path.
 	 */
-	protected function blade_files_in( array $paths ): Collection {
-		return collect(
-			Finder::create()
-				->in( $paths )
-				->exclude( 'vendor' )
-				->name( '*.blade.php' )
-				->files()
-		);
+	protected function blade_files_in( array $paths ): Finder {
+		return Finder::create()
+			->in( $paths )
+			->exclude( 'vendor' )
+			->name( '*.blade.php' )
+			->files();
+	}
+
+	/**
+	 * Handle console isolation mode.
+	 */
+	protected function handle_console_isolation(): int {
+		$base = $this->container->get_base_path();
+
+		$this->info( "Running in console isolation mode. Compiling all Blade templates found in [{$base}]" );
+
+		$this->compile_views( $this->blade_files_in( [ $base ] ) );
+
+		return self::SUCCESS;
 	}
 }

--- a/src/mantle/framework/console/class-view-cache-command.php
+++ b/src/mantle/framework/console/class-view-cache-command.php
@@ -27,7 +27,7 @@ class View_Cache_Command extends Command {
 	 *
 	 * @var string
 	 */
-	protected $name = 'view:cache';
+	protected $signature = 'view:cache {--wp-content} {--path=} {--skip-clear}';
 
 	/**
 	 * Command Description.
@@ -58,8 +58,9 @@ class View_Cache_Command extends Command {
 
 		$this->blade = $this->container['view.engine.resolver']->resolve( 'blade' )->get_compiler();
 
-		// Clear the compiled views first.
-		$this->call( 'mantle view:clear' );
+		if ( ! $this->option( 'skip-clear', false ) ) {
+			$this->call( 'mantle view:clear' );
+		}
 
 		$compiled_path = $this->container['config']['view.compiled'] ?? null;
 
@@ -75,6 +76,14 @@ class View_Cache_Command extends Command {
 			return Command::FAILURE;
 		}
 
+		if ( $this->option( 'wp-content', false ) ) {
+			return $this->handle_compile_wp_content();
+		}
+
+		if ( $paths = $this->option( 'path' ) ) {
+			return $this->handle_compile_path( $paths );
+		}
+
 		if ( $this->container->is_running_in_console_isolation() ) {
 			return $this->handle_console_isolation();
 		}
@@ -85,14 +94,12 @@ class View_Cache_Command extends Command {
 
 		$paths = $this->finder->get_paths();
 
-
-
 		if ( empty( $paths ) ) {
 			$this->error( 'No view paths found.' );
 			return Command::FAILURE;
 		}
 
-		$this->compile_views( $this->blade_files_in( $paths ) );
+		$this->compile_views( $this->blade_files_in( $paths )->exclude( 'vendor' ) );
 
 		$this->success( 'Blade templates cached successfully.' );
 
@@ -120,7 +127,6 @@ class View_Cache_Command extends Command {
 	protected function blade_files_in( array $paths ): Finder {
 		return Finder::create()
 			->in( $paths )
-			->exclude( 'vendor' )
 			->name( '*.blade.php' )
 			->files();
 	}
@@ -136,5 +142,51 @@ class View_Cache_Command extends Command {
 		$this->compile_views( $this->blade_files_in( [ $base ] ) );
 
 		return self::SUCCESS;
+	}
+
+	/**
+	 * Handle the --wp-content option and compile all views in wp-content.
+	 */
+	protected function handle_compile_wp_content(): int {
+		// Get the path to wp-content from the current directory (which is a child of wp-content).
+		$wp_content_dir = preg_replace( '#/wp-content/.*$#', '/wp-content', __DIR__ );
+
+		if ( ! is_dir( $wp_content_dir ) ) {
+			$this->error( 'No wp-content directory found.' );
+
+			return Command::FAILURE;
+		}
+
+		$this->info( "Compiling all Blade templates found in [{$wp_content_dir}]" );
+
+		$this->compile_views( $this->blade_files_in( [ $wp_content_dir ] ) );
+
+		return Command::SUCCESS;
+	}
+
+	/**
+	 * Handle compile path.
+	 *
+	 * @param string $path Path to compile.
+	 */
+	protected function handle_compile_path( string $path ): int {
+		$cwd = getcwd();
+
+		collect( explode( ',', $path ) )
+			->map( fn ( $item ) => $cwd . DIRECTORY_SEPARATOR . $item )
+			->each( function ( string $path ): void {
+				if ( ! is_dir( $path ) ) {
+					$this->error( "Path [{$path}] does not exist. Skipping..." );
+
+					return;
+				}
+
+				$this->info( "Compiling all Blade templates found in [{$path}]" );
+
+				$this->compile_views( $this->blade_files_in( [ $path ] ) );
+			} )
+			->all();
+
+		return Command::SUCCESS;
 	}
 }

--- a/src/mantle/framework/exceptions/class-handler.php
+++ b/src/mantle/framework/exceptions/class-handler.php
@@ -257,7 +257,7 @@ class Handler implements Contract {
 		try {
 			$view = $this->get_http_exception_view( $e );
 
-			return view(
+			return (string) response()->view(
 				$view[0],
 				$view[1],
 				[

--- a/src/mantle/http/autoload.php
+++ b/src/mantle/http/autoload.php
@@ -82,24 +82,23 @@ if ( ! function_exists( 'view' ) ) {
 	/**
 	 * Return a new view.
 	 *
-	 * @param string       $slug View slug.
-	 * @param array|string $name View name, optional. Supports passing variables in if
-	 *                           $variables is not used.
-	 * @return View|View_Factory
+	 * @param string|null                 $slug View slug.
+	 * @param array<string, mixed>|string $name View name or variables.
+	 * @param array<string, mixed>        $variables Variables for the view, optional.
+	 * @phpstan-return ($slug is null ? View_Factory : View)
 	 */
-	function view( ...$args ) {
+	function view( ?string $slug, array|string|null $name = null, array $variables = [] ): View|View_Factory {
 		$factory = app( View_Factory::class );
-		if ( empty( $args ) ) {
-			return $factory;
-		}
 
-		return $factory->make( ...$args );
+		return $slug ? $factory->make( $slug, $name, $variables ) : $factory;
 	}
 }
 
 if ( ! function_exists( 'render_view' ) ) {
 	/**
 	 * Render a new view.
+	 *
+	 * @deprecated Use view() instead.
 	 *
 	 * @param string       $slug View slug.
 	 * @param array|string $name View name, optional. Supports passing variables in if

--- a/src/mantle/http/autoload.php
+++ b/src/mantle/http/autoload.php
@@ -87,7 +87,7 @@ if ( ! function_exists( 'view' ) ) {
 	 * @param array<string, mixed>        $variables Variables for the view, optional.
 	 * @phpstan-return ($slug is null ? View_Factory : View)
 	 */
-	function view( ?string $slug, array|string|null $name = null, array $variables = [] ): View|View_Factory {
+	function view( ?string $slug = null, array|string|null $name = null, array $variables = [] ): View|View_Factory {
 		$factory = app( View_Factory::class );
 
 		return $slug ? $factory->make( $slug, $name, $variables ) : $factory;
@@ -131,9 +131,9 @@ if ( ! function_exists( 'loop' ) ) {
 	 */
 	function loop( ...$args ): string {
 		return view()
-		->loop( ...$args )
-		->map( fn ( View $item ) => $item->render() )
-		->implode( '' );
+			->loop( ...$args )
+			->map( fn ( View $item ) => $item->render() )
+			->implode( '' );
 	}
 }
 

--- a/src/mantle/http/autoload.php
+++ b/src/mantle/http/autoload.php
@@ -80,7 +80,7 @@ if ( ! function_exists( 'request' ) ) {
 
 if ( ! function_exists( 'view' ) ) {
 	/**
-	 * Return a new view.
+	 * Return a new view or the view factory.
 	 *
 	 * @param string|null                 $slug View slug.
 	 * @param array<string, mixed>|string $name View name or variables.

--- a/src/mantle/http/view/class-factory.php
+++ b/src/mantle/http/view/class-factory.php
@@ -302,11 +302,10 @@ class Factory implements Contract {
 	 * Resolve the engine for a given path.
 	 *
 	 * @param string $path Path to resolve.
-	 * @return Engine|\Illuminate\View\Engines\CompilerEngine
 	 *
 	 * @throws InvalidArgumentException Thrown on unknown extension from file.
 	 */
-	public function get_engine_from_path( string $path ) {
+	public function get_engine_from_path( string $path ): \Mantle\Contracts\View\Engine {
 		if ( isset( $this->path_engine_cache[ $path ] ) ) {
 			return $this->engines->resolve( $this->path_engine_cache[ $path ] );
 		}

--- a/src/mantle/http/view/class-factory.php
+++ b/src/mantle/http/view/class-factory.php
@@ -30,38 +30,34 @@ class Factory implements Contract {
 
 	/**
 	 * The IoC container instance.
-	 *
-	 * @var Container
 	 */
-	protected $container;
+	protected Container $container;
 
 	/**
 	 * Data that should be available to all templates.
 	 *
 	 * @var array<mixed>
 	 */
-	protected $shared = [];
+	protected array $shared = [];
 
 	/**
 	 * Stack of views being rendered.
 	 *
 	 * @var array<mixed>
 	 */
-	protected $stack;
+	protected array $stack;
 
 	/**
 	 * Current view being rendered.
-	 *
-	 * @var View|null
 	 */
-	protected $current;
+	protected ?View $current = null;
 
 	/**
 	 * The extension to engine bindings.
 	 *
 	 * @var string[]
 	 */
-	protected $extensions = [
+	protected array $extensions = [
 		'blade.php' => 'blade',
 		'php'       => 'php',
 		'css'       => 'file',
@@ -110,12 +106,10 @@ class Factory implements Contract {
 	 * @param array<string, mixed>|string $key Key to share.
 	 * @param mixed|null                  $value Value to share.
 	 */
-	public function share( $key, $value = null ): void {
+	public function share( array|string $key, mixed $value = null ): void {
 		$keys = is_array( $key ) ? $key : [ $key => $value ];
 
-		foreach ( $keys as $key => $value ) {
-			$this->shared[ $key ] = $value;
-		}
+		$this->shared = array_merge( $this->shared, $keys );
 	}
 
 	/**
@@ -124,7 +118,7 @@ class Factory implements Contract {
 	 * @param string $key Key to get item by.
 	 * @param mixed  $default Default value.
 	 */
-	public function shared( $key, $default = null ): mixed {
+	public function shared( string $key, mixed $default = null ): mixed {
 		return Arr::get( $this->shared, $key, $default );
 	}
 
@@ -156,7 +150,7 @@ class Factory implements Contract {
 	public function pop(): static {
 		array_pop( $this->stack );
 
-		$this->current = end( $this->stack );
+		$this->current = end( $this->stack ) ?: null;
 
 		if ( ! $this->current ) {
 			$this->current = null;
@@ -210,7 +204,7 @@ class Factory implements Contract {
 	 */
 	protected function resolve_view_path( string $slug, ?string $name = null ): ?string {
 		// Prepend the current view if the requested slug is a child template.
-		if ( Str::starts_with( $slug, '_' ) && $this->current ) {
+		if ( Str::starts_with( $slug, '_' ) && $this->current instanceof \Mantle\Http\View\View ) {
 			return $this->resolve_child_view_path_from_parent( $slug );
 		}
 

--- a/src/mantle/http/view/class-factory.php
+++ b/src/mantle/http/view/class-factory.php
@@ -53,6 +53,13 @@ class Factory implements Contract {
 	protected ?View $current = null;
 
 	/**
+	 * The cached array of engines for file paths.
+	 *
+	 * @var array<string, string>
+	 */
+	protected array $path_engine_cache = [];
+
+	/**
 	 * The extension to engine bindings.
 	 *
 	 * @var string[]
@@ -188,11 +195,14 @@ class Factory implements Contract {
 			$name      = null;
 		}
 
-		$variables = array_merge( $this->get_shared(), $variables );
-		$path      = $this->resolve_view_path( $slug, $name );
-		$engine    = $this->get_engine_from_path( $path );
+		$path = $this->resolve_view_path( $slug, $name );
 
-		return new View( $this, $engine, $path, $variables );
+		return new View(
+			factory: $this,
+			engine: $this->get_engine_from_path( $path ),
+			path: $path,
+			data: array_merge( $this->get_shared(), $variables ),
+		);
 	}
 
 	/**
@@ -297,10 +307,16 @@ class Factory implements Contract {
 	 * @throws InvalidArgumentException Thrown on unknown extension from file.
 	 */
 	public function get_engine_from_path( string $path ) {
+		if ( isset( $this->path_engine_cache[ $path ] ) ) {
+			return $this->engines->resolve( $this->path_engine_cache[ $path ] );
+		}
+
 		$extension = $this->get_extension( $path );
 		if ( ! $extension ) {
 			throw new InvalidArgumentException( "Unknown extension in file: {$path}" );
 		}
+
+		$this->path_engine_cache[ $path ] = $this->extensions[ $extension ];
 
 		return $this->engines->resolve( $this->extensions[ $extension ] );
 	}

--- a/src/mantle/http/view/class-factory.php
+++ b/src/mantle/http/view/class-factory.php
@@ -12,7 +12,7 @@ use Illuminate\View\Concerns\ManagesLoops;
 use Illuminate\View\Concerns\ManagesStacks;
 use InvalidArgumentException;
 use Mantle\Contracts\Container;
-use Mantle\Contracts\Http\View\Factory as ViewFactory;
+use Mantle\Contracts\Http\View\Factory as Contract;
 use Mantle\Contracts\View\Engine;
 use Mantle\Support\Arr;
 use Mantle\Support\Collection;
@@ -23,7 +23,7 @@ use WP_Query;
 /**
  * View Factory
  */
-class Factory implements ViewFactory {
+class Factory implements Contract {
 	use ManagesLayouts;
 	use ManagesLoops;
 	use ManagesStacks;
@@ -183,12 +183,12 @@ class Factory implements ViewFactory {
 	/**
 	 * Get the rendered contents of a view.
 	 *
-	 * @param string              $slug View slug.
-	 * @param array<mixed>|string $name View name, optional. Supports passing variables in if
+	 * @param string                           $slug View slug.
+	 * @param array<string, mixed>|string|null $name View name, optional. Supports passing variables in if
 	 *                           $variables is not used.
-	 * @param array<mixed>        $variables Variables for the view, optional.
+	 * @param array<string, mixed>             $variables Variables for the view, optional.
 	 */
-	public function make( string $slug, $name = null, array $variables = [] ): View {
+	public function make( string $slug, array|string|null $name = null, array $variables = [] ): View {
 		if ( is_array( $name ) ) {
 			$variables = array_merge( $name, $variables );
 			$name      = null;

--- a/src/mantle/http/view/class-view-exception.php
+++ b/src/mantle/http/view/class-view-exception.php
@@ -1,0 +1,19 @@
+<?php
+namespace Mantle\Http\View;
+
+use RuntimeException;
+
+/**
+ * View Exception class.
+ */
+class View_Exception extends RuntimeException {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $message Exception message.
+	 * @param string $view 	View name.
+	 */
+	public function __construct( string $message, public readonly string $view ) {
+		parent::__construct( $message );
+	}
+}

--- a/src/mantle/http/view/class-view-exception.php
+++ b/src/mantle/http/view/class-view-exception.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * View_Exception class file
+ *
+ * @package Mantle
+ */
+
 namespace Mantle\Http\View;
 
 use RuntimeException;
@@ -11,7 +17,7 @@ class View_Exception extends RuntimeException {
 	 * Constructor.
 	 *
 	 * @param string $message Exception message.
-	 * @param string $view 	View name.
+	 * @param string $view  View name.
 	 */
 	public function __construct( string $message, public readonly string $view ) {
 		parent::__construct( $message );

--- a/src/mantle/http/view/class-view-finder.php
+++ b/src/mantle/http/view/class-view-finder.php
@@ -243,7 +243,7 @@ class View_Finder {
 	 * Check if the view name has hint information.
 	 *
 	 * The hint information is used to determine if the view should be loaded from
-	 * a specific in the format of "@alias/view-name".
+	 * a specific path that is passed in the format of "@alias/view-name".
 	 *
 	 * @param string $name View name.
 	 */

--- a/src/mantle/http/view/class-view-finder.php
+++ b/src/mantle/http/view/class-view-finder.php
@@ -43,7 +43,8 @@ class View_Finder {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $base_path Base path.
+	 * @param string     $base_path Base path.
+	 * @param Filesystem $files Filesystem instance.
 	 */
 	public function __construct( protected string $base_path, protected readonly Filesystem $files ) {
 		$this->set_default_paths();

--- a/src/mantle/http/view/class-view-finder.php
+++ b/src/mantle/http/view/class-view-finder.php
@@ -10,6 +10,7 @@
 namespace Mantle\Http\View;
 
 use InvalidArgumentException;
+use Mantle\Filesystem\Filesystem;
 use Mantle\Support\Str;
 
 use function Mantle\Support\Helpers\event;
@@ -25,14 +26,14 @@ class View_Finder {
 	 *
 	 * @var string[]
 	 */
-	protected $paths = [];
+	protected array $paths = [];
 
 	/**
 	 * Register a view extension with the finder.
 	 *
 	 * @var string[]
 	 */
-	protected $extensions = [
+	protected array $extensions = [
 		'blade.php',
 		'php',
 		'css',
@@ -44,7 +45,7 @@ class View_Finder {
 	 *
 	 * @param string $base_path Base path.
 	 */
-	public function __construct( protected string $base_path ) {
+	public function __construct( protected string $base_path, protected readonly Filesystem $files ) {
 		$this->set_default_paths();
 
 		\add_action( 'after_setup_theme', [ $this, 'set_default_paths' ] );
@@ -56,7 +57,7 @@ class View_Finder {
 	 *
 	 * @param string $extension Extension to add.
 	 */
-	public function add_extension( $extension ): static {
+	public function add_extension( string $extension ): static {
 		$index = array_search( $extension, $this->extensions, true );
 
 		if ( false !== $index ) {
@@ -170,9 +171,8 @@ class View_Finder {
 		$alias = null;
 
 		// Extract the alias if passed.
-		if ( str_starts_with( $slug, '@' ) ) {
-			$alias = substr( Str::before( $slug, '/' ), 1 );
-			$slug  = Str::after( $slug, '/' );
+		if ( $this->has_hint_information( $slug ) ) {
+			[ $alias, $slug ] = explode( '/', $slug, 2 );
 		}
 
 		$templates = [];
@@ -197,7 +197,7 @@ class View_Finder {
 	 *
 	 * @throws InvalidArgumentException Thrown on unknown view to locate.
 	 */
-	public function locate_template( array $templates, ?string $alias = null ): string {
+	protected function locate_template( array $templates, ?string $alias = null ): string {
 		$paths = $this->get_paths();
 
 		if ( $alias ) {
@@ -215,7 +215,7 @@ class View_Finder {
 				foreach ( $this->get_paths() as $path ) {
 					$path = "{$path}/{$possible_view_file}";
 
-					if ( file_exists( $path ) ) {
+					if ( $this->files->exists( $path ) ) {
 						return $path;
 					}
 				}
@@ -236,5 +236,17 @@ class View_Finder {
 			fn ( $extension ) => "{$name}.{$extension}",
 			$this->extensions
 		);
+	}
+
+	/**
+	 * Check if the view name has hint information.
+	 *
+	 * The hint information is used to determine if the view should be loaded from
+	 * a specific in the format of "@alias/view-name".
+	 *
+	 * @param string $name View name.
+	 */
+	public function has_hint_information( string $name ): bool {
+		return str_starts_with( $name, '@' ) && false !== strpos( $name, '/' );
 	}
 }

--- a/src/mantle/http/view/class-view.php
+++ b/src/mantle/http/view/class-view.php
@@ -9,7 +9,6 @@
 
 namespace Mantle\Http\View;
 
-use Illuminate\View\Engines\CompilerEngine;
 use Mantle\Contracts\Http\View\Factory as Factory_Contract;
 use Mantle\Contracts\View\Engine;
 use Mantle\Database\Model\Post;
@@ -43,14 +42,14 @@ class View implements \Stringable {
 	/**
 	 * Constructor.
 	 *
-	 * @param Factory_Contract                               $factory View Factory.
-	 * @param Engine|\Illuminate\View\Engines\CompilerEngine $engine View Engine.
-	 * @param string                                         $path View path.
-	 * @param array<string, mixed>                           $data Variables for the view, optional.
+	 * @param Factory_Contract     $factory View Factory.
+	 * @param Engine               $engine View Engine.
+	 * @param string               $path View path.
+	 * @param array<string, mixed> $data Variables for the view, optional.
 	 */
 	public function __construct(
 		protected Factory_Contract $factory,
-		protected Engine|CompilerEngine $engine,
+		protected Engine $engine,
 		protected string $path,
 		protected array $data = [],
 	) {

--- a/src/mantle/http/view/class-view.php
+++ b/src/mantle/http/view/class-view.php
@@ -22,8 +22,6 @@ use WP_Post;
 class View implements \Stringable {
 	/**
 	 * Post object to set for the post.
-	 *
-	 * @var Post|\WP_Post|int|null
 	 */
 	protected Post|\WP_Post|int|null $post = null;
 
@@ -122,10 +120,11 @@ class View implements \Stringable {
 		$cache_ttl = match ( $cache_ttl ) {
 			false => null,
 			true => 0, // Indefinite.
-			default => (int) $cache_ttl,
+			default => $cache_ttl,
 		};
 
 		$this->cache_ttl = $cache_ttl;
+
 		$this->cache_key = $cache_key;
 
 		return $this;
@@ -222,17 +221,7 @@ class View implements \Stringable {
 		$this->factory->push( $this );
 
 		// Invoke the engine to render the view.
-		try {
-			$contents = $this->engine->get( $this->path, $this->data );
-		} catch ( \Throwable $e ) {
-			if ( $e instanceof \Illuminate\View\ViewException && str_contains( $e->getMessage(), 'File does not exist at path' ) ) {
-				// $compile_path
-				throw new View_Exception(
-					"Unable to compile view [{$this->path}]. Ensure that the compiled path is properly created and chmod with 0777.",
-					$this->path,
-				);
-			}
-		}
+		$contents = $this->engine->get( $this->path, $this->data );
 
 		$this->factory->pop();
 

--- a/src/mantle/http/view/class-view.php
+++ b/src/mantle/http/view/class-view.php
@@ -14,6 +14,7 @@ use Mantle\Contracts\Http\View\Factory as Factory_Contract;
 use Mantle\Contracts\View\Engine;
 use Mantle\Database\Model\Post;
 use Mantle\Support\Arr;
+use WP_Post;
 
 /**
  * View Class
@@ -24,28 +25,22 @@ class View implements \Stringable {
 	 *
 	 * @var Post|\WP_Post|int|null
 	 */
-	protected $post;
+	protected Post|\WP_Post|int|null $post = null;
 
 	/**
 	 * The original post to restore after rendering the view.
-	 *
-	 * @var \WP_Post
 	 */
-	protected $original_post;
+	protected ?WP_Post $original_post = null;
 
 	/**
 	 * Cache key to use.
-	 *
-	 * @var string
 	 */
-	protected $cache_key;
+	protected ?string $cache_key = null;
 
 	/**
 	 * Cache TTL for the view.
-	 *
-	 * @var int|null
 	 */
-	protected $cache_ttl;
+	protected ?int $cache_ttl = null;
 
 	/**
 	 * Constructor.
@@ -77,7 +72,7 @@ class View implements \Stringable {
 	 *
 	 * @param Post|\WP_Post|int $post Post object.
 	 */
-	public function set_post( $post ): static {
+	public function set_post( WP_Post|Post|int $post ): static {
 		$this->post = $post;
 		return $this;
 	}
@@ -88,7 +83,7 @@ class View implements \Stringable {
 	 * @param string|array<string, mixed> $key Key to set.
 	 * @param mixed                       $value Value to set.
 	 */
-	public function with( $key, $value = null ): static {
+	public function with( string|array $key, mixed $value = null ): static {
 		if ( is_array( $key ) ) {
 			$this->data = array_merge( $this->data, $key );
 		} else {
@@ -123,21 +118,24 @@ class View implements \Stringable {
 	 * @param int|bool $cache_ttl Cache TTL or false to disable. Defaults to 15 minutes.
 	 * @param string   $cache_key Cache key to use, optional.
 	 */
-	public function cache( $cache_ttl = 900, ?string $cache_key = null ): static {
-		if ( false === $cache_ttl ) {
-			$cache_ttl = -1;
-		}
+	public function cache( int|bool $cache_ttl = 900, ?string $cache_key = null ): static {
+		$cache_ttl = match ( $cache_ttl ) {
+			false => null,
+			true => 0, // Indefinite.
+			default => (int) $cache_ttl,
+		};
 
 		$this->cache_ttl = $cache_ttl;
 		$this->cache_key = $cache_key;
+
 		return $this;
 	}
 
 	/**
 	 * Retrieve the cache key to use for the view.
 	 */
-	public function get_cache_key(): string {
-		if ( ! empty( $this->cache_key ) ) {
+	public function get_cache_key(): ?string {
+		if ( $this->cache_key ) {
 			return $this->cache_key;
 		}
 
@@ -224,7 +222,17 @@ class View implements \Stringable {
 		$this->factory->push( $this );
 
 		// Invoke the engine to render the view.
-		$contents = $this->engine->get( $this->path, $this->data );
+		try {
+			$contents = $this->engine->get( $this->path, $this->data );
+		} catch ( \Throwable $e ) {
+			if ( $e instanceof \Illuminate\View\ViewException && str_contains( $e->getMessage(), 'File does not exist at path' ) ) {
+				// $compile_path
+				throw new View_Exception(
+					"Unable to compile view [{$this->path}]. Ensure that the compiled path is properly created and chmod with 0777.",
+					$this->path,
+				);
+			}
+		}
 
 		$this->factory->pop();
 

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -7,7 +7,7 @@
 
 namespace Mantle\View;
 
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Filesystem\Filesystem as Illuminate_Filesystem;
 use Mantle\Http\View\Factory;
 use Mantle\Http\View\View_Finder;
 use Mantle\Support\Service_Provider;
@@ -16,6 +16,7 @@ use Mantle\View\Engines\File_Engine;
 use Mantle\View\Engines\Php_Engine;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
+use Mantle\Filesystem\Filesystem;
 
 use function Mantle\Support\Helpers\tap;
 
@@ -40,7 +41,7 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_blade_compiler(): void {
 		$this->app->singleton(
 			'blade.compiler',
-			fn ( $app ) => new BladeCompiler( new Filesystem(), $app['config']['view.compiled'] ),
+			fn ( $app ) => new BladeCompiler( new Illuminate_Filesystem(), $app['config']['view.compiled'] ),
 		);
 	}
 
@@ -105,7 +106,7 @@ class View_Service_Provider extends Service_Provider {
 		$this->app->singleton(
 			'view.loader',
 			fn ( $app ) => tap(
-				new View_Finder( $app->get_base_path() ),
+				new View_Finder( $app->get_base_path(), new Filesystem() ),
 				function ( View_Finder $loader ): void {
 					// Register the base view folder for the project.
 					$loader->add_path( $this->app->get_base_path( 'views/' ) );

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -150,6 +150,10 @@ class View_Service_Provider extends Service_Provider {
 		static $should_cache_views = null;
 
 		if ( is_null( $should_cache_views ) ) {
+			if ( $this->app->is_running_in_console_isolation() ) {
+				return true;
+			}
+
 			/**
 			 * Early return to allow for Blade views without filesystem compiling.
 			 *

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -45,34 +45,12 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_blade_compiler(): void {
 		$this->app->singleton(
 			'blade.compiler',
-			function ( \Mantle\Contracts\Application $app ) {
-				$compiled_path = $app['config']['view.compiled'];
-
-				$filesystem = new Filesystem();
-
-				$filesystem->ensure_directory_exists( $compiled_path, 0777, true );
-
-				$should_cache = $this->should_cache_views();
-
-				// Trigger a notice if the compiled view path is not writeable.
-				if ( ! $filesystem->is_writable( $compiled_path ) ) {
-					_doing_it_wrong(
-						__FUNCTION__,
-						/* translators: %s: path to the compiled views directory. */
-						__( 'The compiled views directory (%s) is not writable.', 'mantle' ),
-						'1.0.0',
-					);
-
-					$should_cache = false;
-				}
-
-				return new BladeCompiler(
-					new Illuminate_Filesystem(),
-					$compiled_path,
-					$app->get_base_path(),
-					$should_cache,
-				);
-			},
+			fn ( \Mantle\Contracts\Application $app ) => new BladeCompiler(
+				new Illuminate_Filesystem(),
+				$app['config']['view.compiled'],
+				$app->get_base_path(),
+				$this->should_cache_views(),
+			),
 		);
 	}
 
@@ -180,9 +158,12 @@ class View_Service_Provider extends Service_Provider {
 			// Trigger a notice if the compiled view path is not writeable.
 			if ( ! $filesystem->is_writable( $compiled_path ) ) {
 				_doing_it_wrong(
-					__FUNCTION__,
-					/* translators: %s: path to the compiled views directory. */
-					__( 'The compiled views directory (%s) is not writable.', 'mantle' ),
+					self::class . '::' . __FUNCTION__,
+					esc_html( sprintf(
+						/* translators: %s: path to the compiled views directory. */
+						__( 'The compiled views directory (%1$s) is not writable.', 'mantle' ),
+						$compiled_path
+					) ),
 					'1.0.0',
 				);
 

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -15,12 +15,9 @@ use Mantle\View\Engines\Engine_Resolver;
 use Mantle\View\Engines\File_Engine;
 use Mantle\View\Engines\Php_Engine;
 use Illuminate\View\Compilers\BladeCompiler;
-use Illuminate\View\Engines\CompilerEngine;
-use Mantle\Application\Application;
 use Mantle\Filesystem\Filesystem;
 use Mantle\View\Engines\Blade_Engine;
 
-use function Mantle\Support\Helpers\is_unit_testing;
 use function Mantle\Support\Helpers\mixed;
 use function Mantle\Support\Helpers\tap;
 

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -60,7 +60,6 @@ class View_Service_Provider extends Service_Provider {
 			fn () => tap(
 				new Engine_Resolver(),
 				function ( Engine_Resolver $resolver ): void {
-					// Register the various view engines.
 					$this->register_php_engine( $resolver );
 					$this->register_file_engine( $resolver );
 					$this->register_blade_engine( $resolver );

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -16,8 +16,12 @@ use Mantle\View\Engines\File_Engine;
 use Mantle\View\Engines\Php_Engine;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
+use Mantle\Application\Application;
 use Mantle\Filesystem\Filesystem;
+use Mantle\View\Engines\Blade_Engine;
 
+use function Mantle\Support\Helpers\is_unit_testing;
+use function Mantle\Support\Helpers\mixed;
 use function Mantle\Support\Helpers\tap;
 
 /**
@@ -41,7 +45,34 @@ class View_Service_Provider extends Service_Provider {
 	protected function register_blade_compiler(): void {
 		$this->app->singleton(
 			'blade.compiler',
-			fn ( $app ) => new BladeCompiler( new Illuminate_Filesystem(), $app['config']['view.compiled'] ),
+			function ( \Mantle\Contracts\Application $app ) {
+				$compiled_path = $app['config']['view.compiled'];
+
+				$filesystem = new Filesystem();
+
+				$filesystem->ensure_directory_exists( $compiled_path, 0777, true );
+
+				$should_cache = $this->should_cache_views();
+
+				// Trigger a notice if the compiled view path is not writeable.
+				if ( ! $filesystem->is_writable( $compiled_path ) ) {
+					_doing_it_wrong(
+						__FUNCTION__,
+						/* translators: %s: path to the compiled views directory. */
+						__( 'The compiled views directory (%s) is not writable.', 'mantle' ),
+						'1.0.0',
+					);
+
+					$should_cache = false;
+				}
+
+				return new BladeCompiler(
+					new Illuminate_Filesystem(),
+					$compiled_path,
+					$app->get_base_path(),
+					$should_cache,
+				);
+			},
 		);
 	}
 
@@ -57,7 +88,7 @@ class View_Service_Provider extends Service_Provider {
 					// Register the various view engines.
 					$this->register_php_engine( $resolver );
 					$this->register_file_engine( $resolver );
-					$this->register_compiler_engine( $resolver );
+					$this->register_blade_engine( $resolver );
 				}
 			),
 		);
@@ -69,10 +100,7 @@ class View_Service_Provider extends Service_Provider {
 	 * @param Engine_Resolver $resolver Engine resolver.
 	 */
 	protected function register_php_engine( Engine_Resolver $resolver ): void {
-		$resolver->register(
-			'php',
-			fn () => new Php_Engine(),
-		);
+		$resolver->register( 'php', fn () => new Php_Engine( $this->app['files'] ) );
 	}
 
 	/**
@@ -81,10 +109,7 @@ class View_Service_Provider extends Service_Provider {
 	 * @param Engine_Resolver $resolver Engine resolver.
 	 */
 	protected function register_file_engine( Engine_Resolver $resolver ): void {
-		$resolver->register(
-			'file',
-			fn () => new File_Engine(),
-		);
+		$resolver->register( 'file', fn () => new File_Engine() );
 	}
 
 	/**
@@ -92,10 +117,14 @@ class View_Service_Provider extends Service_Provider {
 	 *
 	 * @param Engine_Resolver $resolver Engine resolver.
 	 */
-	protected function register_compiler_engine( Engine_Resolver $resolver ): void {
+	protected function register_blade_engine( Engine_Resolver $resolver ): void {
 		$resolver->register(
 			'blade',
-			fn () => new CompilerEngine( $this->app['blade.compiler'] ),
+			fn () => new Blade_Engine(
+				filesystem: $this->app['files'],
+				compiler: $this->app['blade.compiler'],
+				should_write_files: $this->should_cache_views(),
+			),
 		);
 	}
 
@@ -133,5 +162,42 @@ class View_Service_Provider extends Service_Provider {
 				return $factory;
 			}
 		);
+	}
+
+	/**
+	 * Check if views should be cached (written to the filesystem).
+	 */
+	protected function should_cache_views(): bool {
+		$compiled_path = $this->app['config']['view.compiled'];
+
+		static $is_writeable = null;
+
+		if ( is_null( $is_writeable ) ) {
+			$filesystem = new Filesystem();
+
+			$filesystem->ensure_directory_exists( $compiled_path, 0777, true );
+
+			// Trigger a notice if the compiled view path is not writeable.
+			if ( ! $filesystem->is_writable( $compiled_path ) ) {
+				_doing_it_wrong(
+					__FUNCTION__,
+					/* translators: %s: path to the compiled views directory. */
+					__( 'The compiled views directory (%s) is not writable.', 'mantle' ),
+					'1.0.0',
+				);
+
+				$is_writeable = false;
+			}
+
+			$is_writeable = $filesystem->is_directory( $compiled_path );
+		}
+
+		/**
+		 * Filter to determine if views should be cached.
+		 *
+		 * @param bool   $is_writeable Whether the compiled path is writeable.
+		 * @param string $compiled_path The path to the compiled views directory.
+		 */
+		return mixed( apply_filters( 'mantle_should_cache_views', $is_writeable, $compiled_path ) )->bool();
 	}
 }

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -17,8 +17,8 @@ use Mantle\View\Engines\Php_Engine;
 use Illuminate\View\Compilers\BladeCompiler;
 use Mantle\Filesystem\Filesystem;
 use Mantle\View\Engines\Blade_Engine;
+use RuntimeException;
 
-use function Mantle\Support\Helpers\mixed;
 use function Mantle\Support\Helpers\tap;
 
 /**
@@ -141,41 +141,47 @@ class View_Service_Provider extends Service_Provider {
 
 	/**
 	 * Check if views should be cached (written to the filesystem).
+	 *
+	 * @throws RuntimeException If the compiled views directory is not writable.
 	 */
 	protected function should_cache_views(): bool {
 		$compiled_path = $this->app['config']['view.compiled'];
 
-		static $is_writeable = null;
+		static $should_cache_views = null;
 
-		if ( is_null( $is_writeable ) ) {
-			$filesystem = new Filesystem();
+		if ( is_null( $should_cache_views ) ) {
+			/**
+			 * Early return to allow for Blade views without filesystem compiling.
+			 *
+			 * @param bool|null             $is_writeable Whether the compiled path is writeable.
+			 * @param View_Service_Provider $provider The current instance.
+			 */
+			$should_cache_views = apply_filters( 'mantle_views_should_cache_blade_views', null, $this );
 
-			$filesystem->ensure_directory_exists( $compiled_path, 0777, true );
-
-			// Trigger a notice if the compiled view path is not writeable.
-			if ( ! $filesystem->is_writable( $compiled_path ) ) {
-				_doing_it_wrong(
-					self::class . '::' . __FUNCTION__,
-					esc_html( sprintf(
-						/* translators: %s: path to the compiled views directory. */
-						__( 'The compiled views directory (%1$s) is not writable.', 'mantle' ),
-						$compiled_path
-					) ),
-					'1.0.0',
-				);
-
-				$is_writeable = false;
+			if ( is_bool( $should_cache_views ) ) {
+				return $should_cache_views;
 			}
 
-			$is_writeable = $filesystem->is_directory( $compiled_path );
+			$filesystem = new Filesystem();
+
+			$exists = $filesystem->is_directory( $compiled_path );
+
+			// If the directory doesn't exist, try to create it.
+			if ( ! $exists ) {
+				$exists = $filesystem->ensure_directory_exists( $compiled_path, 0755, true );
+			}
+
+			// If the directory exists but is not writable, try to change permissions.
+			if ( $exists && ! $filesystem->is_writable( $compiled_path ) && ! $filesystem->chmod( $compiled_path, 0755 ) ) {
+				throw new RuntimeException(
+					/* translators: %s: path to the compiled views directory. */
+					esc_html( sprintf( __( 'The compiled views directory (%s) is not writable.', 'mantle' ), $compiled_path ) ),
+				);
+			}
+
+			$should_cache_views = $exists;
 		}
 
-		/**
-		 * Filter to determine if views should be cached.
-		 *
-		 * @param bool   $is_writeable Whether the compiled path is writeable.
-		 * @param string $compiled_path The path to the compiled views directory.
-		 */
-		return mixed( apply_filters( 'mantle_should_cache_views', $is_writeable, $compiled_path ) )->bool();
+		return $should_cache_views;
 	}
 }

--- a/src/mantle/view/class-view-service-provider.php
+++ b/src/mantle/view/class-view-service-provider.php
@@ -110,7 +110,7 @@ class View_Service_Provider extends Service_Provider {
 		$this->app->singleton(
 			'view.loader',
 			fn ( $app ) => tap(
-				new View_Finder( $app->get_base_path(), new Filesystem() ),
+				new View_Finder( $app->get_base_path(), $app['files'] ),
 				function ( View_Finder $loader ): void {
 					// Register the base view folder for the project.
 					$loader->add_path( $this->app->get_base_path( 'views/' ) );

--- a/src/mantle/view/engines/class-blade-engine.php
+++ b/src/mantle/view/engines/class-blade-engine.php
@@ -45,6 +45,13 @@ class Blade_Engine extends Php_Engine {
 	}
 
 	/**
+	 * Retrieve the Blade compiler instance.
+	 */
+	public function get_compiler(): BladeCompiler {
+		return $this->compiler;
+	}
+
+	/**
 	 * Evaluate the contents of a view at a given path.
 	 *
 	 * @throws View_Exception Thrown on error writing compiled view.
@@ -56,10 +63,11 @@ class Blade_Engine extends Php_Engine {
 	public function get( string $path, array $data = [] ): string {
 		$this->last_compiled[] = $path;
 
-		// If we aren't able to write the compiled files, it needs to render the
+		// If we aren't able to write the compiled files, we need to render the
 		// blade template dynamically. This could mean that the
 		// storage/framework/views directory is not writable or that the user has
-		// disabled writing files altogether.
+		// disabled writing files altogether. Either way, the view cannot be
+		// required.
 		if ( ! $this->should_write_files ) {
 			$compiled = $this->compiler->compileString( $this->filesystem->get( $path ) );
 

--- a/src/mantle/view/engines/class-blade-engine.php
+++ b/src/mantle/view/engines/class-blade-engine.php
@@ -69,9 +69,7 @@ class Blade_Engine extends Php_Engine {
 		// disabled writing files altogether. Either way, the view cannot be
 		// required.
 		if ( ! $this->should_write_files ) {
-			$compiled = $this->compiler->compileString( $this->filesystem->get( $path ) );
-
-			return $this->render_string( $compiled, $data );
+			return $this->render_string( $this->filesystem->get( $path ), $data );
 		}
 
 		// If this given view has expired, which means it has simply been edited since
@@ -122,18 +120,20 @@ class Blade_Engine extends Php_Engine {
 	 * Render a compiled Blade template dynamically.
 	 *
 	 * This does require eval() so templates must be trusted and sanitized
-	 * independently.
+	 * before being passed to this method.
 	 *
-	 * @param string               $view The view path.
+	 * @param string               $template The uncompiled Blade template.
 	 * @param array<string, mixed> $data The data to pass to the view.
 	 */
-	protected function render_string( string $view, array $data ): string {
+	public function render_string( string $template, array $data ): string {
+		$template = $this->compiler->compileString( $template );
+
 		$ob_level = ob_get_level();
 
 		ob_start();
 
 		try {
-			$__view = $view;
+			$__view = $template;
 			$__data = $data;
 
 			( static function () use ( $__view, $__data ): void {

--- a/src/mantle/view/engines/class-blade-engine.php
+++ b/src/mantle/view/engines/class-blade-engine.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Blade_Engine class file.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\View\Engines;
+
+use Illuminate\View\Compilers\BladeCompiler;
+use Mantle\Contracts\View\Engine;
+use Mantle\Filesystem\Filesystem;
+use Mantle\Http\View\View_Exception;
+use Throwable;
+
+use function Mantle\Support\Helpers\validate_file;
+
+/**
+ * Blade Template Engine
+ */
+class Blade_Engine extends Php_Engine {
+	/**
+	 * A stack of the last compiled templates.
+	 *
+	 * @var string[]
+	 */
+	protected array $last_compiled = [];
+
+	/**
+	 * The view paths that were compiled or are not expired, keyed by the path.
+	 *
+	 * @var array<string, true>
+	 */
+	protected array $compiled_or_not_expired = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Filesystem    $filesystem
+	 * @param BladeCompiler $compiler
+	 * @param bool         $should_write_files
+	 */
+	public function __construct( Filesystem $filesystem, protected readonly BladeCompiler $compiler, protected readonly bool $should_write_files ) {
+		parent::__construct( $filesystem );
+	}
+
+	/**
+	 * Evaluate the contents of a view at a given path.
+	 *
+	 * @param string               $path View path.
+	 * @param array<string, mixed> $data View data.
+	 */
+	public function get( string $path, array $data = [] ): string {
+		$this->last_compiled[] = $path;
+
+		// If we aren't able to write the compiled files, we will just return the
+		if ( ! $this->should_write_files ) {
+			dd('on the fly');
+		}
+
+		// If this given view has expired, which means it has simply been edited since
+		// it was last compiled, we will re-compile the views so we can evaluate a
+		// fresh copy of the view. We'll pass the compiler the path of the view.
+		if ( ! isset( $this->compiled_or_not_expired[ $path ] ) && $this->compiler->isExpired( $path ) ) {
+			$this->compiler->compile( $path );
+		}
+
+		try {
+			$results = $this->evaluate_path( $this->compiler->getCompiledPath( $path ), $data );
+		} catch ( \Illuminate\View\ViewException $e ) {
+			if ( str_contains( $e->getMessage(), 'File does not exist at path' ) ) {
+				throw new View_Exception(
+					"Unable to compile view [{$path}]. Ensure that the compiled view path (storage/framework/views) is properly created and chmod with 0777.",
+					$path,
+				);
+			}
+
+			throw $e;
+		}
+
+		$this->compiled_or_not_expired[ $path ] = true;
+
+		array_pop( $this->last_compiled );
+
+		return $results;
+	}
+
+	/**
+	 * Handle a view exception.
+	 *
+	 * @param  \Throwable $e Exception thrown.
+	 * @param  int        $ob_level Output buffer level.
+	 * @return void
+	 *
+	 * @throws \Throwable Rethrows the exception thrown.
+	 */
+	protected function handle_view_exception( Throwable $e, $ob_level ) {
+		while ( ob_get_level() > $ob_level ) {
+			ob_end_clean();
+		}
+
+		throw $e;
+	}
+}

--- a/src/mantle/view/engines/class-blade-engine.php
+++ b/src/mantle/view/engines/class-blade-engine.php
@@ -38,7 +38,7 @@ class Blade_Engine extends Php_Engine {
 	 *
 	 * @param Filesystem    $filesystem
 	 * @param BladeCompiler $compiler
-	 * @param bool         $should_write_files
+	 * @param bool          $should_write_files
 	 */
 	public function __construct( Filesystem $filesystem, protected readonly BladeCompiler $compiler, protected readonly bool $should_write_files ) {
 		parent::__construct( $filesystem );
@@ -47,15 +47,23 @@ class Blade_Engine extends Php_Engine {
 	/**
 	 * Evaluate the contents of a view at a given path.
 	 *
+	 * @throws View_Exception Thrown on error writing compiled view.
+	 * @throws \Illuminate\View\ViewException Thrown on internal view error.
+	 *
 	 * @param string               $path View path.
 	 * @param array<string, mixed> $data View data.
 	 */
 	public function get( string $path, array $data = [] ): string {
 		$this->last_compiled[] = $path;
 
-		// If we aren't able to write the compiled files, we will just return the
+		// If we aren't able to write the compiled files, it needs to render the
+		// blade template dynamically. This could mean that the
+		// storage/framework/views directory is not writable or that the user has
+		// disabled writing files altogether.
 		if ( ! $this->should_write_files ) {
-			dd('on the fly');
+			$compiled = $this->compiler->compileString( $this->filesystem->get( $path ) );
+
+			return $this->render_string( $compiled, $data );
 		}
 
 		// If this given view has expired, which means it has simply been edited since
@@ -100,5 +108,37 @@ class Blade_Engine extends Php_Engine {
 		}
 
 		throw $e;
+	}
+
+	/**
+	 * Render a compiled Blade template dynamically.
+	 *
+	 * This does require eval() so templates must be trusted and sanitized
+	 * independently.
+	 *
+	 * @param string               $view The view path.
+	 * @param array<string, mixed> $data The data to pass to the view.
+	 */
+	protected function render_string( string $view, array $data ): string {
+		$ob_level = ob_get_level();
+
+		ob_start();
+
+		try {
+			$__view = $view;
+			$__data = $data;
+
+			( static function () use ( $__view, $__data ): void {
+				global $posts, $post, $wp_did_header, $wp_query, $wp_rewrite, $wpdb, $wp_version, $wp, $id, $comment, $user_ID;
+
+				extract( $__data, EXTR_SKIP ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract, WordPress.PHP.DiscouragedPHPFunctions.extract_extract, Squiz.PHP.Eval.Discouraged
+
+				eval( '?>' . $__view ); // phpcs:ignore WordPress.PHP.Eval.EvalFound, Squiz.PHP.Eval.Discouraged
+			} )();
+		} catch ( Throwable $e ) {
+			$this->handle_view_exception( $e, $ob_level );
+		}
+
+		return ltrim( ob_get_clean() );
 	}
 }

--- a/src/mantle/view/engines/class-blade-engine.php
+++ b/src/mantle/view/engines/class-blade-engine.php
@@ -38,7 +38,7 @@ class Blade_Engine extends Php_Engine {
 	 *
 	 * @param Filesystem    $filesystem
 	 * @param BladeCompiler $compiler
-	 * @param bool          $should_write_files
+	 * @param bool          $should_write_files Whether to write compiled files or not. This can be set to true if the compiled views directory does not exist or is not writeable.
 	 */
 	public function __construct( Filesystem $filesystem, protected readonly BladeCompiler $compiler, protected readonly bool $should_write_files ) {
 		parent::__construct( $filesystem );
@@ -119,8 +119,13 @@ class Blade_Engine extends Php_Engine {
 	/**
 	 * Render a compiled Blade template dynamically.
 	 *
-	 * This does require eval() so templates must be trusted and sanitized
-	 * before being passed to this method.
+	 * This does require eval() so templates must be trusted and sanitized before
+	 * being passed to this method.
+	 *
+	 * Templates are normally written to the filesystem and then require'd to be
+	 * rendered. The same security concerns apply to that approach as well. The
+	 * difference here is that templates are not written to the filesystem and are
+	 * instead evaluated directly.
 	 *
 	 * @param string               $template The uncompiled Blade template.
 	 * @param array<string, mixed> $data The data to pass to the view.

--- a/src/mantle/view/engines/class-engine-resolver.php
+++ b/src/mantle/view/engines/class-engine-resolver.php
@@ -18,7 +18,7 @@ class Engine_Resolver {
 	/**
 	 * The array of engine resolvers.
 	 *
-	 * @var array<string, \Closure>
+	 * @var array<string, \Closure(): Engine>
 	 */
 	protected array $resolvers = [];
 
@@ -35,29 +35,28 @@ class Engine_Resolver {
 	 * The engine string typically corresponds to a file extension.
 	 *
 	 * @param  string   $engine
-	 * @param  \Closure $resolver
+	 * @param  \Closure(): Engine $resolver
 	 */
-	public function register( $engine, Closure $resolver ): void {
-			unset( $this->resolved[ $engine ] );
+	public function register( string $engine, Closure $resolver ): void {
+		unset( $this->resolved[ $engine ] );
 
-			$this->resolvers[ $engine ] = $resolver;
+		$this->resolvers[ $engine ] = $resolver;
 	}
 
 	/**
 	 * Resolve an engine instance by name.
 	 *
-	 * @param  string $engine
-	 * @return Engine|\Illuminate\View\Engines\CompilerEngine
+	 * @param string $engine
 	 *
 	 * @throws InvalidArgumentException Thrown on unknown engine.
 	 */
-	public function resolve( $engine ) {
+	public function resolve( string $engine ): Engine {
 		if ( isset( $this->resolved[ $engine ] ) ) {
 			return $this->resolved[ $engine ];
 		}
 
 		if ( isset( $this->resolvers[ $engine ] ) ) {
-			$this->resolved[ $engine ] = call_user_func( $this->resolvers[ $engine ] );
+			$this->resolved[ $engine ] = $this->resolvers[ $engine ]();
 			return $this->resolved[ $engine ];
 		}
 

--- a/src/mantle/view/engines/class-engine-resolver.php
+++ b/src/mantle/view/engines/class-engine-resolver.php
@@ -34,7 +34,7 @@ class Engine_Resolver {
 	 *
 	 * The engine string typically corresponds to a file extension.
 	 *
-	 * @param  string   $engine
+	 * @param  string             $engine
 	 * @param  \Closure(): Engine $resolver
 	 */
 	public function register( string $engine, Closure $resolver ): void {

--- a/src/mantle/view/engines/class-php-engine.php
+++ b/src/mantle/view/engines/class-php-engine.php
@@ -35,8 +35,8 @@ class Php_Engine implements Engine {
 	/**
 	 * Get the evaluated contents of the view at the given path.
 	 *
-	 * @param string $path View path.
-	 * @param array<string, mixed>  $data View data.
+	 * @param string               $path View path.
+	 * @param array<string, mixed> $data View data.
 	 */
 	protected function evaluate_path( string $path, array $data ): string {
 		$ob_level = ob_get_level();

--- a/src/mantle/view/engines/class-php-engine.php
+++ b/src/mantle/view/engines/class-php-engine.php
@@ -8,14 +8,20 @@
 namespace Mantle\View\Engines;
 
 use Mantle\Contracts\View\Engine;
+use Mantle\Filesystem\Filesystem;
 use Throwable;
-
-use function Mantle\Support\Helpers\validate_file;
 
 /**
  * PHP Template to load WordPress template files.
  */
 class Php_Engine implements Engine {
+	/**
+	 * Constructor.
+	 *
+	 * @param Filesystem $filesystem
+	 */
+	public function __construct( protected readonly Filesystem $filesystem ) {}
+
 	/**
 	 * Evaluate the contents of a view at a given path.
 	 *
@@ -23,14 +29,22 @@ class Php_Engine implements Engine {
 	 * @param array<string, mixed> $data View data.
 	 */
 	public function get( string $path, array $data = [] ): string {
+		return $this->evaluate_path( $path, $data );
+	}
+
+	/**
+	 * Get the evaluated contents of the view at the given path.
+	 *
+	 * @param string $path View path.
+	 * @param array<string, mixed>  $data View data.
+	 */
+	protected function evaluate_path( string $path, array $data ): string {
 		$ob_level = ob_get_level();
 
 		ob_start();
 
 		try {
-			if ( 0 === validate_file( $path ) ) {
-				load_template( $path, false );
-			}
+			$this->filesystem->get_require( $path, $data );
 		} catch ( Throwable $e ) {
 			$this->handle_view_exception( $e, $ob_level );
 		}

--- a/tests/View/BladeViewsTest.php
+++ b/tests/View/BladeViewsTest.php
@@ -2,7 +2,9 @@
 namespace Mantle\Tests\View;
 
 use Mantle\Testing\FrameworkTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group( 'views' )]
 class BladeViewsTest extends FrameworkTestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/View/BladeViewsTest.php
+++ b/tests/View/BladeViewsTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mantle\Tests\View;
 
+use Mantle\Facade\Blade;
 use Mantle\Testing\FrameworkTestCase;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -35,6 +36,31 @@ class BladeViewsTest extends FrameworkTestCase {
 		$this->assertStringContainsString(
 			'child',
 			(string) view( '@blade/parent' )
+		);
+	}
+
+	public function test_compile_from_string(): void {
+		$this->assertEquals(
+			'Hello, <?php echo e($name); ?>.',
+			Blade::compile_string( 'Hello, {{ $name }}.', [ 'name' => 'world' ] )
+		);
+	}
+
+	public function test_render_string(): void {
+		$this->assertEquals(
+			'Hello, world.',
+			Blade::render_string( 'Hello, {{ $name }}.', [ 'name' => 'world' ] )
+		);
+	}
+
+	public function test_blade_directive(): void {
+		Blade::directive( 'test', function ( $expression ) {
+			return "<?php echo 'Test: $expression'; ?>";
+		} );
+
+		$this->assertEquals(
+			'Test: test',
+			Blade::render_string( '@test(test)' )
 		);
 	}
 }

--- a/tests/View/FileEngineTest.php
+++ b/tests/View/FileEngineTest.php
@@ -2,7 +2,9 @@
 namespace Mantle\Tests\View;
 
 use Mantle\Testing\FrameworkTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group( 'views' )]
 class FileEngineTest extends FrameworkTestCase {
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/View/PhpViewsTest.php
+++ b/tests/View/PhpViewsTest.php
@@ -4,7 +4,9 @@ namespace Mantle\Tests\View;
 use Mantle\Testing\FrameworkTestCase;
 use Mantle\Facade\View;
 use Mantle\Http\View\Factory;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group( 'views' )]
 class PhpViewsTest extends FrameworkTestCase {
 	protected Factory $view_factory;
 

--- a/tests/View/ViewFinderTest.php
+++ b/tests/View/ViewFinderTest.php
@@ -51,7 +51,6 @@ class ViewFinderTest extends FrameworkTestCase {
 		$this->assertTrue( View_Loader::has_hint_information( '@example/path' ) );
 		$this->assertTrue( View_Loader::has_hint_information( '@example/path/other' ) );
 		$this->assertFalse( View_Loader::has_hint_information( 'example/path' ) );
-
 	}
 
 	/**

--- a/tests/View/ViewFinderTest.php
+++ b/tests/View/ViewFinderTest.php
@@ -3,7 +3,9 @@ namespace Mantle\Tests\View;
 
 use Mantle\Facade\View_Loader;
 use Mantle\Testing\FrameworkTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group( 'views' )]
 class ViewFinderTest extends FrameworkTestCase {
 	protected function setUp(): void {
 		parent::setUp();
@@ -43,6 +45,13 @@ class ViewFinderTest extends FrameworkTestCase {
 
 		$this->load_view( '@view-loader-alias/alias-specific' );
 		$this->assertEquals( 'alias', $_SERVER['__view_loaded'] );
+	}
+
+	public function test_has_hint_information(): void {
+		$this->assertTrue( View_Loader::has_hint_information( '@example/path' ) );
+		$this->assertTrue( View_Loader::has_hint_information( '@example/path/other' ) );
+		$this->assertFalse( View_Loader::has_hint_information( 'example/path' ) );
+
 	}
 
 	/**


### PR DESCRIPTION
Allows for Blade templating to be rendered by passing a Blade template string. Not designed for everyday use with the compiled .blade.php template being the preferred approach.