### PR TITLE
Issue-782: Better meta support for `Object_Metadata`

### DIFF
--- a/src/mantle/support/class-object-metadata.php
+++ b/src/mantle/support/class-object-metadata.php
@@ -47,7 +47,7 @@ class Object_Metadata implements ArrayAccess, Jsonable, \JsonSerializable, \Stri
 	}
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
 	 * @param string|null $meta_type Meta type.
 	 * @param int|null    $object_id Object ID.
@@ -67,7 +67,7 @@ class Object_Metadata implements ArrayAccess, Jsonable, \JsonSerializable, \Stri
 	 */
 	public function save(): static {
 		if ( ! $this->meta_type || ! $this->object_id || ! $this->meta_key ) {
-			throw new InvalidArgumentException( 'Unable to save sub-property of an metadata.' );
+			throw new InvalidArgumentException( 'Unable to save sub-property of a metadata.' );
 		}
 
 		update_metadata( $this->meta_type, $this->object_id, $this->meta_key, $this->value );
@@ -78,15 +78,62 @@ class Object_Metadata implements ArrayAccess, Jsonable, \JsonSerializable, \Stri
 	}
 
 	/**
-	 * Delete the option.
+	 * Add the meta data.
 	 *
-	 * @throws InvalidArgumentException If the option is a sub-property of an option.
+	 * @throws InvalidArgumentException If the object is retrieving sub-property of a metadata and the meta type is not passed.
+	 */
+	public function add(): static {
+		if ( ! $this->meta_type || ! $this->object_id || ! $this->meta_key ) {
+			throw new InvalidArgumentException( 'Unable to add sub-property of a metadata.' );
+		}
+
+		add_metadata( $this->meta_type, $this->object_id, $this->meta_key, $this->value );
+
+		$this->value = get_metadata( $this->meta_type, $this->object_id, $this->meta_key, true );
+
+		return $this;
+	}
+
+	/**
+	 * Delete the meta data.
+	 *
+	 * @throws InvalidArgumentException If the object is a sub-property of a metadata.
 	 */
 	public function delete(): void {
 		if ( ! $this->meta_type || ! $this->object_id || ! $this->meta_key ) {
-			throw new InvalidArgumentException( 'Unable to delete option on a sub-property of an option.' );
+			throw new InvalidArgumentException( 'Unable to delete meta on a sub-property of a metadata.' );
 		}
 
 		delete_metadata( $this->meta_type, $this->object_id, $this->meta_key );
+	}
+
+	/**
+	 * Delete a specific meta key that matches the value.
+	 *
+	 * @param mixed $value Value to delete.
+	 *
+	 * @throws InvalidArgumentException If the object is a sub-property of a metadata.
+	 */
+	public function delete_value( mixed $value ): void {
+		if ( ! $this->meta_type || ! $this->object_id || ! $this->meta_key ) {
+			throw new InvalidArgumentException( 'Unable to delete meta on a sub-property of a metadata.' );
+		}
+
+		delete_metadata( $this->meta_type, $this->object_id, $this->meta_key, $value );
+	}
+
+	/**
+	 * Fetch all meta values for the given meta.
+	 *
+	 * @throws InvalidArgumentException If the object is a sub-property of a metadata.
+	 */
+	public function all(): static {
+		if ( ! $this->meta_type || ! $this->object_id || ! $this->meta_key ) {
+			throw new InvalidArgumentException( 'Unable to fetch all meta on a sub-property of a metadata.' );
+		}
+
+		$value = get_metadata( $this->meta_type, $this->object_id, $this->meta_key );
+
+		return new static( $this->meta_type, $this->object_id, $this->meta_key, $value, $this->throw );
 	}
 }

