### PR TITLE
Adjust JSON assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `WP_DEFAULT_THEME` environment variable to ensure that the theme is properly
   set during installation.
 
+### Fixed
+
+- Fixed issue with empty JSON not being parsed properly with `Assertable_Json_String`.
+
 ## v1.9.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `assertJsonPathEmpty()`, `assertJsonPathNotEmpty()`,
-  `assertJsonPathContains()`, and `assertJsonPathNotContains()` methods to the
-  test response class.
+  `assertJsonPathContains()`, `assertJsonPathNotContains()`, and
+  `assertJsonPathCallback()` methods to the test response class.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `assertJsonPathEmpty()`, `assertJsonPathNotEmpty()`,
+  `assertJsonPathContains()`, and `assertJsonPathNotContains()` methods to the
+  test response class.
+
 ### Changed
 
 - Changed the `theme()` method of the installation manager to set the

--- a/src/mantle/http-client/class-response.php
+++ b/src/mantle/http-client/class-response.php
@@ -11,6 +11,8 @@ use ArrayAccess;
 use LogicException;
 use Mantle\Support\Collection;
 use Mantle\Support\Traits\Macroable;
+use Mantle\Testing\Assertable_HTML_String;
+use Mantle\Testing\Assertable_Json_String;
 use SimpleXMLElement;
 use WP_Error;
 use WP_Http_Cookie;
@@ -286,7 +288,7 @@ class Response implements ArrayAccess {
 	 * @param  mixed       $default
 	 * @return mixed
 	 */
-	public function json( $key = null, $default = null ) {
+	public function json( ?string $key = null, mixed $default = null ) {
 		if ( $this->decoded === null ) {
 			$this->decoded = json_decode( $this->body(), true );
 		}
@@ -296,6 +298,16 @@ class Response implements ArrayAccess {
 		}
 
 		return data_get( $this->decoded, $key, $default );
+	}
+
+
+	/**
+	 * Retrieve an instance of Assertable_Json_String to perform fluent JSON assertions.
+	 *
+	 * @param string|null $key Optional key to pass to `json()` to scope the JSON data.
+	 */
+	public function assertable_json( ?string $key = null ): Assertable_Json_String {
+		return new Assertable_Json_String( $this->json( $key ) );
 	}
 
 	/**
@@ -337,7 +349,7 @@ class Response implements ArrayAccess {
 	 * @param  string|null $key
 	 * @return Collection<array-key, mixed>
 	 */
-	public function collect( $key = null ): \Mantle\Support\Collection {
+	public function collect( ?string $key = null ): \Mantle\Support\Collection {
 		return new Collection( $this->json( $key ) );
 	}
 

--- a/src/mantle/testing/class-assertable-json-string.php
+++ b/src/mantle/testing/class-assertable-json-string.php
@@ -43,10 +43,14 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 		} else {
 			$decoded = json_decode( $this->json, true );
 
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				PHPUnit::fail( 'Invalid JSON was returned from the response: ' . json_last_error_msg() );
+			}
+
 			$this->decoded = is_array( $decoded ) ? $decoded : null;
 		}
 
-		if ( is_null( $this->decoded ) || false == $this->decoded ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		if ( null === $this->decoded ) {
 			PHPUnit::fail( 'Invalid JSON was returned from the response.' );
 		}
 	}

--- a/src/mantle/testing/class-assertable-json-string.php
+++ b/src/mantle/testing/class-assertable-json-string.php
@@ -81,6 +81,32 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	}
 
 	/**
+	 * Assert that the value at the given path in the response matches the given regular expression.
+	 *
+	 * @param string $path  Path to check.
+	 * @param string $regex Regular expression to match against.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertPathMatches( string $path, string $regex, string $message = '' ): static {
+		PHPUnit::assertMatchesRegularExpression( $regex, (string) $this->json( $path ), $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path does not match the given regular expression pattern in the response.
+	 *
+	 * @param string $path Path to check.
+	 * @param string $pattern Regular expression pattern to match.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertPathNotMatches( string $path, string $pattern, string $message = '' ): static {
+		PHPUnit::assertDoesNotMatchRegularExpression( $pattern, (string) $this->json( $path ), $message );
+
+		return $this;
+	}
+
+	/**
 	 * Assert that a specific path exists in the response.
 	 *
 	 * @param string $path Path to check.

--- a/src/mantle/testing/class-assertable-json-string.php
+++ b/src/mantle/testing/class-assertable-json-string.php
@@ -72,9 +72,10 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 *
 	 * @param  string $path
 	 * @param  mixed  $expect
+	 * @param  string $message Optional message on failure.
 	 */
