### PR TITLE
Add a memo() helper to memoize values based on dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added a `memo()` helper to memoize the result of a closure based on its
+  dependencies and context.
+
 ## v1.9.0
 
 ### Added

--- a/src/mantle/support/class-memoizable.php
+++ b/src/mantle/support/class-memoizable.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Memoizable class file
+ *
+ * @package Mantle
+ */
+
+declare(strict_types=1);
+
+namespace Mantle\Support;
+
+use Closure;
+use Laravel\SerializableClosure\Support\ReflectionClosure;
+use WeakMap;
+
+/**
+ * Memoize class
+ *
+ * This class provides a simple way to cache the results of expensive function
+ * calls. Mirrors react's useMemo() by providing a callback to invoke if the
+ * dependencies are changed.
+ */
+class Memoizable {
+	/**
+	 * Retrieve a Memoizable instance.
+	 *
+	 * @param array<int, array<string, mixed>> $trace
+	 * @param Closure                          $callable
+	 * @param array<mixed>|null                $dependencies
+	 */
+	public static function try_from_trace( array $trace, Closure $callable, ?array $dependencies ): ?static {
+		if ( $hash = static::hash_from_trace( $trace, $callable, $dependencies ) ) {
+			return new static( $hash, self::object_from_trace( $trace ), $callable );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Retrieve a cache key from a backtrace.
+	 *
+	 * @param array<int, array<string, mixed>> $trace
+	 * @param callable                         $callable
+	 * @param array<mixed>|null                $dependencies
+	 */
+	protected static function hash_from_trace( array $trace, callable $callable, ?array $dependencies ): ?string {
+		if ( str_contains( $trace[0]['file'] ?? '', "eval()'d code" ) ) {
+			return null;
+		}
+
+		$uses = $dependencies ?? [];
+
+		$class = $callable instanceof Closure ? ( new ReflectionClosure( $callable ) )->getClosureCalledClass()?->getName() : null;
+
+		$class ??= $trace[1]['class'] ?? null;
+
+		return hash( 'xxh128', sprintf(
+			'%s@%s%s:%s (%s)',
+			$trace[0]['file'],
+			$class ? $class . '@' : '',
+			$trace[1]['function'],
+			$trace[0]['line'],
+			serialize( $uses ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		) );
+	}
+
+	/**
+	 * Computes the object of the memoizable from the given trace, if any.
+	 *
+	 * @param  array<int, array<string, mixed>> $trace
+	 */
+	protected static function object_from_trace( array $trace ): ?object {
+		return $trace[1]['object'] ?? null;
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string|null $hash A unique hash representing the memoization key.
+	 * @param object|null $object The object context in which the callable is executed.
+	 * @param Closure     $callable The callable function to be memoized.
+	 */
+	public function __construct( public readonly ?string $hash, public readonly ?object $object, public readonly Closure $callable ) {}
+}

--- a/src/mantle/support/class-memoizable.php
+++ b/src/mantle/support/class-memoizable.php
@@ -11,7 +11,6 @@ namespace Mantle\Support;
 
 use Closure;
 use Laravel\SerializableClosure\Support\ReflectionClosure;
-use WeakMap;
 
 /**
  * Memoize class

--- a/src/mantle/support/class-memoize.php
+++ b/src/mantle/support/class-memoize.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Memoize class file
+ *
+ * @package Mantle
+ */
+
+declare(strict_types=1);
+
+namespace Mantle\Support;
+
+use Closure;
+use Mantle\Support\Traits\Singleton;
+use WeakMap;
+
+/**
+ * Memoize class
+ *
+ * This class provides a simple way to cache the results of expensive function
+ * calls. Mirrors react's useMemo() by providing a callback to invoke if the
+ * dependencies are changed.
+ */
+class Memoize {
+	use Singleton;
+
+	/**
+	 * Whether memoization is enabled.
+	 */
+	protected static bool $enabled = true;
+
+	/**
+	 * Enable the memoization.
+	 */
+	public static function enable(): void {
+		static::$enabled = true;
+	}
+
+	/**
+	 * Disable the memoization.
+	 */
+	public static function disable(): void {
+		static::$enabled = false;
+	}
+
+	/**
+	 * Flush all memoized values.
+	 */
+	public static function flush(): void {
+		static::instance()->values = new WeakMap();
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WeakMap<object, array<string, mixed>> $values A weak map to hold memoized values.
+	 */
+	protected function __construct( protected WeakMap $values = new WeakMap() ) {}
+
+	/**
+	 * Retrieve the value of a memoized callable.
+	 *
+	 * @param Memoizable $memoizable The memoizable instance.
+	 */
+	public function value( Memoizable $memoizable ): mixed {
+		if ( ! static::$enabled ) {
+			return call_user_func( $memoizable->callable );
+		}
+
+		$object = $memoizable->object ?: $this;
+
+		$hash = $memoizable->hash;
+
+		if ( ! isset( $this->values[ $object ] ) ) {
+				$this->values[ $object ] = [];
+		}
+
+		if ( ! array_key_exists( $hash, $this->values[ $object ] ) ) {
+			$this->values[ $object ][ $hash ] = call_user_func( $memoizable->callable );
+		}
+
+		return $this->values[ $object ][ $hash ];
+	}
+}

--- a/src/mantle/support/class-memoize.php
+++ b/src/mantle/support/class-memoize.php
@@ -62,7 +62,7 @@ class Memoize {
 	 * @param Memoizable $memoizable The memoizable instance.
 	 */
 	public function value( Memoizable $memoizable ): mixed {
-		if ( ! static::$enabled ) {
+		if ( ! static::$enabled || ! $memoizable->hash ) {
 			return call_user_func( $memoizable->callable );
 		}
 

--- a/src/mantle/support/class-memoize.php
+++ b/src/mantle/support/class-memoize.php
@@ -68,16 +68,14 @@ class Memoize {
 
 		$object = $memoizable->object ?: $this;
 
-		$hash = $memoizable->hash;
-
 		if ( ! isset( $this->values[ $object ] ) ) {
-				$this->values[ $object ] = [];
+			$this->values[ $object ] = [];
 		}
 
-		if ( ! array_key_exists( $hash, $this->values[ $object ] ) ) {
-			$this->values[ $object ][ $hash ] = call_user_func( $memoizable->callable );
+		if ( ! array_key_exists( $memoizable->hash, $this->values[ $object ] ) ) {
+			$this->values[ $object ][ $memoizable->hash ] = call_user_func( $memoizable->callable );
 		}
 
-		return $this->values[ $object ][ $hash ];
+		return $this->values[ $object ][ $memoizable->hash ];
 	}
 }

--- a/src/mantle/support/helpers/helpers-memoize.php
+++ b/src/mantle/support/helpers/helpers-memoize.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Memoize helpers.
+ *
+ * @package Mantle
+ */
+
+namespace Mantle\Support\Helpers;
+
+use Closure;
+use Mantle\Support\Memoize;
+use Mantle\Support\Memoizable;
+
+/**
+ * Memoize a callback function.
+ *
+ * @template TReturnValue
+ *
+ * @param Closure           $callback The function to memoize.
+ * @param array<mixed>|null $dependencies The dependencies that trigger a re-evaluation.
+ * @return mixed The memoized result.
+ *
+ * @phpstan-param Closure(): TReturnValue $callback
+ * @phpstan-return TReturnValue
+ */
+function memo( Closure $callback, ?array $dependencies = null ): mixed {
+	$memoizable = Memoizable::try_from_trace(
+		debug_backtrace( DEBUG_BACKTRACE_PROVIDE_OBJECT, 2 ), // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$callback,
+		$dependencies,
+	);
+
+	return $memoizable instanceof Memoizable ? Memoize::instance()->value( $memoizable ) : $callback();
+}

--- a/src/mantle/support/helpers/helpers.php
+++ b/src/mantle/support/helpers/helpers.php
@@ -19,5 +19,6 @@ require_once __DIR__ . '/helpers-environment.php';
 require_once __DIR__ . '/helpers-general.php';
 require_once __DIR__ . '/helpers-log.php';
 require_once __DIR__ . '/helpers-meta-data.php';
+require_once __DIR__ . '/helpers-memoize.php';
 require_once __DIR__ . '/helpers-rest-api.php';
 require_once __DIR__ . '/helpers-validated-hook-removal.php';

--- a/src/mantle/testing/TestCase.php
+++ b/src/mantle/testing/TestCase.php
@@ -14,6 +14,7 @@ use Mantle\Database\Model\Model;
 use Mantle\Facade\Facade;
 use Mantle\Framework\Alias_Loader;
 use Mantle\Support\Collection;
+use Mantle\Support\Memoize;
 use Mantle\Testing\Concerns\Admin_Screen;
 use Mantle\Testing\Concerns\Assertions;
 use Mantle\Testing\Concerns\Core_Shim;
@@ -106,6 +107,8 @@ abstract class TestCase extends BaseTestCase {
 		if ( class_exists( \Spatie\Once\Cache::class ) ) {
 			\Spatie\Once\Cache::getInstance()->disable();
 		}
+
+		Memoize::disable();
 
 		static::register_traits();
 

--- a/tests/Support/MemoizeTest.php
+++ b/tests/Support/MemoizeTest.php
@@ -11,6 +11,7 @@ class MemoizeTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		Memoize::enable();
 		Memoize::flush();
 	}
 

--- a/tests/Support/MemoizeTest.php
+++ b/tests/Support/MemoizeTest.php
@@ -1,0 +1,92 @@
+<?php
+namespace Mantle\Tests\Support;
+
+use Mantle\Support\Memoize;
+use PHPUnit\Framework\TestCase;
+
+use function Mantle\Support\Helpers\collect;
+use function Mantle\Support\Helpers\memo;
+
+class MemoizeTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		Memoize::flush();
+	}
+
+	public function test_it_can_memoize(): void {
+		$values = [];
+		for ( $i = 0; $i < 3; $i++ ) {
+			$values[] = memo( fn () => rand( 1, PHP_INT_MAX ) );
+		};
+
+		$this->assertCount( 1, collect( $values )->unique()->all() );
+
+		// Ensure it is unique across multiple calls.
+		$values_2 = [];
+		for ( $i = 0; $i < 3; $i++ ) {
+			$values_2[] = memo( fn () => rand( 1, PHP_INT_MAX ) );
+		};
+
+		$this->assertCount( 1, collect( $values_2 )->unique()->all() );
+		$this->assertNotEquals( $values[0], $values_2[0] );
+	}
+
+	public function test_it_can_memoize_with_dependencies(): void {
+		$values  = [];
+		for ( $i = 0; $i < 10; $i++ ) {
+			$values[] = memo(
+				fn () => rand( 1, PHP_INT_MAX ),
+				// This will result in two unique values as dependencies.
+				[ $i % 2 ],
+			);
+		};
+
+		$values = collect( $values )->unique()->values()->all();
+
+		$this->assertCount( 2, $values );
+		$this->assertNotEquals( $values[0], $values[1] );
+	}
+
+	public function test_it_can_disable_memoization(): void {
+		Memoize::disable();
+
+		$values = [];
+		for ( $i = 0; $i < 3; $i++ ) {
+			$values[] = memo( fn () => rand( 1, PHP_INT_MAX ) );
+		};
+
+		$this->assertCount( 3, collect( $values )->unique()->all() );
+
+		Memoize::enable();
+
+		$values_2 = [];
+		for ( $i = 0; $i < 3; $i++ ) {
+			$values_2[] = memo( fn () => rand( 1, PHP_INT_MAX ) );
+		};
+
+		$this->assertCount( 1, collect( $values_2 )->unique()->all() );
+	}
+
+	public function test_it_can_flush_memoization(): void {
+		$callable = function (): array {
+			$values = [];
+			for ( $i = 0; $i < 3; $i++ ) {
+				$values[] = memo( fn () => rand( 1, PHP_INT_MAX ) );
+			};
+
+			return $values;
+		};
+
+		$values = $callable();
+
+		$this->assertCount( 1, collect( $values )->unique()->all() );
+
+		Memoize::flush();
+
+		$values_2 = $callable();
+
+		$this->assertCount( 1, collect( $values_2 )->unique()->all() );
+		$this->assertNotEquals( $values[0], $values_2[0] );
+	}
+}


### PR DESCRIPTION
Similar to Laravel and Spatie's `once()` method but only uses an explicit set of dependencies rather than all variables passed to the parent method.