### PR TITLE
Issue-779: Hookable: add support for validator attributes

### DIFF
--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -212,7 +212,7 @@ trait Hookable {
 				}
 
 				// Check if the method passes all validators.
-				if ( false === $this->fire_validator( $method ) ) {
+				if ( false === $this->validate_method( $method ) ) {
 					continue;
 				}
 

--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -282,13 +282,6 @@ trait Hookable {
 			if ( ! $attribute->newInstance()->validate() ) {
 				return false;
 			}
-
-		// Check all validators for this method.
-		foreach ( $attributes as $attribute ) {
-			$instance = $attribute->newInstance();
-			if ( $instance instanceof \Mantle\Types\Validator && ! $instance->validate() ) {
-				return false;
-			}
 		}
 
 		return true;

--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -133,7 +133,7 @@ trait Hookable {
 					}
 
 					// Check if the method passes all validators.
-					if ( false === $this->fire_validator( $reflection_method ) ) {
+					if ( false === $this->validate_method( $reflection_method ) ) {
 						return null;
 					}
 
@@ -188,7 +188,7 @@ trait Hookable {
 				}
 
 				// Check if the method passes all validators.
-				if ( false === $this->fire_validator( $method ) ) {
+				if ( false === $this->validate_method( $method ) ) {
 					continue;
 				}
 

--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -273,7 +273,6 @@ trait Hookable {
 	 * Fire all validators for a method.
 	 *
 	 * @param ReflectionMethod $method The hook callback method.
-	 * @return bool
 	 */
 	protected function fire_validator( ReflectionMethod $method ): bool {
 		$attributes = $method->getAttributes();
@@ -281,10 +280,8 @@ trait Hookable {
 		// Check all validators for this method.
 		foreach ( $attributes as $attribute ) {
 			$instance = $attribute->newInstance();
-			if ( $instance instanceof \Mantle\Types\Validator ) {
-				if ( ! $instance->validate() ) {
-					return false;
-				}
+			if ( $instance instanceof \Mantle\Types\Validator && ! $instance->validate() ) {
+				return false;
 			}
 		}
 

--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -274,7 +274,7 @@ trait Hookable {
 	 *
 	 * @param ReflectionMethod $method The hook callback method.
 	 */
-	protected function fire_validator( ReflectionMethod $method ): bool {
+	protected function validate_method( ReflectionMethod $method ): bool {
 		$attributes = $method->getAttributes();
 
 		// Check all validators for this method.

--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -23,9 +23,12 @@ use function Mantle\Support\Helpers\collect;
 /**
  * Register all hooks on a class.
  *
- * Collects all of the `Action`/`Filter` attribute methods as well as the
+ * Collects all the `Action`/`Filter` attribute methods as well as the
  * `on_{hook}` and `on_{hook}_at_{priority}` methods and registers them with the
  * respective WordPress hooks.
+ *
+ * It also supports validator attributes that can prevent the
+ * hook from being registered if the validator returns false.
  *
  * Attributes are the preferred way to register hooks but the method naming
  * convention to define the hook name is still supported for backwards
@@ -54,7 +57,7 @@ trait Hookable {
 	/**
 	 * Boot all actions and attribute methods on the service provider.
 	 *
-	 * Collects all of the `on_{hook}`, `on_{hook}_at_{priority}`,
+	 * Collects all the `on_{hook}`, `on_{hook}_at_{priority}`,
 	 * `action__{hook}`, and `filter__{hook}` methods as well as the attribute
 	 * based `#[Action]` and `#[Filter]` methods and registers them with the
 	 * respective WordPress hooks.
@@ -100,7 +103,7 @@ trait Hookable {
 	 */
 	private function collect_action_methods(): Collection {
 		// Determine if the legacy attribute is on the class to allow for duplicate
-		// hook registration when a action method has an attribute.
+		// hook registration when an action method has an attribute.
 		$has_legacy_attribute = collect(
 			( $this->reflection )->getAttributes( Allow_Legacy_Duplicate_Registration::class ),
 		)->is_not_empty();
@@ -110,8 +113,8 @@ trait Hookable {
 				static fn ( string $method ) => Str::starts_with( $method, [ 'on_', 'action__', 'filter__' ] )
 			)
 			->map(
-				function ( string $method ) use ( $has_legacy_attribute ): ?array {
-					$reflection_method = $this->reflection->getMethod( $method );
+				function ( string $method_name ) use ( $has_legacy_attribute ): ?array {
+					$reflection_method = $this->reflection->getMethod( $method_name );
 
 					if ( ! $reflection_method->isPublic() ) {
 						$this->fire_doing_it_wrong( $reflection_method );
@@ -129,20 +132,25 @@ trait Hookable {
 						return null;
 					}
 
+					// Check if the method passes all validators.
+					if ( false === $this->fire_validator( $reflection_method ) ) {
+						return null;
+					}
+
 					$type = match ( true ) {
-						Str::starts_with( $method, 'filter__' ) => 'filter',
+						Str::starts_with( $method_name, 'filter__' ) => 'filter',
 						default => 'action',
 					};
 
 					$hook = match ( true ) {
-						Str::starts_with( $method, 'on_' ) => Str::after( $method, 'on_' ),
-						default => Str::after( $method, $type . '__' ),
+						Str::starts_with( $method_name, 'on_' ) => Str::after( $method_name, 'on_' ),
+						default => Str::after( $method_name, $type . '__' ),
 					};
 
 					$priority = 10;
 
+					// Strip the priority from the hook name.
 					if ( Str::contains( $hook, '_at_' ) ) {
-						// Strip the priority from the hook name.
 						$priority = (int) Str::after_last( $hook, '_at_' );
 						$hook     = Str::before_last( $hook, '_at_' );
 					}
@@ -150,7 +158,7 @@ trait Hookable {
 					return [
 						'type'     => $type,
 						'hook'     => $hook,
-						'method'   => $method,
+						'method'   => $method_name,
 						'priority' => $priority,
 					];
 				}
@@ -160,10 +168,11 @@ trait Hookable {
 	}
 
 	/**
-	 * Collect all attribute actions on the service provider.
+	 * Collect all attribute actions/filters on the service provider.
 	 *
-	 * Allow methods with the `#[Action]` attribute to automatically register
-	 * WordPress hooks.
+	 * Allow methods with the `#[Action]` or `#[Filter]` attribute to automatically register
+	 * WordPress hooks. It also supports validator attributes that can prevent the
+	 * hook from being registered if the validator returns false.
 	 *
 	 * @phpstan-return Collection<int, HookItem>
 	 */
@@ -172,8 +181,14 @@ trait Hookable {
 
 		foreach ( $this->reflection->getMethods() as $method ) {
 			foreach ( $method->getAttributes( Action::class ) as $attribute ) {
+				// Skip non-public methods.
 				if ( ! $method->isPublic() ) {
 					$this->fire_doing_it_wrong( $method );
+					continue;
+				}
+
+				// Check if the method passes all validators.
+				if ( false === $this->fire_validator( $method ) ) {
 					continue;
 				}
 
@@ -190,8 +205,14 @@ trait Hookable {
 			}
 
 			foreach ( $method->getAttributes( Filter::class ) as $attribute ) {
+				// Skip non-public methods.
 				if ( ! $method->isPublic() ) {
 					$this->fire_doing_it_wrong( $method );
+					continue;
+				}
+
+				// Check if the method passes all validators.
+				if ( false === $this->fire_validator( $method ) ) {
 					continue;
 				}
 
@@ -246,5 +267,27 @@ trait Hookable {
 		}
 
 		_doing_it_wrong( esc_html( static::class . '::' . $method->getName() ), esc_html( $message ), '1.0.0' );
+	}
+
+	/**
+	 * Fire all validators for a method.
+	 *
+	 * @param ReflectionMethod $method The hook callback method.
+	 * @return bool
+	 */
+	protected function fire_validator( ReflectionMethod $method ): bool {
+		$attributes = $method->getAttributes();
+
+		// Check all validators for this method.
+		foreach ( $attributes as $attribute ) {
+			$instance = $attribute->newInstance();
+			if ( $instance instanceof \Mantle\Types\Validator ) {
+				if ( ! $instance->validate() ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
 	}
 }

--- a/src/mantle/support/traits/trait-hookable.php
+++ b/src/mantle/support/traits/trait-hookable.php
@@ -275,7 +275,13 @@ trait Hookable {
 	 * @param ReflectionMethod $method The hook callback method.
 	 */
 	protected function validate_method( ReflectionMethod $method ): bool {
-		$attributes = $method->getAttributes();
+		$attributes = $method->getAttributes( \Mantle\Types\Validator::class, \ReflectionAttribute::IS_INSTANCEOF );
+
+		// Check all validators for this method.
+		foreach ( $attributes as $attribute ) {
+			if ( ! $attribute->newInstance()->validate() ) {
+				return false;
+			}
 
 		// Check all validators for this method.
 		foreach ( $attributes as $attribute ) {

--- a/tests/Support/Concerns/TestValidatorAttribute.php
+++ b/tests/Support/Concerns/TestValidatorAttribute.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Mantle\Tests\Support\Concerns;
+
+#[\Attribute( \Attribute::TARGET_METHOD )]
+class TestValidatorAttribute implements \Mantle\Types\Validator {
+	public function __construct(
+		private readonly bool $should_pass = true
+	) {}
+
+	public function validate(): bool {
+		return $this->should_pass;
+	}
+}

--- a/tests/Support/HookableAttributeTest.php
+++ b/tests/Support/HookableAttributeTest.php
@@ -7,8 +7,8 @@ use Mantle\Support\Attributes\Filter;
 use Mantle\Support\Attributes\Hookable\Allow_Legacy_Duplicate_Registration;
 use Mantle\Support\Traits\Hookable;
 use Mantle\Testing\FrameworkTestCase;
+use Mantle\Tests\Support\Concerns\TestValidatorAttribute;
 use PHPUnit\Framework\Attributes\Group;
-
 
 #[Group('hookable')]
 class HookableAttributeTest extends FrameworkTestCase {
@@ -48,7 +48,6 @@ class HookableAttributeTest extends FrameworkTestCase {
 	}
 
 	public function test_action_with_priority(): void {
-
 		$_SERVER['__hook_fired'] = [];
 
 		$class = new class {
@@ -63,7 +62,6 @@ class HookableAttributeTest extends FrameworkTestCase {
 			public function action_at_10( mixed $args ): void {
 				$_SERVER['__hook_fired'][] = 10;
 			}
-
 		};
 
 		// Remove the action that was added by creating the anonymous class.
@@ -78,6 +76,75 @@ class HookableAttributeTest extends FrameworkTestCase {
 		$this->assertSame( [ 10, 20 ], $_SERVER['__hook_fired'] );
 	}
 
+	public function test_action_with_valid_attributes_only(): void {
+		$_SERVER['__hook_fired'] = false;
+
+		$class = new class {
+			use Hookable;
+
+			#[Action( 'example_action' )]
+			public function action_at_20( mixed $args ): void {
+				$_SERVER['__hook_fired'] = $this->get_number();
+			}
+
+			public function get_number(): string {
+				return 'boo';
+			}
+		};
+
+		new $class;
+
+		$this->assertEmpty( $_SERVER['__hook_fired'] );
+
+		do_action( 'example_action', 'foo' );
+
+		$this->assertSame( 'boo', $_SERVER['__hook_fired'] );
+	}
+
+	public function test_action_with_inactive_validator_attribute(): void {
+		$_SERVER['__hook_fired'] = false;
+
+		$class = new class {
+			use Hookable;
+
+			#[TestValidatorAttribute( false )]
+			#[Action( 'example_action' )]
+			public function example_action( mixed $args ): void {
+				$_SERVER['__hook_fired'] = $args;
+			}
+		};
+
+		new $class;
+
+		$this->assertFalse( $_SERVER['__hook_fired'] );
+
+		do_action( 'example_action', 'foo' );
+
+		$this->assertFalse( $_SERVER['__hook_fired'] );
+	}
+
+	public function test_action_with_active_validator_attribute(): void {
+		$_SERVER['__hook_fired'] = false;
+
+		$class = new class {
+			use Hookable;
+
+			#[TestValidatorAttribute( true )]
+			#[Action( 'example_action' )]
+			public function example_action( mixed $args ): void {
+				$_SERVER['__hook_fired'] = $args;
+			}
+		};
+
+		new $class;
+
+		$this->assertFalse( $_SERVER['__hook_fired'] );
+
+		do_action( 'example_action', 'foo' );
+
+		$this->assertSame( 'foo', $_SERVER['__hook_fired'] );
+	}
+
 	public function test_filter(): void {
 		$_SERVER['__hook_fired'] = false;
 
@@ -85,7 +152,7 @@ class HookableAttributeTest extends FrameworkTestCase {
 			use Hookable;
 
 			#[Filter( 'example_action' )]
-			public function filter_the_value( mixed $value ): mixed {
+			public function filter_the_value( mixed $value ): string {
 				$_SERVER['__hook_fired'] = $value;
 
 				return 'bar';
@@ -137,6 +204,60 @@ class HookableAttributeTest extends FrameworkTestCase {
 
 		$this->assertSame( [ 5, 15 ], $_SERVER['__hook_fired'] );
 		$this->assertSame( 35, $value );
+	}
+
+	public function test_filter_with_inactive_validator_attribute(): void {
+		$_SERVER['__hook_fired'] = false;
+
+		$class = new class {
+			use Hookable;
+
+			#[TestValidatorAttribute( false )]
+			#[Filter( 'example_action' )]
+			public function filter_the_value( mixed $value ): string {
+				$_SERVER['__hook_fired'] = $value;
+
+				return 'bar';
+			}
+		};
+
+		remove_all_filters( 'example_action' );
+
+		new $class;
+
+		$this->assertFalse( $_SERVER['__hook_fired'] );
+
+		$value = apply_filters( 'example_action', 'foo' );
+
+		$this->assertEmpty( $_SERVER['__hook_fired'] );
+		$this->assertSame( 'foo', $value );
+	}
+
+	public function test_filter_with_active_validator_attribute(): void {
+		$_SERVER['__hook_fired'] = false;
+
+		$class = new class {
+			use Hookable;
+
+			#[TestValidatorAttribute( true )]
+			#[Filter( 'example_action' )]
+			public function filter_the_value( mixed $value ): string {
+				$_SERVER['__hook_fired'] = $value;
+
+				return 'bar';
+			}
+		};
+
+		remove_all_filters( 'example_action' );
+
+		new $class;
+
+		$this->assertFalse( $_SERVER['__hook_fired'] );
+
+		$value = apply_filters( 'example_action', 'foo' );
+
+		$this->assertSame( 'foo', $_SERVER['__hook_fired'] );
+		$this->assertSame( 'bar', $value );
 	}
 
 	public function test_multiple_filters_on_one_method(): void {

--- a/tests/Support/HookableMethodNameTest.php
+++ b/tests/Support/HookableMethodNameTest.php
@@ -4,6 +4,7 @@ namespace Mantle\Tests\Support;
 
 use Mantle\Support\Traits\Hookable;
 use Mantle\Testing\FrameworkTestCase;
+use Mantle\Tests\Support\Concerns\TestValidatorAttribute;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('hookable')]
@@ -68,6 +69,48 @@ class HookableMethodNameTest extends FrameworkTestCase {
 		do_action( 'example_action', 'foo' );
 
 		$this->assertSame( [ 10, 20 ], $_SERVER['__hook_fired'] );
+	}
+
+	public function test_action_with_inactive_validator_attribute(): void {
+		$_SERVER['__hook_fired'] = false;
+
+		$class = new class {
+			use Hookable;
+
+			#[TestValidatorAttribute( false )]
+			public function action__example_action( mixed $args ): void {
+				$_SERVER['__hook_fired'] = $args;
+			}
+		};
+
+		new $class;
+
+		$this->assertFalse( $_SERVER['__hook_fired'] );
+
+		do_action( 'example_action', 'foo' );
+
+		$this->assertFalse( $_SERVER['__hook_fired'] );
+	}
+
+	public function test_action_with_active_validator_attribute(): void {
+		$_SERVER['__hook_fired'] = false;
+
+		$class = new class {
+			use Hookable;
+
+			#[TestValidatorAttribute( true )]
+			public function action__example_action( mixed $args ): void {
+				$_SERVER['__hook_fired'] = $args;
+			}
+		};
+
+		new $class;
+
+		$this->assertFalse( $_SERVER['__hook_fired'] );
+
+		do_action( 'example_action', 'foo' );
+
+		$this->assertSame( 'foo', $_SERVER['__hook_fired'] );
 	}
 
 	public function test_filter(): void {


### PR DESCRIPTION
### Summary

Fixes #779

Adds support for validator attributes to the `Hookable` trait, enabling conditional registration of hooks based on custom validation logic. Hooks are now only registered if their associated validator attribute passes.

### Description

This PR enhances the `Hookable` trait by introducing support for validator attributes on hook methods. When a method in a class using `Hookable` is decorated with a validator attribute, the hook is only registered if the validator returns `true`. This enables more granular control over which hooks are active, based on custom logic defined in validator attributes.

Key updates include:
- Updates to the `trait-hookable.php` docblocks and logic to document and support validator attributes.
- Addition of a new `TestValidatorAttribute` class for testing, implemented as a PHP attribute that determines hook registration eligibility.
- Expanded test coverage to verify correct behavior when validator attributes are present and return both true and false values.

### Use Case

```php
class MyFeature extends Hookable_Feature {

   #[MyCustomValidator(true)]
   #[Action('init')]
   public function cool_hook(): void {}

   #[MyCustomValidator(true)]
   public function on_cool_hook(): void {}
}
```
With this update, the above hooks will only be registered if `MyCustomValidator` returns `true`.

### Testing Instructions

- Add a validator attribute to a method in a class that uses the `Hookable` trait.
- Confirm that the hook is registered only if the validator condition passes.
- Test with both passing and failing validator conditions to ensure expected behavior.

### Additional Testing Details

- New tests have been introduced in `HookableAttributeTest` and `HookableMethodNameTest` to cover scenarios where validator attributes are active and inactive.
- The `TestValidatorAttribute` is used to simulate both passing and failing validation conditions, confirming that hooks are properly registered or skipped.

### Checklist

- [x] I have tested these changes locally.
- [x] I have added or updated tests as appropriate.
- [ ] I have updated relevant documentation as needed.