--- a/src/mantle/support/class-option.php
+++ b/src/mantle/support/class-option.php
@@ -23,8 +23,8 @@ class Option implements ArrayAccess, Jsonable, \JsonSerializable, \Stringable {
 	/**
 	 * Retrieve an option from the database.
 	 *
-	 * @param string $option Option name.
-	 * @param mixed  $default Default value. Default is null.
+	 * @param string|null $option Option name.
+	 * @param mixed       $default Default value. Default is null.
 	 */
 	public static function of( ?string $option, mixed $default = null ): static {
 		return new static( $option, get_option( $option, $default ) );

--- a/tests/Support/InteractsWithData/ObjectMetadataTest.php
+++ b/tests/Support/InteractsWithData/ObjectMetadataTest.php
@@ -54,6 +54,25 @@ class ObjectMetadataTest extends FrameworkTestCase {
 	}
 
 	#[DataProvider('objectTypeProvider')]
+	public function test_add_data( string $object_type ): void {
+		$object_id = static::factory()->{$object_type}->create();
+		$metadata  = Object_Metadata::of( $object_type, $object_id, 'test_meta' );
+
+		$metadata->set( 'new-test' );
+		$metadata->add();
+
+		$metadata->set( 'new-test-2' );
+		$metadata->add();
+
+		$all_values = $metadata->all()->array();
+
+		// Test all meta values from the same key are retrieved.
+		$this->assertCount( 2, $all_values );
+		$this->assertEquals( [ 'new-test', 'new-test-2' ], $metadata->all()->array() );
+		$this->assertSame( get_metadata( $object_type, $object_id, 'test_meta' ),$all_values );
+	}
+
+	#[DataProvider('objectTypeProvider')]
 	public function test_update_data( string $object_type ): void {
 		$object_id = static::factory()->{$object_type}->create();
 
@@ -79,6 +98,28 @@ class ObjectMetadataTest extends FrameworkTestCase {
 		$metadata->delete();
 
 		$this->assertEmpty( get_metadata( $object_type, $object_id, 'test_meta', true ) );
+	}
+
+	#[DataProvider('objectTypeProvider')]
+	public function test_delete_data_value( string $object_type ): void {
+		$object_id = static::factory()->{$object_type}->create();
+		$metadata = Object_Metadata::of( $object_type, $object_id, 'test_meta' );
+
+		$value1 = 'new-test';
+		$value2 = 'new-test-2';
+
+		$metadata->set( $value1 );
+		$metadata->add();
+
+		$metadata->set( $value2 );
+		$metadata->add();
+
+		$metadata->delete_value( $value1 );
+
+		$refreshed = Object_Metadata::of( $object_type, $object_id, 'test_meta' );
+
+		$this->assertSame( $value2, $refreshed->value() );
+		$this->assertNotEmpty( $refreshed->string() );
 	}
 
 	#[DataProvider('objectTypeProvider')]


### PR DESCRIPTION
### Summary

Fixes #782

### Description

This pull request significantly improves the flexibility and robustness of the `Object_Metadata` class. It addresses previous limitations by enabling the deletion of specific unique metadata values, supporting retrieval of all values associated with a given meta key, and allowing multiple unique values to be saved under the same key for an object. Documentation and exception messages have also been clarified for better maintainability. Additionally, related documentation in the `Option` class has been updated to accurately reflect nullable parameter types.

### Changes

- Enhanced `Object_Metadata` to support:
  - Adding multiple values for the same meta key.
  - Retrieving all values for a given meta key.
  - Deleting a specific meta key/value pair.
- Improved docblocks and exception messages for clarity and accuracy.
- Updated PHPDoc in the `Option` class to reflect nullable parameters.
- Added comprehensive tests:
  - Verifying addition and retrieval of multiple values for the same meta key.
  - Ensuring deletion of a specific metadata value functions as expected.

### Testing

- Confirm that multiple unique values can be added and retrieved for the same meta key.
- Verify that deleting a specific unique meta value works as intended.
- Ensure that documentation and exception messages are clear and accurate.
- All new and existing tests pass, including those for the new functionalities.

### Related Issue

Closes #782