### PR TITLE
Make multiple properties private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.10.1
+
+### Changed
+
+- Multiple properties in `Makes_Http_Requests` are now private to prevent
+  unintended side effects from tests that modify these properties directly.
+
 ## v1.10.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.10.1
+## Unreleased
 
 ### Changed
 

--- a/src/mantle/testing/concerns/trait-interacts-with-requests.php
+++ b/src/mantle/testing/concerns/trait-interacts-with-requests.php
@@ -41,14 +41,14 @@ trait Interacts_With_Requests {
 	 *
 	 * @var Collection<int, StubCallback>
 	 */
-	protected Collection $stub_callbacks;
+	private Collection $stub_callbacks;
 
 	/**
 	 * Storage of request URLs.
 	 *
 	 * @var Collection<int, Request>
 	 */
-	protected Collection $recorded_requests;
+	private Collection $recorded_requests;
 
 	/**
 	 * Flag to prevent external requests from being made. By default, this is
@@ -56,21 +56,21 @@ trait Interacts_With_Requests {
 	 *
 	 * @var Mock_Http_Response|callable|bool
 	 */
-	protected mixed $preventing_stray_requests = false;
+	private mixed $preventing_stray_requests = false;
 
 	/**
 	 * Stray requests that should be ignored (not reported).
 	 *
 	 * @var Collection<int, string>
 	 */
-	protected Collection $ignored_strayed_requests;
+	private Collection $ignored_strayed_requests;
 
 	/**
 	 * Recorded actual HTTP requests made during the test.
 	 *
 	 * @var Collection<int, string>
 	 */
-	protected Collection $recorded_actual_requests;
+	private Collection $recorded_actual_requests;
 
 	/**
 	 * Setup the trait.
@@ -100,6 +100,13 @@ trait Interacts_With_Requests {
 	 */
 	public function prevent_stray_requests( Mock_Http_Response|Closure|bool $response = true ): void {
 		$this->preventing_stray_requests = $response;
+	}
+
+	/**
+	 * Determine if stray requests are being prevented.
+	 */
+	public function is_preventing_stray_requests(): bool {
+		return false !== $this->preventing_stray_requests;
 	}
 
 	/**

--- a/src/mantle/testing/concerns/trait-makes-http-requests.php
+++ b/src/mantle/testing/concerns/trait-makes-http-requests.php
@@ -31,33 +31,33 @@ trait Makes_Http_Requests {
 	 *
 	 * @var array<string, string>
 	 */
-	protected array $default_cookies = [];
+	private array $default_cookies = [];
 
 	/**
 	 * Additional headers for the request.
 	 *
 	 * @var array<string, string>
 	 */
-	protected array $default_headers = [];
+	private array $default_headers = [];
 
 	/**
 	 * Whether to use HTTPS by default.
 	 */
-	protected bool|null $default_https = null;
+	private bool|null $default_https = null;
 
 	/**
 	 * The array of callbacks to be run before the event is started.
 	 *
 	 * @var array<callable>
 	 */
-	protected array $before_callbacks = [];
+	private array $before_callbacks = [];
 
 	/**
 	 * The array of callbacks to be run after the event is finished.
 	 *
 	 * @var array<callable>
 	 */
-	protected array $after_callbacks = [];
+	private array $after_callbacks = [];
 
 	/**
 	 * Backup of global WordPress dependencies.

--- a/tests/Testing/Concerns/InteractsWithExternalRequestsTest.php
+++ b/tests/Testing/Concerns/InteractsWithExternalRequestsTest.php
@@ -350,8 +350,7 @@ class InteractsWithExternalRequestsTest extends FrameworkTestCase {
 	}
 
 	public function test_prevent_remote_requests_trait() {
-		// The trait sets up the default response.
-		$this->assertInstanceOf( Mock_Http_Response::class, $this->preventing_stray_requests );
+		$this->assertTrue( $this->is_preventing_stray_requests() );
 
 		wp_remote_get( 'https://example.com/' );
 	}


### PR DESCRIPTION
Prevents IDEs from suggesting a property (incorrect) instead of the method (correct) to use with traits.