### PR TITLE
Enhance HTTP pool requests to have parity with non-pooled requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Adjusted the format of pooled HTTP requests to use `Pooled_Pending_Request`
+  class methods which support direct chaining of methods like `put()`, `post()`,
+  etc.
+
 ## v1.8.6
 
 ### Fixed

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -58,6 +58,10 @@ parameters:
 		- "#@return is not subtype of template type TKey#"
 		- "#WP_REST_Request does not specify its types#"
 		- "#WP_REST_Request but does not specify its types#"
+		-
+			identifier: method.childReturnType
+			paths:
+				- src/mantle/http-client/class-pooled-pending-request.php
 
 	scanFiles:
 		- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-stubs.php

--- a/src/mantle/http-client/class-pending-request.php
+++ b/src/mantle/http-client/class-pending-request.php
@@ -9,27 +9,30 @@
 
 namespace Mantle\Http_Client;
 
-use DateTimeInterface;
 use InvalidArgumentException;
 use Mantle\Support\Pipeline;
 use Mantle\Support\Traits\Conditionable;
 use Mantle\Support\Traits\Macroable;
 
-use function Mantle\Support\Helpers\collect;
 use function Mantle\Support\Helpers\retry;
 use function Mantle\Support\Helpers\tap;
 
 /**
  * Pending Request to be made with the Http Client.
+ *
+ * This class is in transition to remove the more dynamic get/set methods that
+ * exist together to two sets of methods. For example, `url()` will become
+ * `get_url()` and `set_url()` and so on.
  */
 class Pending_Request {
+	use Concerns\Caches_Requests;
 	use Conditionable;
 	use Macroable;
 
 	/**
 	 * Base URL for the request.
 	 */
-	protected string $base_url = '';
+	protected ?string $base_url = null;
 
 	/**
 	 * Method for the request.
@@ -75,11 +78,6 @@ class Pending_Request {
 	protected array $middleware = [];
 
 	/**
-	 * Flag if the request is for a pooled request.
-	 */
-	protected bool $pooled = false;
-
-	/**
 	 * Create an instance of the Http Client
 	 */
 	public static function create(): static {
@@ -112,49 +110,25 @@ class Pending_Request {
 	}
 
 	/**
-	 * Enable caching for the request.
+	 * Set the base URL for the pending request.
 	 *
-	 * @param int|DateTimeInterface|callable(Pending_Request $request): int $ttl Time to live for the cache.
+	 * @param string|null $url Base URL.
 	 */
-	public function cache( int|DateTimeInterface|callable $ttl = 3600 ): static {
-		// Check if there is a caching middleware.
-		if ( collect( $this->middleware )->contains( fn ( $middleware ) => $middleware instanceof Cache_Middleware ) ) {
-			return $this;
+	public function base_url( ?string $url = null ): static|string|null {
+		if ( is_null( $url ) ) {
+			return $this->get_base_url();
 		}
 
-		return $this->prepend_middleware( new Cache_Middleware( $ttl ) );
+		return $this->set_base_url( $url );
 	}
 
 	/**
-	 * Purge the cache for the request.
+	 * Retrieve the base URL for the pending request.
 	 *
-	 * @throws InvalidArgumentException If the request has no URL or is not cached.
-	 *
-	 * @param string|null             $url URL to purge, optional.
-	 * @param string|Http_Method|null $method Method to purge, optional.
+	 * @return string|null
 	 */
-	public function purge( ?string $url = null, string|Http_Method|null $method = null ): bool {
-		if ( ! is_null( $url ) ) {
-			$this->url( $url );
-		}
-
-		if ( ! is_null( $method ) ) {
-			$this->method( $method );
-		}
-
-		if ( empty( $this->url ) ) {
-			throw new InvalidArgumentException( 'Cannot purge cache for a request that has no URL. Call url() first.' );
-		}
-
-		$middleware = collect( $this->middleware )->first( fn ( $middleware ) => $middleware instanceof Cache_Middleware );
-
-		if ( ! $middleware ) {
-			throw new InvalidArgumentException( 'Cannot purge cache for a request that is not cached. Call cache() first.' );
-		}
-
-		assert( $middleware instanceof Cache_Middleware );
-
-		return $middleware->purge( $this );
+	public function get_base_url(): ?string {
+		return $this->base_url;
 	}
 
 	/**
@@ -162,11 +136,7 @@ class Pending_Request {
 	 *
 	 * @param string|null $url Base URL.
 	 */
-	public function base_url( ?string $url = null ): static|string {
-		if ( is_null( $url ) ) {
-			return $this->base_url;
-		}
-
+	public function set_base_url( ?string $url ): static {
 		$this->base_url = $url;
 
 		return $this;
@@ -177,12 +147,28 @@ class Pending_Request {
 	 *
 	 * @param string|null $url URL for the request, optional.
 	 */
-	public function url( string|null $url = null ): static|string {
+	public function url( string|null $url = null ): static|string|null {
 		if ( is_null( $url ) ) {
-			return $this->url;
+			return $this->get_url();
 		}
 
-		$this->url = ltrim( rtrim( $this->base_url, '/' ) . '/' . ltrim( $url, '/' ), '/' );
+		return $this->set_url( $url );
+	}
+
+	/**
+	 * Retrieve the URL for the request.
+	 */
+	public function get_url(): ?string {
+		return $this->url ?? null;
+	}
+
+	/**
+	 * Set the URL for the request.
+	 *
+	 * @param string $url URL for the request.
+	 */
+	public function set_url( string $url ): static {
+		$this->url = ltrim( rtrim( $this->base_url ?? '', '/' ) . '/' . ltrim( $url, '/' ), '/' );
 
 		return $this;
 	}
@@ -194,9 +180,25 @@ class Pending_Request {
 	 */
 	public function method( string|Http_Method|null $method = null ): static|Http_Method {
 		if ( is_null( $method ) ) {
-			return $this->method;
+			return $this->get_method();
 		}
 
+		return $this->set_method( $method );
+	}
+
+	/**
+	 * Retrieve the method for the request.
+	 */
+	public function get_method(): Http_Method {
+		return $this->method;
+	}
+
+	/**
+	 * Set the HTTP method for the request.
+	 *
+	 * @param Http_Method $method HTTP Method to set.
+	 */
+	public function set_method( Http_Method|string $method ): static {
 		if ( is_string( $method ) ) {
 			$method = Http_Method::from( strtoupper( $method ) );
 		}
@@ -544,16 +546,11 @@ class Pending_Request {
 	/**
 	 * Issue a GET request to the given URL.
 	 *
-	 * @throws InvalidArgumentException If the request is pooled.
-	 *
 	 * @param  string                           $url URL to retrieve.
 	 * @param  array<string, mixed>|string|null $query Query parameters (assumed to be urlencoded).
+	 * @return Response
 	 */
-	public function get( string $url, array|string|null $query = null ): Response {
-		if ( $this->pooled ) {
-			throw new InvalidArgumentException( 'Cannot call get() on a pooled request.' );
-		}
-
+	public function get( string $url, array|string|null $query = null ) {
 		return $this->send(
 			Http_Method::GET,
 			$url,
@@ -564,16 +561,11 @@ class Pending_Request {
 	/**
 	 * Issue a HEAD request to the given URL.
 	 *
-	 * @throws InvalidArgumentException If the request is pooled.
-	 *
 	 * @param  string                           $url URL to retrieve.
 	 * @param  array<string, mixed>|string|null $query Query parameters (assumed to be urlencoded).
+	 * @return Response
 	 */
-	public function head( string $url, array|string|null $query = null ): Response {
-		if ( $this->pooled ) {
-			throw new InvalidArgumentException( 'Cannot call head() on a pooled request.' );
-		}
-
+	public function head( string $url, array|string|null $query = null ) {
 		return $this->send(
 			Http_Method::HEAD,
 			$url,
@@ -584,16 +576,11 @@ class Pending_Request {
 	/**
 	 * Issue a POST request to the given URL.
 	 *
-	 * @throws InvalidArgumentException If the request is pooled.
-	 *
 	 * @param  string                    $url URL to post.
 	 * @param  array<string, mixed>|null $data Data to send with the request.
+	 * @return Response
 	 */
-	public function post( string $url, ?array $data = null ): Response {
-		if ( $this->pooled ) {
-			throw new InvalidArgumentException( 'Cannot call post() on a pooled request.' );
-		}
-
+	public function post( string $url, ?array $data = null ) {
 		return $this->send(
 			Http_Method::POST,
 			$url,
@@ -604,16 +591,11 @@ class Pending_Request {
 	/**
 	 * Issue a PATCH request to the given URL.
 	 *
-	 * @throws InvalidArgumentException If the request is pooled.
-	 *
 	 * @param  string                    $url URL to patch.
 	 * @param  array<string, mixed>|null $data Data to send with the request.
+	 * @return Response
 	 */
-	public function patch( string $url, ?array $data = null ): Response {
-		if ( $this->pooled ) {
-			throw new InvalidArgumentException( 'Cannot call patch() on a pooled request.' );
-		}
-
+	public function patch( string $url, ?array $data = null ) {
 		return $this->send(
 			Http_Method::PATCH,
 			$url,
@@ -624,16 +606,11 @@ class Pending_Request {
 	/**
 	 * Issue a PUT request to the given URL.
 	 *
-	 * @throws InvalidArgumentException If the request is pooled.
-	 *
 	 * @param  string                    $url URL to put.
 	 * @param  array<string, mixed>|null $data Data to send with the request.
+	 * @return Response
 	 */
-	public function put( string $url, ?array $data = null ): Response {
-		if ( $this->pooled ) {
-			throw new InvalidArgumentException( 'Cannot call put() on a pooled request.' );
-		}
-
+	public function put( string $url, ?array $data = null ) {
 		return $this->send(
 			Http_Method::PUT,
 			$url,
@@ -644,16 +621,11 @@ class Pending_Request {
 	/**
 	 * Issue a DELETE request to the given URL.
 	 *
-	 * @throws InvalidArgumentException If the request is pooled.
-	 *
 	 * @param  string                    $url URL to delete.
 	 * @param  array<string, mixed>|null $data Data to send with the request.
+	 * @return Response
 	 */
-	public function delete( string $url, ?array $data = null ): Response {
-		if ( $this->pooled ) {
-			throw new InvalidArgumentException( 'Cannot call delete() on a pooled request.' );
-		}
-
+	public function delete( string $url, ?array $data = null ) {
 		return $this->send(
 			Http_Method::DELETE,
 			$url,
@@ -674,7 +646,7 @@ class Pending_Request {
 	 */
 	public function send( string|Http_Method|null $method = null, ?string $url = null, array $options = [] ): mixed {
 		if ( $url ) {
-			$this->url( $url );
+			$this->set_url( $url );
 		}
 
 		if ( empty( $this->url ) ) {
@@ -682,21 +654,12 @@ class Pending_Request {
 		}
 
 		if ( $method ) {
-			$this->method( $method );
+			$this->set_method( $method );
 		}
 
 		$this->options = array_merge( $this->options, $options );
 
-		// Ensure some options are always set.
-		$this->options['throw_exception'] ??= false;
-		$this->options['retry']             = max( 1, $this->options['retry'] ?? 1 );
-
-		$this->prepare_request_url();
-
-		// If this is a pooled request, return the instance of the request.
-		if ( $this->pooled ) {
-			return $this;
-		}
+		$this->prepare_request();
 
 		return retry(
 			$this->options['retry'],
@@ -732,20 +695,10 @@ class Pending_Request {
 	}
 
 	/**
-	 * Determine if this is a pooled request.
-	 *
-	 * @param bool $pooled Whether this is a pooled request.
-	 */
-	public function pooled( bool $pooled = true ): static {
-		$this->pooled = $pooled;
-
-		return $this;
-	}
-
-	/**
 	 * Create a pool request from the current pending request.
 	 *
 	 * @param callable $callback Callback to build the HTTP pool.
+	 * @phpstan-param (callable(Pool $pool): array<int|string, Response>) $callback
 	 * @return array<int|string, Response>
 	 */
 	public function pool( callable $callback ): array {
@@ -753,9 +706,12 @@ class Pending_Request {
 	}
 
 	/**
-	 * Prepare the request URL.
+	 * Prepare the request before sending it.
 	 */
-	protected function prepare_request_url(): void {
+	public function prepare_request(): void {
+		$this->options['throw_exception'] ??= false;
+		$this->options['retry']             = max( 1, $this->options['retry'] ?? 1 );
+
 		if ( isset( $this->options['query'] ) ) {
 			if ( is_array( $this->options['query'] ) ) {
 				$this->url = add_query_arg( $this->options['query'], $this->url );

--- a/src/mantle/http-client/class-pending-request.php
+++ b/src/mantle/http-client/class-pending-request.php
@@ -124,8 +124,6 @@ class Pending_Request {
 
 	/**
 	 * Retrieve the base URL for the pending request.
-	 *
-	 * @return string|null
 	 */
 	public function get_base_url(): ?string {
 		return $this->base_url;
@@ -550,7 +548,7 @@ class Pending_Request {
 	 * @param  array<string, mixed>|string|null $query Query parameters (assumed to be urlencoded).
 	 * @return Response
 	 */
-	public function get( string $url, array|string|null $query = null ) {
+	public function get( string $url, array|string|null $query = null ): mixed {
 		return $this->send(
 			Http_Method::GET,
 			$url,
@@ -565,7 +563,7 @@ class Pending_Request {
 	 * @param  array<string, mixed>|string|null $query Query parameters (assumed to be urlencoded).
 	 * @return Response
 	 */
-	public function head( string $url, array|string|null $query = null ) {
+	public function head( string $url, array|string|null $query = null ): mixed {
 		return $this->send(
 			Http_Method::HEAD,
 			$url,
@@ -580,7 +578,7 @@ class Pending_Request {
 	 * @param  array<string, mixed>|null $data Data to send with the request.
 	 * @return Response
 	 */
-	public function post( string $url, ?array $data = null ) {
+	public function post( string $url, ?array $data = null ): mixed {
 		return $this->send(
 			Http_Method::POST,
 			$url,
@@ -595,7 +593,7 @@ class Pending_Request {
 	 * @param  array<string, mixed>|null $data Data to send with the request.
 	 * @return Response
 	 */
-	public function patch( string $url, ?array $data = null ) {
+	public function patch( string $url, ?array $data = null ): mixed {
 		return $this->send(
 			Http_Method::PATCH,
 			$url,
@@ -610,7 +608,7 @@ class Pending_Request {
 	 * @param  array<string, mixed>|null $data Data to send with the request.
 	 * @return Response
 	 */
-	public function put( string $url, ?array $data = null ) {
+	public function put( string $url, ?array $data = null ): mixed {
 		return $this->send(
 			Http_Method::PUT,
 			$url,
@@ -625,7 +623,7 @@ class Pending_Request {
 	 * @param  array<string, mixed>|null $data Data to send with the request.
 	 * @return Response
 	 */
-	public function delete( string $url, ?array $data = null ) {
+	public function delete( string $url, ?array $data = null ): mixed {
 		return $this->send(
 			Http_Method::DELETE,
 			$url,

--- a/src/mantle/http-client/class-pool.php
+++ b/src/mantle/http-client/class-pool.php
@@ -38,7 +38,7 @@ class Pool {
 			return Pooled_Pending_Request::from_pending_request( $this->base_request );
 		}
 
-		return Pooled_Pending_Request::from_pending_request( $this->base_request );
+		return $this->base_request;
 	}
 
 	/**
@@ -82,7 +82,6 @@ class Pool {
 	 *
 	 * @param string       $method Method name.
 	 * @param array<mixed> $args   Arguments for the method.
-	 * @return Pooled_Pending_Request
 	 */
 	public function __call( string $method, array $args = [] ): Pooled_Pending_Request {
 		$request = $this->create_request()->{$method}( ...$args );

--- a/src/mantle/http-client/class-pool.php
+++ b/src/mantle/http-client/class-pool.php
@@ -12,29 +12,33 @@ use function Alley\WP\Concurrent_Remote_Requests\wp_remote_request;
 /**
  * Http Pool for making requests concurrently.
  *
- * @mixin \Mantle\Http_Client\Pending_Request
+ * @mixin \Mantle\Http_Client\Pooled_Pending_Request
  */
 class Pool {
 	/**
 	 * Pool of pending requests.
 	 *
-	 * @var array<string|int, Pending_Request>
+	 * @var array<string|int, Pooled_Pending_Request>
 	 */
 	protected array $pool = [];
 
 	/**
 	 * Constructor.
 	 *
-	 * @param Pending_Request $base_request
+	 * @param Pending_Request|Pooled_Pending_Request $base_request
 	 */
-	public function __construct( protected Pending_Request $base_request ) {
+	public function __construct( protected Pending_Request|Pooled_Pending_Request $base_request ) {
 	}
 
 	/**
 	 * Create a pending request for the pool
 	 */
-	protected function create_request(): Pending_Request {
-		return ( clone $this->base_request )->pooled();
+	protected function create_request(): Pooled_Pending_Request {
+		if ( ! $this->base_request instanceof Pooled_Pending_Request ) {
+			return Pooled_Pending_Request::from_pending_request( $this->base_request );
+		}
+
+		return Pooled_Pending_Request::from_pending_request( $this->base_request );
 	}
 
 	/**
@@ -44,13 +48,13 @@ class Pool {
 	 * @return array<int|string, Response>
 	 */
 	public function results(): array {
-		// Execute the pool of requests.
 		$results = wp_remote_request(
 			array_map(
-				fn ( Pending_Request $request ) => [
-					$request->url(),
-					$request->get_request_args(),
-				],
+				function ( Pooled_Pending_Request $request ): array {
+					$request->prepare_request();
+
+					return [ $request->url(), $request->get_request_args() ];
+				},
 				$this->pool,
 			)
 		);
@@ -59,10 +63,7 @@ class Pool {
 			throw new Http_Client_Exception( Response::create( $results ) );
 		}
 
-		return array_map(
-			fn ( array $result ) => Response::create( $result ),
-			$results,
-		);
+		return array_map( fn ( array $result ) => Response::create( $result ), $results );
 	}
 
 	/**
@@ -70,7 +71,7 @@ class Pool {
 	 *
 	 * @param string $key The name of the pending request.
 	 */
-	public function as( string $key ): Pending_Request {
+	public function as( string $key ): Pooled_Pending_Request {
 		$this->pool[ $key ] = $this->create_request();
 
 		return $this->pool[ $key ];
@@ -81,9 +82,9 @@ class Pool {
 	 *
 	 * @param string       $method Method name.
 	 * @param array<mixed> $args   Arguments for the method.
-	 * @return Pending_Request
+	 * @return Pooled_Pending_Request
 	 */
-	public function __call( string $method, array $args = [] ) {
+	public function __call( string $method, array $args = [] ): Pooled_Pending_Request {
 		$request = $this->create_request()->{$method}( ...$args );
 
 		$this->pool[] = $request;

--- a/src/mantle/http-client/class-pooled-pending-request.php
+++ b/src/mantle/http-client/class-pooled-pending-request.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Pooled_Pending_Request class file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Http_Client;
+
+/**
+ * Pooled Pending Request
+ */
+class Pooled_Pending_Request extends Pending_Request {
+	/**
+	 * Create a new Pooled_Pending_Request from a Pending_Request.
+	 *
+	 * @param Pending_Request $request The pending request to convert.
+	 */
+	public static function from_pending_request( Pending_Request $request ): self {
+		$pooled_request = new self();
+
+		if ( $base_url = $request->get_base_url() ) {
+			$pooled_request->set_base_url( $base_url );
+		}
+
+		if ( $url = $request->get_url() ) {
+			$pooled_request->set_url( $url );
+		}
+
+		$pooled_request->set_method( $request->get_method() );
+
+		$pooled_request->options = $request->options;
+
+		return $pooled_request;
+	}
+
+	/**
+	 * Issue a GET request to the given URL.
+	 *
+	 * @param  string                           $url URL to retrieve.
+	 * @param  array<string, mixed>|string|null $query Query parameters (assumed to be urlencoded).
+	 * @return static
+	 */
+	public function get( string $url, array|string|null $query = null ) {
+		$this->set_method( Http_Method::GET )->set_url( $url );
+
+		if ( $query ) {
+			$this->options['query'] = $query;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Issue a HEAD request to the given URL.
+	 *
+	 * @param  string                           $url URL to retrieve.
+	 * @param  array<string, mixed>|string|null $query Query parameters (assumed to be urlencoded).
+	 * @return static
+	 */
+	public function head( string $url, array|string|null $query = null ) {
+		$this->set_method( Http_Method::HEAD )->set_url( $url );
+
+		if ( $query ) {
+			$this->options['query'] = $query;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Issue a POST request to the given URL.
+	 *
+	 * @param  string                    $url URL to post.
+	 * @param  array<string, mixed>|null $data Data to send with the request.
+	 * @return static
+	 */
+	public function post( string $url, ?array $data = null ) {
+		$this->set_method( Http_Method::POST )->set_url( $url );
+
+		if ( $data ) {
+			$this->options[ $this->body_format ] = $data;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Issue a PATCH request to the given URL.
+	 *
+	 * @param  string                    $url URL to patch.
+	 * @param  array<string, mixed>|null $data Data to send with the request.
+	 * @return static
+	 */
+	public function patch( string $url, ?array $data = null ) {
+		$this->set_method( Http_Method::PATCH )->set_url( $url );
+
+		if ( $data ) {
+			$this->options[ $this->body_format ] = $data;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Issue a PUT request to the given URL.
+	 *
+	 * @param  string                    $url URL to put.
+	 * @param  array<string, mixed>|null $data Data to send with the request.
+	 * @return static
+	 */
+	public function put( string $url, ?array $data = null ) {
+		$this->set_method( Http_Method::PUT )->set_url( $url );
+
+		if ( $data ) {
+			$this->options[ $this->body_format ] = $data;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Issue a DELETE request to the given URL.
+	 *
+	 * @param  string                    $url URL to delete.
+	 * @param  array<string, mixed>|null $data Data to send with the request.
+	 * @return static
+	 */
+	public function delete( string $url, ?array $data = null ) {
+		$this->set_method( Http_Method::DELETE )->set_url( $url );
+
+		if ( $data ) {
+			$this->options[ $this->body_format ] = $data;
+		}
+
+		return $this;
+	}
+}

--- a/src/mantle/http-client/class-pooled-pending-request.php
+++ b/src/mantle/http-client/class-pooled-pending-request.php
@@ -39,9 +39,8 @@ class Pooled_Pending_Request extends Pending_Request {
 	 *
 	 * @param  string                           $url URL to retrieve.
 	 * @param  array<string, mixed>|string|null $query Query parameters (assumed to be urlencoded).
-	 * @return static
 	 */
-	public function get( string $url, array|string|null $query = null ) {
+	public function get( string $url, array|string|null $query = null ): static {
 		$this->set_method( Http_Method::GET )->set_url( $url );
 
 		if ( $query ) {
@@ -56,9 +55,8 @@ class Pooled_Pending_Request extends Pending_Request {
 	 *
 	 * @param  string                           $url URL to retrieve.
 	 * @param  array<string, mixed>|string|null $query Query parameters (assumed to be urlencoded).
-	 * @return static
 	 */
-	public function head( string $url, array|string|null $query = null ) {
+	public function head( string $url, array|string|null $query = null ): static {
 		$this->set_method( Http_Method::HEAD )->set_url( $url );
 
 		if ( $query ) {
@@ -73,9 +71,8 @@ class Pooled_Pending_Request extends Pending_Request {
 	 *
 	 * @param  string                    $url URL to post.
 	 * @param  array<string, mixed>|null $data Data to send with the request.
-	 * @return static
 	 */
-	public function post( string $url, ?array $data = null ) {
+	public function post( string $url, ?array $data = null ): static {
 		$this->set_method( Http_Method::POST )->set_url( $url );
 
 		if ( $data ) {
@@ -90,9 +87,8 @@ class Pooled_Pending_Request extends Pending_Request {
 	 *
 	 * @param  string                    $url URL to patch.
 	 * @param  array<string, mixed>|null $data Data to send with the request.
-	 * @return static
 	 */
-	public function patch( string $url, ?array $data = null ) {
+	public function patch( string $url, ?array $data = null ): static {
 		$this->set_method( Http_Method::PATCH )->set_url( $url );
 
 		if ( $data ) {
@@ -107,9 +103,8 @@ class Pooled_Pending_Request extends Pending_Request {
 	 *
 	 * @param  string                    $url URL to put.
 	 * @param  array<string, mixed>|null $data Data to send with the request.
-	 * @return static
 	 */
-	public function put( string $url, ?array $data = null ) {
+	public function put( string $url, ?array $data = null ): static {
 		$this->set_method( Http_Method::PUT )->set_url( $url );
 
 		if ( $data ) {
@@ -124,9 +119,8 @@ class Pooled_Pending_Request extends Pending_Request {
 	 *
 	 * @param  string                    $url URL to delete.
 	 * @param  array<string, mixed>|null $data Data to send with the request.
-	 * @return static
 	 */
-	public function delete( string $url, ?array $data = null ) {
+	public function delete( string $url, ?array $data = null ): static {
 		$this->set_method( Http_Method::DELETE )->set_url( $url );
 
 		if ( $data ) {

--- a/src/mantle/http-client/concerns/trait-caches-requests.php
+++ b/src/mantle/http-client/concerns/trait-caches-requests.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Caches_Requests trait file
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Http_Client\Concerns;
+
+use DateTimeInterface;
+use InvalidArgumentException;
+use Mantle\Http_Client\Cache_Middleware;
+use Mantle\Http_Client\Http_Method;
+use Mantle\Http_Client\Pending_Request;
+
+use function Mantle\Support\Helpers\collect;
+
+/**
+ * Caches requests using the Cache_Middleware for the Http Client.
+ *
+ * @mixin \Mantle\Http_Client\Pending_Request
+ */
+trait Caches_Requests {
+	/**
+	 * Enable caching for the request.
+	 *
+	 * @param int|DateTimeInterface|callable $ttl Time to live for the cache.
+	 * @phpstan-param int|DateTimeInterface|(callable(Pending_Request $request): int) $ttl
+	 */
+	public function cache( int|DateTimeInterface|callable $ttl = 3600 ): static {
+		// Check if there is a caching middleware.
+		if ( collect( $this->middleware )->contains( fn ( $middleware ) => $middleware instanceof Cache_Middleware ) ) {
+			return $this;
+		}
+
+		return $this->prepend_middleware( new Cache_Middleware( $ttl ) );
+	}
+
+	/**
+	 * Purge the cache for the request.
+	 *
+	 * @throws InvalidArgumentException If the request has no URL or is not cached.
+	 *
+	 * @param string|null             $url URL to purge, optional.
+	 * @param string|Http_Method|null $method Method to purge, optional.
+	 */
+	public function purge( ?string $url = null, string|Http_Method|null $method = null ): bool {
+		if ( ! is_null( $url ) ) {
+			$this->set_url( $url );
+		}
+
+		if ( ! is_null( $method ) ) {
+			$this->set_method( $method );
+		}
+
+		if ( empty( $this->url ) ) {
+			throw new InvalidArgumentException( 'Cannot purge cache for a request that has no URL. Call url() first.' );
+		}
+
+		$middleware = collect( $this->middleware )->first( fn ( $middleware ) => $middleware instanceof Cache_Middleware );
+
+		if ( ! $middleware ) {
+			throw new InvalidArgumentException( 'Cannot purge cache for a request that is not cached. Call cache() first.' );
+		}
+
+		assert( $middleware instanceof Cache_Middleware );
+
+		return $middleware->purge( $this );
+	}
+}

--- a/src/mantle/testing/concerns/trait-phpunit-upgrade-warning.php
+++ b/src/mantle/testing/concerns/trait-phpunit-upgrade-warning.php
@@ -70,7 +70,7 @@ trait PHPUnit_Upgrade_Warning {
 		}
 
 		render(
-			<<<HTML
+			<<<'HTML'
 			<div class="space-y-1">
 				<div class="bg-red-300 text-red-700 pt-2 py-2">
 					<strong>🚨 Warning:</strong> You are running PHPUnit 10+ against a test suite that contains legacy test cases.

--- a/tests/HttpClient/HttpClientTest.php
+++ b/tests/HttpClient/HttpClientTest.php
@@ -377,6 +377,21 @@ EOF
 		] );
 
 		$response = $this->http_factory->pool( fn ( Pool $pool ) => [
+			$pool->get( 'https://example.com/async/' ),
+			$pool->post( 'https://example.com/second-async/' ),
+		] );
+
+		$this->assertEquals( 200, $response[0]->status() );
+		$this->assertEquals( 402, $response[1]->status() );
+	}
+
+	public function test_pool_requests_legacy() {
+		$this->fake_request( [
+			'https://example.com/async/' => Mock_Http_Response::create()->with_status( 200 ),
+			'https://example.com/second-async/' => Mock_Http_Response::create()->with_status( 402 ),
+		] );
+
+		$response = $this->http_factory->pool( fn ( Pool $pool ) => [
 			$pool->method( 'get' )->url( 'https://example.com/async/' ),
 			$pool->method( 'get' )->url( 'https://example.com/second-async/' ),
 		] );


### PR DESCRIPTION
```php
use Mantle\Facade\Http;

Http::pool( fn ( Pool $pool ) => [
	$pool->get( 'https://example.com/async/' ),
	$pool->post( 'https://example.com/second-async/' ),
] );
```