-	public function assertPath( string $path, mixed $expect ): static {
-		PHPUnit::assertSame( $expect, $this->json( $path ) );
+	public function assertPath( string $path, mixed $expect, string $message = '' ): static {
+		PHPUnit::assertSame( $expect, $this->json( $path ), $message );
 
 		return $this;
 	}
@@ -83,9 +84,10 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * Assert that a specific path exists in the response.
 	 *
 	 * @param string $path Path to check.
+	 * @param string $message Optional message on failure.
 	 */
-	public function assertPathExists( string $path ): static {
-		PHPUnit::assertNotNull( $this->json( $path ) );
+	public function assertPathExists( string $path, string $message = '' ): static {
+		PHPUnit::assertNotNull( $this->json( $path ), $message );
 
 		return $this;
 	}
@@ -94,9 +96,68 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	 * Assert that a specific path does not exist in the response.
 	 *
 	 * @param string $path Path to check.
+	 * @param string $message Optional message on failure.
 	 */
-	public function assertPathMissing( string $path ): static {
-		PHPUnit::assertNull( $this->json( $path ) );
+	public function assertPathMissing( string $path, string $message = '' ): static {
+		PHPUnit::assertNull( $this->json( $path ), $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path is empty in the response.
+	 *
+	 * @param string $path  Path to check.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertPathEmpty( string $path, string $message = '' ): static {
+		PHPUnit::assertEmpty( $this->json( $path ), $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path is not empty in the response.
+	 *
+	 * @param string $path  Path to check.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertPathNotEmpty( string $path, string $message = '' ): static {
+		PHPUnit::assertNotEmpty( $this->json( $path ), $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path contains the given string value in the response.
+	 *
+	 * @param string $path  Path to check.
+	 * @param string $needle Value to check for.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertPathContains( string $path, string $needle, string $message = '' ): static {
+		PHPUnit::assertStringContainsString(
+			$needle,
+			(string) $this->json( $path ),
+			$message,
+		);
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path does not contain the given string value in the response.
+	 *
+	 * @param string $path  Path to check.
+	 * @param string $needle Value to check for.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertPathNotContains( string $path, string $needle, string $message = '' ): static {
+		PHPUnit::assertStringNotContainsString(
+			$needle,
+			(string) $this->json( $path ),
+			$message,
+		);
 
 		return $this;
 	}

--- a/src/mantle/testing/class-assertable-json-string.php
+++ b/src/mantle/testing/class-assertable-json-string.php
@@ -189,6 +189,27 @@ class Assertable_Json_String implements ArrayAccess, Countable {
 	}
 
 	/**
+	 * Assert that the value at the given path in the response passes the given truth test.
+	 *
+	 * @param string   $path     Path to check.
+	 * @param callable $callback Callback that receives the value and returns true if it passes.
+	 * @param string   $message  Optional message on failure.
+	 *
+	 * @phpstan-param (callable(mixed): bool) $callback
+	 */
+	public function assertPathCallback( string $path, callable $callback, string $message = '' ): static {
+		$value = $this->json( $path );
+
+		if ( empty( $message ) ) {
+			$message = "The value at path [{$path}] did not pass the given truth test.";
+		}
+
+		PHPUnit::assertTrue( (bool) $callback( $value ), $message );
+
+		return $this;
+	}
+
+	/**
 	 * Assert that the response has the similar JSON as given.
 	 *
 	 * @param  array $data

--- a/src/mantle/testing/class-pending-testable-request.php
+++ b/src/mantle/testing/class-pending-testable-request.php
@@ -649,7 +649,7 @@ class Pending_Testable_Request {
 
 		$scheme = wp_parse_url( home_url(), PHP_URL_SCHEME );
 
-		return ! empty( $scheme ) ? $scheme : 'http';
+		return empty( $scheme ) ? 'http' : $scheme;
 	}
 
 	/**

--- a/src/mantle/testing/class-test-response.php
+++ b/src/mantle/testing/class-test-response.php
@@ -713,9 +713,10 @@ class Test_Response {
 	 *
 	 * @param  string $path
 	 * @param  mixed  $expect
+	 * @param  string $message Optional message on failure.
 	 */
-	public function assertJsonPath( string $path, $expect ): static {
-		$this->decoded_json()->assertPath( $path, $expect );
+	public function assertJsonPath( string $path, mixed $expect, string $message = '' ): static {
+		$this->decoded_json()->assertPath( $path, $expect, $message );
 
 		return $this;
 	}
@@ -724,9 +725,10 @@ class Test_Response {
 	 * Assert that a specific path exists in the response.
 	 *
 	 * @param string $path Path to check.
+	 * @param string $message Optional message on failure.
 	 */
-	public function assertJsonPathExists( string $path ): static {
-		$this->decoded_json()->assertPathExists( $path );
+	public function assertJsonPathExists( string $path, string $message = '' ): static {
+		$this->decoded_json()->assertPathExists( $path, $message );
 
 		return $this;
 	}
@@ -735,9 +737,60 @@ class Test_Response {
 	 * Assert that a specific path does not exist in the response.
 	 *
 	 * @param string $path Path to check.
+	 * @param string $message Optional message on failure.
 	 */
-	public function assertJsonPathMissing( string $path ): static {
-		$this->decoded_json()->assertPathMissing( $path );
+	public function assertJsonPathMissing( string $path, string $message = '' ): static {
+		$this->decoded_json()->assertPathMissing( $path, $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path is empty in the response.
+	 *
+	 * @param string $path Path to check.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertJsonPathEmpty( string $path, string $message = '' ): static {
+		$this->decoded_json()->assertPathEmpty( $path, $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path is not empty in the response.
+	 *
+	 * @param string $path Path to check.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertJsonPathNotEmpty( string $path, string $message = '' ): static {
+		$this->decoded_json()->assertPathNotEmpty( $path, $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path contains the given string value in the response.
+	 *
+	 * @param string $path  Path to check.
+	 * @param string $value Value to check for.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertJsonPathContains( string $path, string $value, string $message = '' ): static {
+		$this->decoded_json()->assertPathContains( $path, $value, $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path does not contain the given string value in the response.
+	 *
+	 * @param string $path  Path to check.
+	 * @param string $value Value to check for.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertJsonPathNotContains( string $path, string $value, string $message = '' ): static {
+		$this->decoded_json()->assertPathNotContains( $path, $value, $message );
 
 		return $this;
 	}
@@ -745,7 +798,7 @@ class Test_Response {
 	/**
 	 * Assert that the response has the exact given JSON.
 	 *
-	 * @param  array $data
+	 * @param array<mixed> $data
 	 */
 	public function assertExactJson( array $data ): static {
 		$this->decoded_json()->assertExact( $data );
@@ -756,7 +809,7 @@ class Test_Response {
 	/**
 	 * Assert that the response contains the given JSON fragment.
 	 *
-	 * @param  array $data Data to compare.
+	 * @param  array<mixed> $data Data to compare.
 	 */
 	public function assertJsonFragment( array $data ): static {
 		$this->decoded_json()->assertFragment( $data );
@@ -767,8 +820,8 @@ class Test_Response {
 	/**
 	 * Assert that the response does not contain the given JSON fragment.
 	 *
-	 * @param  array $data Data to compare.
-	 * @param  bool  $exact Flag for exact match, defaults to false.
+	 * @param  array<mixed> $data Data to compare.
+	 * @param  bool         $exact Flag for exact match, defaults to false.
 	 */
 	public function assertJsonMissing( array $data, $exact = false ): static {
 		$this->decoded_json()->assertMissing( $data, $exact );
@@ -779,7 +832,7 @@ class Test_Response {
 	/**
 	 * Assert that the response does not contain the exact JSON fragment.
 	 *
-	 * @param  array $data
+	 * @param  array<mixed> $data
 	 */
 	public function assertJsonMissingExact( array $data ): static {
 		$this->decoded_json()->assertMissingExact( $data );
@@ -793,7 +846,7 @@ class Test_Response {
 	 * @param  int         $count
 	 * @param  string|null $key
 	 */
-	public function assertJsonCount( int $count, $key = null ): static {
+	public function assertJsonCount( int $count, ?string $key = null ): static {
 		$this->decoded_json()->assertCount( $count, $key );
 
 		return $this;

--- a/src/mantle/testing/class-test-response.php
+++ b/src/mantle/testing/class-test-response.php
@@ -722,6 +722,32 @@ class Test_Response {
 	}
 
 	/**
+	 * Assert that a specific path matches the given regular expression pattern in the response.
+	 *
+	 * @param string $path Path to check.
+	 * @param string $pattern Regular expression pattern to match.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertJsonPathMatches( string $path, string $pattern, string $message = '' ): static {
+		$this->decoded_json()->assertPathMatches( $path, $pattern, $message );
+
+		return $this;
+	}
+
+	/**
+	 * Assert that a specific path does not match the given regular expression pattern in the response.
+	 *
+	 * @param string $path Path to check.
+	 * @param string $pattern Regular expression pattern to match.
+	 * @param string $message Optional message on failure.
+	 */
+	public function assertJsonPathNotMatches( string $path, string $pattern, string $message = '' ): static {
+		$this->decoded_json()->assertPathNotMatches( $path, $pattern, $message );
+
+		return $this;
+	}
+
+	/**
 	 * Assert that a specific path exists in the response.
 	 *
 	 * @param string $path Path to check.

--- a/src/mantle/testing/class-test-response.php
+++ b/src/mantle/testing/class-test-response.php
@@ -822,6 +822,21 @@ class Test_Response {
 	}
 
 	/**
+	 * Assert that the value at a given JSON path passes a user-provided callback.
+	 *
+	 * @param string   $path     Path to check.
+	 * @param callable $callback Callback that receives the value at the path and returns true if assertion passes.
+	 * @param string   $message  Optional failure message.
+	 *
+	 * @phpstan-param (callable(mixed): bool) $callback
+	 */
+	public function assertJsonPathCallback( string $path, callable $callback, string $message = '' ): static {
+		$this->decoded_json()->assertPathCallback( $path, $callback, $message );
+
+		return $this;
+	}
+
+	/**
 	 * Assert that the response has the exact given JSON.
 	 *
 	 * @param array<mixed> $data

--- a/tests/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Testing/Concerns/MakesHttpRequestsTest.php
@@ -253,7 +253,8 @@ class MakesHttpRequestsTest extends FrameworkTestCase {
 			->assertJsonPathNotContains( 'title.rendered', 'Not' )
 			->assertJsonPathExists( 'guid' )
 			->assertJsonPathMissing( 'example_path' )
-			->assertJsonPathMatches( 'id', '/^\d+$/' );
+			->assertJsonPathMatches( 'id', '/^\d+$/' )
+			->assertJsonPathCallback( 'title.rendered', fn( $value ) => str_contains( $value, 'Example' ) );
 	}
 
 	public function test_rest_api_route_headers() {

--- a/tests/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Testing/Concerns/MakesHttpRequestsTest.php
@@ -241,12 +241,16 @@ class MakesHttpRequestsTest extends FrameworkTestCase {
 	}
 
 	public function test_rest_api_route() {
-		$post_id = static::factory()->post->create();
+		$post_id = static::factory()->post->create( [ 'post_title' => 'Example Post Title' ] );
 
 		$this->get( rest_url( "wp/v2/posts/{$post_id}" ) )
 			->assertOk()
 			->assertJsonPath( 'id', $post_id )
 			->assertJsonPath( 'title.rendered', get_the_title( $post_id ) )
+			->assertJsonPathNotEmpty( 'title.rendered' )
+			->assertJsonPathEmpty( 'unknown' )
+			->assertJsonPathContains( 'title.rendered', 'Post Title' )
+			->assertJsonPathNotContains( 'title.rendered', 'Not' )
 			->assertJsonPathExists( 'guid' )
 			->assertJsonPathMissing( 'example_path' );
 	}

--- a/tests/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Testing/Concerns/MakesHttpRequestsTest.php
@@ -252,7 +252,8 @@ class MakesHttpRequestsTest extends FrameworkTestCase {
 			->assertJsonPathContains( 'title.rendered', 'Post Title' )
 			->assertJsonPathNotContains( 'title.rendered', 'Not' )
 			->assertJsonPathExists( 'guid' )
-			->assertJsonPathMissing( 'example_path' );
+			->assertJsonPathMissing( 'example_path' )
+			->assertJsonPathMatches( 'id', '/^\d+$/' );
 	}
 
 	public function test_rest_api_route_headers() {

--- a/tests/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Testing/Concerns/MakesHttpRequestsTest.php
@@ -12,6 +12,7 @@ use Mantle\Testing\Concerns\Refresh_Database;
 use Mantle\Testing\Concerns\Reset_Server;
 use Mantle\Testing\FrameworkTestCase;
 use Mantle\Testing\Test_Response;
+use Mantle\Testing\Utils;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -255,6 +256,17 @@ class MakesHttpRequestsTest extends FrameworkTestCase {
 			->assertJsonPathMissing( 'example_path' )
 			->assertJsonPathMatches( 'id', '/^\d+$/' )
 			->assertJsonPathCallback( 'title.rendered', fn( $value ) => str_contains( $value, 'Example' ) );
+	}
+
+	/**
+	 * Test for an issue with parsing an empty JSON array `[]` response.
+	 */
+	public function test_json_parsing_error_empty_array(): void {
+		Utils::delete_all_posts();
+
+		$this->get( rest_url( 'wp/v2/posts' ) )
+			->assertOk()
+			->assertJsonCount( 0 );
 	}
 
 	public function test_rest_api_route_headers() {


### PR DESCRIPTION
## Added

- Added `assertJsonPathEmpty()`, `assertJsonPathNotEmpty()`,
  `assertJsonPathContains()`, `assertJsonPathNotContains()`, and
  `assertJsonPathCallback()` methods to the test response class.

## Fixed

- Fixed issue with empty JSON not being parsed properly with `Assertable_Json_String`.