### PR TITLE
Improve performance of dump() method, add information about current query

### DIFF
--- a/src/mantle/support/traits/trait-enumerates-values.php
+++ b/src/mantle/support/traits/trait-enumerates-values.php
@@ -733,7 +733,7 @@ trait Enumerates_Values {
 	 *
 	 * @return array<TKey, TValue>
 	 */
-	public function jsonSerialize(): mixed { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function json_serialize(): mixed { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
 		return array_map(
 			fn ( $value ): mixed => match ( true ) {
 				$value instanceof JsonSerializable => $value->jsonSerialize(),
@@ -743,6 +743,15 @@ trait Enumerates_Values {
 			},
 			$this->all()
 		);
+	}
+
+	/**
+	 * Alias to json_serialize().
+	 *
+	 * @return array<TKey, TValue>
+	 */
+	public function jsonSerialize(): mixed { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return $this->json_serialize();
 	}
 
 	/**

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -197,7 +197,7 @@ class Utils {
 	 * currently provided by WordPress. Core can always add new conditional tags
 	 * in the future and we don't want to maintain a hardcoded list.
 	 *
-	 * @return string[]
+	 * @return callable-string[]
 	 */
 	public static function get_query_conditional_tags(): array {
 		return collect( get_class_methods( \WP_Query::class ) )

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -191,6 +191,24 @@ class Utils {
 	}
 
 	/**
+	 * Retrieve all of core's conditional tags from WP_Query.
+	 *
+	 * This should return a list of all conditional tags (is_<name>) that are
+	 * currently provided by WordPress. Core can always add new conditional tags
+	 * in the future and we don't want to maintain a hardcoded list.
+	 *
+	 * @return string[]
+	 */
+	public static function get_query_conditional_tags(): array {
+		return collect( get_class_methods( \WP_Query::class ) )
+			->filter( fn ( $method ) => str_starts_with( $method, 'is_' ) && function_exists( $method ) )
+			->reject( fn ( $method ) => in_array( $method, [ 'is_comments_popup', 'is_main_query' ], true ) )
+			->sort()
+			->values()
+			->all();
+	}
+
+	/**
 	 * Set a permalink structure.
 	 *
 	 * Hooked as a callback to the 'populate_options' action, we use this function to set a permalink structure during

--- a/src/mantle/testing/concerns/trait-assertions.php
+++ b/src/mantle/testing/concerns/trait-assertions.php
@@ -15,6 +15,7 @@ use Mantle\Contracts\Support\Arrayable;
 use Mantle\Database\Model\Post;
 use Mantle\Database\Model\Term;
 use Mantle\Database\Model\User;
+use Mantle\Testing\Utils;
 use PHPUnit\Framework\Assert as PHPUnit;
 use UnitEnum;
 use WP_Post;
@@ -176,38 +177,7 @@ trait Assertions {
 
 		assert( $wp_query instanceof \WP_Query );
 
-		$all = [
-			'is_404',
-			'is_admin',
-			'is_archive',
-			'is_attachment',
-			'is_author',
-			'is_category',
-			'is_comment_feed',
-			'is_date',
-			'is_day',
-			'is_embed',
-			'is_feed',
-			'is_front_page',
-			'is_home',
-			'is_privacy_policy',
-			'is_month',
-			'is_page',
-			'is_paged',
-			'is_post_type_archive',
-			'is_posts_page',
-			'is_preview',
-			'is_robots',
-			'is_favicon',
-			'is_search',
-			'is_single',
-			'is_singular',
-			'is_tag',
-			'is_tax',
-			'is_time',
-			'is_trackback',
-			'is_year',
-		];
+		$all = Utils::get_query_conditional_tags();
 
 		foreach ( $prop as $true_thing ) {
 			PHPUnit::assertContains( $true_thing, $all, "Unknown conditional: {$true_thing}." );

--- a/src/mantle/testing/concerns/trait-response-dumper.php
+++ b/src/mantle/testing/concerns/trait-response-dumper.php
@@ -14,7 +14,9 @@ namespace Mantle\Testing\Concerns;
 use Mantle\Support\HTML;
 use Mantle\Testing\Utils;
 use WP_Post;
+use WP_Post_Type;
 use WP_Term;
+use WP_User;
 
 use function Mantle\Support\Helpers\collect;
 use function Mantle\Support\Helpers\data_get;
@@ -314,9 +316,11 @@ trait Response_Dumper {
 			$queried_object = '<em>No queried object found.</em>';
 		} else {
 			$queried_object = match ( $queried_object::class ) {
+				WP_Post_Type::class => "#{$queried_object->name} (WP_Post_Type): {$queried_object->label}",
 				WP_Post::class => "#{$queried_object->ID} (WP_Post): {$queried_object->post_type} — {$queried_object->post_status}",
 				WP_Term::class => "#{$queried_object->term_id} (WP_Term): {$queried_object->name} ({$queried_object->slug})",
-				default => 'unknown',
+				WP_User::class => "#{$queried_object->ID} (WP_User): {$queried_object->display_name}",
+				default => $queried_object::class . ' object',
 			};
 		}
 

--- a/src/mantle/testing/concerns/trait-response-dumper.php
+++ b/src/mantle/testing/concerns/trait-response-dumper.php
@@ -4,13 +4,17 @@
  *
  * phpcs:disable WordPress.WP.AlternativeFunctions.json_encode_json_encode
  * phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+ * phpcs:disable PHPCompatibility
  *
  * @package Mantle
  */
 
 namespace Mantle\Testing\Concerns;
 
+use Mantle\Support\HTML;
+
 use function Mantle\Support\Helpers\collect;
+use function Mantle\Support\Helpers\data_get;
 use function Termwind\render;
 
 /**
@@ -24,8 +28,13 @@ trait Response_Dumper {
 	 *
 	 * The debug should include the request information and the response's status
 	 * code, headers, and content.
+	 *
+	 * @param string|null $selector Selector to limit HTML content to, optional.
+	 *                              For HTML responses, the selector will be a
+	 *                              query selector. JSON responses use dot
+	 *                              notation.
 	 */
-	public function dump(): static {
+	public function dump( ?string $selector = null ): static {
 		if ( ! isset( $this->request ) ) {
 			dump( 'No request information available.' );
 
@@ -56,18 +65,6 @@ trait Response_Dumper {
 
 		// Response information.
 		$response_headers = $this->compile_data_table( $this->headers, 'Header' );
-		$response_content = $this->get_content();
-
-		if ( str_contains( $this->get_header( 'Content-Type' ), 'application/json' ) ) {
-			$json = json_decode( (string) $response_content );
-
-			if ( json_last_error() === JSON_ERROR_NONE ) {
-				$response_content = json_encode( $json, JSON_PRETTY_PRINT );
-			}
-		} else {
-			// Escape the HTML content so it isn't parsed by termwind.
-			$response_content = esc_html( $response_content );
-		}
 
 		$status_code       = $this->get_status_code();
 		$status_code_class = match ( true ) {
@@ -96,10 +93,31 @@ trait Response_Dumper {
 					<h3 class="font-bold">Response Headers</h3>
 					{$response_headers}
 					<h3 class="font-bold">Response Content</h3>
-					<code>{$response_content}</code>
 				</div>
 			HTML,
 		);
+
+		$response_content = $this->get_content();
+
+		if ( str_contains( $this->get_header( 'Content-Type' ), 'application/json' ) ) {
+			$json = json_decode( (string) $response_content );
+
+			if ( json_last_error() === JSON_ERROR_NONE ) {
+				if ( $selector ) {
+					$json = data_get( $json, $selector );
+				}
+
+				echo json_encode( $json, JSON_PRETTY_PRINT );
+
+				return $this;
+			}
+		}
+
+		if ( $selector ) {
+			HTML::create( $response_content )->filter( $selector )->dump();
+		} else {
+			dump( $response_content );
+		}
 
 		return $this;
 	}

--- a/src/mantle/testing/concerns/trait-response-dumper.php
+++ b/src/mantle/testing/concerns/trait-response-dumper.php
@@ -12,6 +12,9 @@
 namespace Mantle\Testing\Concerns;
 
 use Mantle\Support\HTML;
+use Mantle\Testing\Utils;
+use WP_Post;
+use WP_Term;
 
 use function Mantle\Support\Helpers\collect;
 use function Mantle\Support\Helpers\data_get;
@@ -39,6 +42,7 @@ trait Response_Dumper {
 		render( '<hr />' );
 		$this->dump_headers();
 		$this->dump_content( $selector );
+		$this->dump_query();
 
 		return $this;
 	}
@@ -49,6 +53,7 @@ trait Response_Dumper {
 	public function dump_without_content(): static {
 		$this->dump_request();
 		$this->dump_headers();
+		$this->dump_query();
 
 		return $this;
 	}
@@ -297,5 +302,66 @@ trait Response_Dumper {
 				</tbody>
 			</table>
 		HTML;
+	}
+
+	/**
+	 * Dump information about the current WP_Query object.
+	 */
+	public function dump_query(): static {
+		$queried_object = get_queried_object();
+
+		if ( ! $queried_object ) {
+			$queried_object = '<em>No queried object found.</em>';
+		} else {
+			$queried_object = match ( $queried_object::class ) {
+				WP_Post::class => "#{$queried_object->ID} (WP_Post): {$queried_object->post_type} — {$queried_object->post_status}",
+				WP_Term::class => "#{$queried_object->term_id} (WP_Term): {$queried_object->name} ({$queried_object->slug})",
+				default => 'unknown',
+			};
+		}
+
+		$conditionals = [
+			'true'  => [],
+			'false' => [],
+		];
+
+		foreach ( Utils::get_query_conditional_tags() as $conditional ) {
+			if ( $conditional() ) {
+				$conditionals['true'][] = '<span class="text-green-500">' . $conditional . '()</span>';
+			} else {
+				$conditionals['false'][] = '<span class="text-gray-500">' . $conditional . '()</span>';
+			}
+		}
+
+		$conditionals['true']  = implode( ' ', $conditionals['true'] );
+		$conditionals['false'] = implode( ' ', $conditionals['false'] );
+
+		render(
+			<<<HTML
+				<div class="space-y-1">
+					<div>
+						<strong>Queried Object:</strong> {$queried_object}
+					</div>
+					<div>
+						<h4>True Conditionals:</h4>
+						<p>{$conditionals['true']}</p>
+						<h4>False Conditionals:</h4>
+						<p>{$conditionals['false']}</p>
+					</div>
+				</div>
+			HTML
+		);
+
+		return $this;
+	}
+
+	/**
+	 * Dump the queried object and end the script.
+	 */
+	public function dd_query(): never {
+		$this->dump_query();
+		echo 'post';
+
+		exit( 1 );
 	}
 }

--- a/src/mantle/testing/concerns/trait-response-dumper.php
+++ b/src/mantle/testing/concerns/trait-response-dumper.php
@@ -35,6 +35,28 @@ trait Response_Dumper {
 	 *                              notation.
 	 */
 	public function dump( ?string $selector = null ): static {
+		$this->dump_request();
+		render( '<hr />' );
+		$this->dump_headers();
+		$this->dump_content( $selector );
+
+		return $this;
+	}
+
+	/**
+	 * Dump the request and response headers without the content.
+	 */
+	public function dump_without_content(): static {
+		$this->dump_request();
+		$this->dump_headers();
+
+		return $this;
+	}
+
+	/**
+	 * Dump the request information.
+	 */
+	public function dump_request(): static {
 		if ( ! isset( $this->request ) ) {
 			dump( 'No request information available.' );
 
@@ -63,9 +85,6 @@ trait Response_Dumper {
 			HTML;
 		}
 
-		// Response information.
-		$response_headers = $this->compile_data_table( $this->headers, 'Header' );
-
 		$status_code       = $this->get_status_code();
 		$status_code_class = match ( true ) {
 			$status_code >= 200 && $status_code < 300 => 'bg-green-300 text-green-700',
@@ -89,73 +108,68 @@ trait Response_Dumper {
 					<h3 class="font-bold">Request Headers</h3>
 					{$request_headers}
 					{$request_body}
-					<hr />
-					<h3 class="font-bold">Response Headers</h3>
-					{$response_headers}
-					<h3 class="font-bold">Response Content</h3>
 				</div>
 			HTML,
 		);
 
-		$response_content = $this->get_content();
+		return $this;
+	}
 
-		if ( str_contains( $this->get_header( 'Content-Type' ), 'application/json' ) ) {
-			$json = json_decode( (string) $response_content );
+	/**
+	 * Dump the response headers in a table.
+	 */
+	public function dump_headers(): static {
+		$response_headers = $this->compile_data_table( $this->headers, 'Header' );
 
-			if ( json_last_error() === JSON_ERROR_NONE ) {
-				if ( $selector ) {
-					$json = data_get( $json, $selector );
-				}
-
-				echo json_encode( $json, JSON_PRETTY_PRINT );
-
-				return $this;
-			}
-		}
-
-		if ( $selector ) {
-			HTML::create( $response_content )->filter( $selector )->dump();
-		} else {
-			dump( $response_content );
-		}
+		render(
+			<<<HTML
+				<div class="space-y-1 my-1">
+					<h3 class="font-bold">Response Headers</h3>
+					{$response_headers}
+				</div>
+			HTML,
+		);
 
 		return $this;
 	}
 
 	/**
 	 * Dump the contents of the response to the screen.
+	 *
+	 * @param string|null $selector Query selector or JSON path to filter the content, optional.
 	 */
-	public function dump_content(): static {
+	public function dump_content( ?string $selector = null ): static {
 		$content = $this->get_content();
 
 		if ( str_contains( $this->get_header( 'Content-Type' ), 'application/json' ) ) {
 			$json = json_decode( (string) $content );
 
 			if ( json_last_error() === JSON_ERROR_NONE ) {
-				$content = json_encode( $json, JSON_PRETTY_PRINT );
+				if ( $selector ) {
+					$json = data_get( $json, $selector );
+				}
+
+				echo json_encode( $json, JSON_PRETTY_PRINT ) . "\n\n";
+
+				return $this;
 			}
-		} else {
-			// Escape the HTML content so it isn't parsed by termwind.
-			$content = esc_html( $content );
 		}
 
 		render(
-			<<<HTML
-				<div class="space-y-1 my-1">
-					<h3 class="font-bold">Response Content</h3>
-					<code>{$content}</code>
-				</div>
-			HTML,
+			$selector
+				? '<h3 class="font-bold mb-1">Response Content (selector: ' . $selector . ')</h3>'
+				: '<h3 class="font-bold mb-1">Response Content</h3>'
 		);
 
-		return $this;
-	}
+		if ( $selector ) {
+			$content = HTML::create( $content )->filter( $selector )->to_html();
+		}
 
-	/**
-	 * Dump the headers of the response to the screen.
-	 */
-	public function dump_headers(): static {
-		dump( $this->headers );
+		if ( empty( trim( (string) $content ) ) ) {
+			render( '<em>No response content.</em>' );
+		} else {
+			dump( $content );
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
The performance of termwind's `<code>` block was too slow for large HTML responses.