### PR TITLE
Add separate testing for VIP mu-plugins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
         # https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
         php: [8.2, 8.3, 8.4, 8.5]
         wordpress: ${{fromJson(needs.get-versions.outputs.versions)}}
-        vip-mu-plugins: ["true", "false"]
+        vip-mu-plugins: [true, false]
         exclude:
           # WordPress 6.7 added support for PHP 8.4.
           - php: 8.4
@@ -121,9 +121,9 @@ jobs:
 #    concurrency:
 #      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}-MS${{ matrix.multisite && '1' || '0' }}-D${{ matrix.dependencies }}-VIP${{ matrix.vip-mu-plugins && '1' || '0' }}
 #      cancel-in-progress: true
-    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} ${{ matrix.multisite && 'Multisite ' || '' }}Dependencies ${{ matrix.dependencies }}${{ matrix.vip-mu-plugins == "true" && ' vip-mu-plugins' || '' }}"
+    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} ${{ matrix.multisite && 'Multisite ' || '' }}Dependencies ${{ matrix.dependencies }}${{ matrix.vip-mu-plugins && ' vip-mu-plugins' || '' }}"
     env:
-      MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins == 'true' && '1' || '0' }}
+      MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -146,14 +146,14 @@ jobs:
       matrix:
         php: [8.3, 8.4]
         wordpress: ["latest"]
-        vip-mu-plugins: ["true", "false"]
+        vip-mu-plugins: [true, false]
     runs-on: ubuntu-latest
 #    concurrency:
 #      group: parallel-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}
 #      cancel-in-progress: true
-    name: "Parallel PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }}${{ matrix.vip-mu-plugins == "true" && ' vip-mu-plugins' || '' }}"
+    name: "Parallel PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }}"
     env:
-      MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins == 'true' && '1' || '0' }}
+      MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -161,7 +161,7 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           install-command: 'composer require --dev --no-update brianium/paratest && composer update --prefer-dist --no-interaction --no-progress'
-          php-version: '${{ matrix.php }}'s
+          php-version: '${{ matrix.php }}'
           skip-wordpress-install: 'true'
           test-command: 'WP_PHPUNIT_PATH=vendor/bin/paratest ./vendor/bin/paratest'
           wordpress-host: 'false'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
         # https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
         php: [8.2, 8.3, 8.4, 8.5]
         wordpress: ${{fromJson(needs.get-versions.outputs.versions)}}
-        vip-mu-plugins: [true, false]
+        vip-mu-plugins: ["true", "false"]
         exclude:
           # WordPress 6.7 added support for PHP 8.4.
           - php: 8.4
@@ -121,7 +121,7 @@ jobs:
 #    concurrency:
 #      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}-MS${{ matrix.multisite && '1' || '0' }}-D${{ matrix.dependencies }}-VIP${{ matrix.vip-mu-plugins && '1' || '0' }}
 #      cancel-in-progress: true
-    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} ${{ matrix.multisite && 'Multisite ' || '' }}Dependencies ${{ matrix.dependencies }}${{ matrix.vip-mu-plugins && ' vip-mu-plugins' || '' }}"
+    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} ${{ matrix.multisite && 'Multisite ' || '' }}Dependencies ${{ matrix.dependencies }}${{ matrix.vip-mu-plugins == "true" && ' vip-mu-plugins' || '' }}"
     env:
       MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins == 'true' && '1' || '0' }}
     steps:
@@ -146,12 +146,12 @@ jobs:
       matrix:
         php: [8.3, 8.4]
         wordpress: ["latest"]
-        vip-mu-plugins: [true, false]
+        vip-mu-plugins: ["true", "false"]
     runs-on: ubuntu-latest
 #    concurrency:
 #      group: parallel-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}
 #      cancel-in-progress: true
-    name: "Parallel PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }}"
+    name: "Parallel PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }}${{ matrix.vip-mu-plugins == "true" && ' vip-mu-plugins' || '' }}"
     env:
       MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins == 'true' && '1' || '0' }}
     steps:
@@ -161,7 +161,7 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           install-command: 'composer require --dev --no-update brianium/paratest && composer update --prefer-dist --no-interaction --no-progress'
-          php-version: '${{ matrix.php }}'
+          php-version: '${{ matrix.php }}'s
           skip-wordpress-install: 'true'
           test-command: 'WP_PHPUNIT_PATH=vendor/bin/paratest ./vendor/bin/paratest'
           wordpress-host: 'false'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,18 +82,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dependencies: ["prefer-lowest", "prefer-stable"]
+        dependencies: ["prefer-stable"]
         multisite: [true, false]
         # See core's PHP Compatibility chart:
         # https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
         php: [8.2, 8.3, 8.4, 8.5]
         wordpress: ${{fromJson(needs.get-versions.outputs.versions)}}
+        vip-mu-plugins: [true, false]
         exclude:
-          # Skip testing with prefer-lowest on more recent PHP versions at this time.
-          - php: 8.4
-            dependencies: "prefer-lowest"
-          - php: 8.5
-            dependencies: "prefer-lowest"
           # WordPress 6.7 added support for PHP 8.4.
           - php: 8.4
             wordpress: "6.6"
@@ -111,25 +107,23 @@ jobs:
             wordpress: "6.6"
           - php: 8.5
             wordpress: "6.5"
-        # Test various older versions of WordPress in a limited capacity.
-        # include:
-        #   - php: 8.3
-        #     wordpress: "6.5"
-        #     dependencies: "prefer-stable"
-        #     multisite: true
-        #   - php: 8.3
-        #     wordpress: "6.6"
-        #     dependencies: "prefer-stable"
-        #     multisite: true
-        #   - php: 8.3
-        #     wordpress: "6.7"
-        #     dependencies: "prefer-stable"
-        #     multisite: true
+        include:
+          # Test with prefer-lowest selectively to check for compatibility issues with older dependencies.
+          - php: 8.3
+            wordpress: "latest"
+            dependencies: "prefer-lowest"
+            multisite: true
+          - php: 8.4
+            wordpress: "latest"
+            dependencies: "prefer-lowest"
+            multisite: true
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}-MS${{ matrix.multisite && '1' || '0' }}-D${{ matrix.dependencies }}
-      cancel-in-progress: true
-    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} ${{ matrix.multisite && 'Multisite' || '' }} Dependencies ${{ matrix.dependencies }}"
+#    concurrency:
+#      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}-MS${{ matrix.multisite && '1' || '0' }}-D${{ matrix.dependencies }}-VIP${{ matrix.vip-mu-plugins && '1' || '0' }}
+#      cancel-in-progress: true
+    name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} ${{ matrix.multisite && 'Multisite ' || '' }}Dependencies ${{ matrix.dependencies }}${{ matrix.vip-mu-plugins && ' vip-mu-plugins' || '' }}"
+    env:
+      MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins == 'true' && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -152,11 +146,14 @@ jobs:
       matrix:
         php: [8.3, 8.4]
         wordpress: ["latest"]
+        vip-mu-plugins: [true, false]
     runs-on: ubuntu-latest
-    concurrency:
-      group: parallel-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}
-      cancel-in-progress: true
+#    concurrency:
+#      group: parallel-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}
+#      cancel-in-progress: true
     name: "Parallel PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }}"
+    env:
+      MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins == 'true' && '1' || '0' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,10 +113,6 @@ jobs:
             wordpress: "latest"
             dependencies: "prefer-lowest"
             multisite: true
-          - php: 8.4
-            wordpress: "latest"
-            dependencies: "prefer-lowest"
-            multisite: true
     runs-on: ubuntu-latest
     name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} ${{ matrix.multisite && 'Multisite ' || '' }}Dependencies ${{ matrix.dependencies }}${{ matrix.vip-mu-plugins && ' vip-mu-plugins' || '' }}"
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,9 +118,6 @@ jobs:
             dependencies: "prefer-lowest"
             multisite: true
     runs-on: ubuntu-latest
-#    concurrency:
-#      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}-MS${{ matrix.multisite && '1' || '0' }}-D${{ matrix.dependencies }}-VIP${{ matrix.vip-mu-plugins && '1' || '0' }}
-#      cancel-in-progress: true
     name: "PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }} ${{ matrix.multisite && 'Multisite ' || '' }}Dependencies ${{ matrix.dependencies }}${{ matrix.vip-mu-plugins && ' vip-mu-plugins' || '' }}"
     env:
       MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins && '1' || '0' }}
@@ -148,9 +145,6 @@ jobs:
         wordpress: ["latest"]
         vip-mu-plugins: [true, false]
     runs-on: ubuntu-latest
-#    concurrency:
-#      group: parallel-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-P${{ matrix.php }}-WP${{ matrix.wordpress }}
-#      cancel-in-progress: true
     name: "Parallel PR Tests PHP ${{ matrix.php }} WordPress ${{ matrix.wordpress }}"
     env:
       MANTLE_INSTALL_VIP_MU_PLUGINS: ${{ matrix.vip-mu-plugins && '1' || '0' }}

--- a/src/mantle/http/class-request.php
+++ b/src/mantle/http/class-request.php
@@ -45,7 +45,7 @@ class Request extends SymfonyRequest implements ArrayAccess, Arrayable {
 	protected $route;
 
 	/**
-	 * All of the converted files for the request.
+	 * All the converted files for the request.
 	 *
 	 * @var array<\Mantle\Http\Uploaded_File>|null
 	 */
@@ -68,7 +68,7 @@ class Request extends SymfonyRequest implements ArrayAccess, Arrayable {
 
 		if ( str_starts_with( (string) $request->headers->get( 'CONTENT_TYPE', '' ), 'application/x-www-form-urlencoded' ) && \in_array( strtoupper( (string) $request->server->get( 'REQUEST_METHOD', 'GET' ) ), [ 'PUT', 'DELETE', 'PATCH' ], true ) ) {
 			parse_str( $request->getContent(), $data );
-			$request->request = new InputBag( $data );
+			$request->request = new InputBag( $data ); // @phpstan-ignore-line argument.type
 		}
 
 		return $request;
@@ -164,7 +164,7 @@ class Request extends SymfonyRequest implements ArrayAccess, Arrayable {
 	}
 
 	/**
-	 * Get all of the segments for the request path.
+	 * Get all the segments for the request path.
 	 *
 	 * @return array<mixed>
 	 */
@@ -228,7 +228,7 @@ class Request extends SymfonyRequest implements ArrayAccess, Arrayable {
 	}
 
 	/**
-	 * Determine if the request is the result of an prefetch call.
+	 * Determine if the request is the result of a prefetch call.
 	 */
 	public function prefetch(): bool {
 		return 0 === strcasecmp( (string) $this->server->get( 'HTTP_X_MOZ' ), 'prefetch' ) ||
@@ -351,7 +351,7 @@ class Request extends SymfonyRequest implements ArrayAccess, Arrayable {
 	}
 
 	/**
-	 * Get all of the input and files for the request.
+	 * Get all the input and files for the request.
 	 */
 	public function to_array(): array {
 		return $this->all();
@@ -468,7 +468,7 @@ class Request extends SymfonyRequest implements ArrayAccess, Arrayable {
 	/**
 	 * Get an input element from the request.
 	 *
-	 * @param  string $key
+	 * @param  string $key Key to get.
 	 */
 	public function __get( string $key ): mixed {
 		return Arr::get(

--- a/src/mantle/http/trait-interacts-with-input.php
+++ b/src/mantle/http/trait-interacts-with-input.php
@@ -167,7 +167,7 @@ trait Interacts_With_Input {
 	/**
 	 * Get the keys for all of the input and files.
 	 *
-	 * @return array<string>
+	 * @return array<int|string>
 	 */
 	public function keys(): array {
 		return array_merge( array_keys( $this->input() ), $this->files->keys() );

--- a/src/mantle/support/class-higher-order-collection-proxy.php
+++ b/src/mantle/support/class-higher-order-collection-proxy.php
@@ -18,7 +18,6 @@ class Higher_Order_Collection_Proxy {
 	 *
 	 * @param  Enumerable $collection The collection being operated on.
 	 * @param  string     $method     The method being proxied.
-	 * @return void
 	 */
 	public function __construct( protected Enumerable $collection, protected string $method ) {}
 

--- a/src/mantle/support/class-higher-order-when-proxy.php
+++ b/src/mantle/support/class-higher-order-when-proxy.php
@@ -19,7 +19,6 @@ class Higher_Order_When_Proxy {
 	 *
 	 * @param  mixed $target The target being conditionally operated on.
 	 * @param  bool  $condition The condition for proxying.
-	 * @return void
 	 */
 	public function __construct( protected mixed $target, protected bool $condition ) {}
 

--- a/src/mantle/support/class-stringable.php
+++ b/src/mantle/support/class-stringable.php
@@ -41,7 +41,6 @@ class Stringable implements ArrayAccess, JsonSerializable, \Stringable {
 	 * Create a new instance of the class.
 	 *
 	 * @param  string $value
-	 * @return void
 	 */
 	public function __construct( $value = '' ) {
 		$this->value = (string) $value;

--- a/src/mantle/testing/class-pending-testable-request.php
+++ b/src/mantle/testing/class-pending-testable-request.php
@@ -352,7 +352,7 @@ class Pending_Testable_Request {
 			) {
 				parse_str( $request->getContent(), $data );
 
-				$request->request = new InputBag( $data );
+				$request->request = new InputBag( $data ); // @phpstan-ignore-line argument.type
 			}
 
 			$this->test_case->app->instance( 'request', $request );

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -432,7 +432,9 @@ class Utils {
 
 		$branch = static::env( 'MANTLE_CI_BRANCH', 'HEAD' );
 
-		putenv( 'WP_CORE_DIR=' . $directory );
+		if ( ! self::env( 'WP_CORE_DIR', false ) ) {
+			putenv( "WP_CORE_DIR={$directory}" ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
+		}
 
 		// Compile the variables to pass to the shell script.
 		$variables = collect(

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -560,6 +560,18 @@ class Utils {
 	}
 
 	/**
+	 * Output a debug message if in debug mode.
+	 *
+	 * @param string $message Message to output.
+	 * @param string $prefix  Optional prefix for the message.
+	 */
+	public static function debug( string $message, string $prefix = 'Install' ): void {
+		if ( static::is_debug_mode() ) {
+			static::info( $message, $prefix );
+		}
+	}
+
+	/**
 	 * Check if we're running in a CI (Continuous Integration) environment.
 	 */
 	public static function is_ci(): bool {

--- a/src/mantle/testing/class-utils.php
+++ b/src/mantle/testing/class-utils.php
@@ -432,6 +432,8 @@ class Utils {
 
 		$branch = static::env( 'MANTLE_CI_BRANCH', 'HEAD' );
 
+		putenv( 'WP_CORE_DIR=' . $directory );
+
 		// Compile the variables to pass to the shell script.
 		$variables = collect(
 			[

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -80,6 +80,8 @@ trait Rsync_Installation {
 	/**
 	 * Add a callback to be run before rsync-ing the codebase.
 	 *
+	 * This is fired after WordPress has been installed but before the code base is rsync-d over
+	 *
 	 * @param callable $callback Callback to invoke before rsync.
 	 * @phpstan-param (callable(Installation_Manager $manager, string $base_install_path): void) $callback
 	 */
@@ -90,7 +92,7 @@ trait Rsync_Installation {
 	}
 
 	/**
-	 * Add a callback to be run after rsync-ing the codebase.
+	 * Add a callback to be run after rsync-ing the codebase..
 	 *
 	 * @param callable $callback Callback to invoke after rsync.
 	 * @phpstan-param (callable(Installation_Manager $manager, string $base_install_path): void) $callback
@@ -102,7 +104,7 @@ trait Rsync_Installation {
 	}
 
 	/**
-	 * Add the default set of exclusions to the list of exclusions to be used when rsyncing the codebase.
+	 * Add the default set of exclusions to the list of exclusions to be used when rsync-ing the codebase.
 	 */
 	public function with_default_exclusions(): static {
 		return $this->exclusions(

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -12,6 +12,7 @@ namespace Mantle\Testing\Concerns;
 
 use Mantle\Support\Str;
 use Mantle\Support\Traits\Conditionable;
+use Mantle\Testing\Installation_Manager;
 use Mantle\Testing\Utils;
 
 use function Mantle\Support\Helpers\collect;

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -380,7 +380,7 @@ trait Rsync_Installation {
 	/**
 	 * Retrieve the default installation path to rsync to.
 	 */
-	protected function get_installation_path(): string {
+	public function get_installation_path(): string {
 		return getenv( 'WP_CORE_DIR' ) ?: sys_get_temp_dir() . '/wordpress';
 	}
 
@@ -388,7 +388,7 @@ trait Rsync_Installation {
 	 * Check if the current installation is underneath an existing WordPress
 	 * installation.
 	 */
-	protected function is_within_wordpress_install(): bool {
+	public function is_within_wordpress_install(): bool {
 		return false !== strpos( __DIR__, '/wp-content/' );
 	}
 

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -64,6 +64,44 @@ trait Rsync_Installation {
 	protected array $rsync_exclusions = [];
 
 	/**
+	 * Callbacks for before rsync-ing the codebase.
+	 *
+	 * @var (callable(Installation_Manager $manager, string $base_install_path): void)[]
+	 */
+	protected array $before_rsync_callbacks = [];
+
+	/**
+	 * Callbacks for after rsync-ing the codebase.
+	 *
+	 * @var (callable(Installation_Manager $manager, string $base_install_path): void)[]
+	 */
+	protected array $after_rsync_callbacks = [];
+
+	/**
+	 * Add a callback to be run before rsync-ing the codebase.
+	 *
+	 * @param callable $callback Callback to invoke before rsync.
+	 * @phpstan-param (callable(Installation_Manager $manager, string $base_install_path): void) $callback
+	 */
+	public function before_rsync( callable $callback ): static {
+		$this->before_rsync_callbacks[] = $callback;
+
+		return $this;
+	}
+
+	/**
+	 * Add a callback to be run after rsync-ing the codebase.
+	 *
+	 * @param callable $callback Callback to invoke after rsync.
+	 * @phpstan-param (callable(Installation_Manager $manager, string $base_install_path): void) $callback
+	 */
+	public function after_rsync( callable $callback ): static {
+		$this->after_rsync_callbacks[] = $callback;
+
+		return $this;
+	}
+
+	/**
 	 * Add the default set of exclusions to the list of exclusions to be used when rsyncing the codebase.
 	 */
 	public function with_default_exclusions(): static {
@@ -463,6 +501,10 @@ trait Rsync_Installation {
 			exit( 1 );
 		}
 
+		foreach ( $this->before_rsync_callbacks as $callback ) {
+			$callback( $this, $base_install_path );
+		}
+
 		$retval = -1;
 
 		// Rsync the from folder to the destination.
@@ -498,6 +540,10 @@ trait Rsync_Installation {
 
 		if ( ! empty( $this->plugins ) ) {
 			$this->perform_plugin_installation( $base_install_path );
+		}
+
+		foreach ( $this->after_rsync_callbacks as $after_rsync_callback ) {
+			$after_rsync_callback( $this, $base_install_path );
 		}
 
 		Utils::success(

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -504,8 +504,8 @@ trait Rsync_Installation {
 			exit( 1 );
 		}
 
-		foreach ( $this->before_rsync_callbacks as $callback ) {
-			$callback( $this, $base_install_path );
+		foreach ( $this->before_rsync_callbacks as $before_rsync_callback ) {
+			$before_rsync_callback( $this, $base_install_path );
 		}
 
 		$retval = -1;

--- a/src/mantle/testing/concerns/trait-rsync-installation.php
+++ b/src/mantle/testing/concerns/trait-rsync-installation.php
@@ -179,6 +179,7 @@ trait Rsync_Installation {
 	 *
 	 * @param bool|string $install The object cache provider to install (redis/memcached)
 	 *                             or true to install the default Memcached object cache (legacy).
+	 * @phpstan-param 'redis'|'memcached'|bool $install
 	 */
 	public function with_object_cache( bool|string $install = true ): static {
 		if ( $this->is_within_wordpress_install() ) {
@@ -518,7 +519,7 @@ trait Rsync_Installation {
 	}
 
 	/**
-	 * Perform the plugin installation after rsyncing the codebase.
+	 * Perform the plugin installation after rsync-ing the codebase.
 	 *
 	 * @param string $dir Directory to the WordPress installation.
 	 */

--- a/tests/Database/Factory/UnitTestingFactoryTest.php
+++ b/tests/Database/Factory/UnitTestingFactoryTest.php
@@ -58,14 +58,10 @@ class UnitTestingFactoryTest extends FrameworkTestCase {
 	}
 
 	/**
-	 * Suppress the deprecation notice for PHPUnit >= 12.
+	 * Suppress the deprecation notice but keep testing it.
 	 */
 	public function test_post_create_with_thumbnail() {
-		if ( static::phpunit_version_compare( '12.0.0', '>=' ) ) {
-			$post_id = @static::factory()->post->create_with_thumbnail();
-		} else {
-			$post_id = static::factory()->post->create_with_thumbnail();
-		}
+		$post_id = @static::factory()->post->create_with_thumbnail();
 
 		$this->assertTrue( has_post_thumbnail( $post_id ) );
 	}

--- a/tests/Testing/Concerns/InteractsWithExternalRequestsTest.php
+++ b/tests/Testing/Concerns/InteractsWithExternalRequestsTest.php
@@ -337,10 +337,13 @@ class InteractsWithExternalRequestsTest extends FrameworkTestCase {
 
 		$this->ignore_stray_request( 'https://alley.com/*' );
 
-		$request = Http::get( 'https://alley.com/' );
+		// Retry to prevent failures with networking.
+		retry( 3, function (): void {
+			$request = Http::get( 'https://alley.com/' );
 
-		$this->assertEquals( 200, $request->status() );
-		$this->assertStringContainsString( 'Alley', $request->body() );
+			$this->assertEquals( 200, $request->status() );
+			$this->assertStringContainsString( 'Alley', $request->body() );
+		}, 1000 );
 
 		$this->assertRequestSent( 'https://alley.com/' );
 

--- a/tests/Testing/Concerns/InteractsWithExternalRequestsTest.php
+++ b/tests/Testing/Concerns/InteractsWithExternalRequestsTest.php
@@ -15,6 +15,8 @@ use Mantle\Testing\Mock_Http_Sequence;
 use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
+use function Mantle\Support\Helpers\retry;
+
 use function Mantle\Testing\mock_http_response;
 
 /**

--- a/tests/Testing/Concerns/InteractsWithExternalRequestsTest.php
+++ b/tests/Testing/Concerns/InteractsWithExternalRequestsTest.php
@@ -339,7 +339,7 @@ class InteractsWithExternalRequestsTest extends FrameworkTestCase {
 
 		// Retry to prevent failures with networking.
 		retry( 3, function (): void {
-			$request = Http::get( 'https://alley.com/' );
+			$request = Http::create()->throw_exception()->get( 'https://alley.com/' );
 
 			$this->assertEquals( 200, $request->status() );
 			$this->assertStringContainsString( 'Alley', $request->body() );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,7 +30,8 @@ if ( Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ) )  {
 		fn ( Installation_Manager $manager ) => $manager
 				->with_vip_mu_plugins()
 				->before( function (): void {
-					// Copy plugins/jetpack to client-mu-plugins/jetpack to allow it to be pinned.
+					// Copy plugins/jetpack to client-mu-plugins/jetpack to allow it to be pinned to a specific version.
+					// VIP requires it to be placed in client-mu-plugins/jetpack.
 					$retcode = 0;
 					$output = Utils::command( 'WP_CORE_DIR && mkdir $WP_CORE_DIR/wp-content/client-mu-plugins && cp -r $WP_CORE_DIR/wp-content/plugins/jetpack $WP_CORE_DIR/wp-content/client-mu-plugins/jetpack', $retcode );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,7 +15,7 @@ define( 'MANTLE_PHPUNIT_FIXTURES_PATH', __DIR__ . '/fixtures' );
 define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 
 // Enable debugging flag for local development on the testing framework.
-// define( 'MANTLE_TESTING_DEBUG', true );
+ define( 'MANTLE_TESTING_DEBUG', true );
 
 // For WordPress VIP testing, pin Jetpack to a specific version.
 if ( Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ) )  {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ define( 'MANTLE_PHPUNIT_FIXTURES_PATH', __DIR__ . '/fixtures' );
 define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 
 // Enable debugging flag for local development on the testing framework.
- define( 'MANTLE_TESTING_DEBUG', true );
+// define( 'MANTLE_TESTING_DEBUG', true );
 
 // For WordPress VIP testing, pin Jetpack to a specific version.
 if ( Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ) )  {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,10 @@
 /**
  * Framework Tests Bootstrap
  *
+ * This is an internal bootstrap file used by the Mantle testing framework. To create your own bootstrap file,
+ * see {@link https://github.com/alleyinteractive/mantle/blob/develop/tests/bootstrap.php}
+ * and {@link https://mantle.alley.com/docs/testing}.
+ *
  * @package Mantle
  */
 
@@ -27,28 +31,29 @@ if ( Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ) )  {
 	->maybe_rsync_plugin()
 	->when(
 		Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ),
-		fn ( Installation_Manager $manager ) => $manager->with_vip_mu_plugins()->before( function () use ( $manager ): void {
-			if ( $manager->is_within_wordpress_install() ) {
-				return;
-			}
-
-			// Copy plugins/jetpack to client-mu-plugins/jetpack to allow it to be pinned to a specific version.
-			// VIP requires it to be placed in client-mu-plugins/jetpack.
-			$retcode = 0;
-			$output  = Utils::command(
-				sprintf(
-					'WP_CORE_DIR=%s mkdir $WP_CORE_DIR/wp-content/client-mu-plugins && cp -r $WP_CORE_DIR/wp-content/plugins/jetpack $WP_CORE_DIR/wp-content/client-mu-plugins/jetpack',
-					Utils::shell_safe( $manager->get_installation_path() ),
-				),
-				$retcode,
-			);
-
-			if ( 0 !== $retcode ) {
-				Utils::error( "Failed to copy Jetpack to client-mu-plugins: \n" . implode( "\n", $output ) );
-				exit( $retcode );
-			}
-		} ),
+		fn ( Installation_Manager $manager ) => $manager->with_vip_mu_plugins(),
 	)
+	// When installing VIP mu-plugins, copy Jetpack to client-mu-plugins after rsync-ing WordPress.
+	// VIP requires a pinned Jetpack to be placed in client-mu-plugins for proper functionality.
+	->after_rsync( function ( Installation_Manager $manager, string $base_path ): void {
+		if ( ! Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ) ) {
+			return;
+		}
+
+		$retcode = 0;
+		$output  = Utils::command(
+			sprintf(
+				'WP_CORE_DIR=%s mkdir $WP_CORE_DIR/wp-content/client-mu-plugins && cp -r $WP_CORE_DIR/wp-content/plugins/jetpack $WP_CORE_DIR/wp-content/client-mu-plugins/jetpack',
+				Utils::shell_safe( $base_path ),
+			),
+			$retcode,
+		);
+
+		if ( 0 !== $retcode ) {
+			Utils::error( "Failed to copy Jetpack to client-mu-plugins: \n" . implode( "\n", $output ) );
+			exit( $retcode );
+		}
+	} )
 	->install_plugin( 'logger', 'https://github.com/alleyinteractive/logger/archive/refs/heads/develop.zip' )
 	->install_plugins(
 		[ 'byline-manager', 'https://github.com/alleyinteractive/byline-manager/archive/refs/heads/production.zip' ],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,9 @@
 
 namespace Mantle\Tests;
 
+use Mantle\Testing\Installation_Manager;
+use Mantle\Testing\Utils;
+
 define( 'MANTLE_PHPUNIT_INCLUDES_PATH', __DIR__ . '/includes' );
 define( 'MANTLE_PHPUNIT_FIXTURES_PATH', __DIR__ . '/fixtures' );
 define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
@@ -14,13 +17,33 @@ define( 'MANTLE_PHPUNIT_TEMPLATE_PATH', __DIR__ . '/template-parts' );
 // Enable debugging flag for local development on the testing framework.
 // define( 'MANTLE_TESTING_DEBUG', true );
 
+// For WordPress VIP testing, pin Jetpack to a specific version.
+if ( Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ) )  {
+	define( 'VIP_JETPACK_PINNED_VERSION', '13.9' );
+	define( 'WPCOM_VIP_JETPACK_LOCAL', true );
+}
+
 \Mantle\Testing\manager()
 	->maybe_rsync_plugin()
-	->with_vip_mu_plugins()
+	->when(
+		Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ),
+		fn ( Installation_Manager $manager ) => $manager
+				->with_vip_mu_plugins()
+				->before( function (): void {
+					// Copy plugins/jetpack to client-mu-plugins/jetpack to allow it to be pinned.
+					$retcode = 0;
+					$output = Utils::command( 'WP_CORE_DIR && mkdir $WP_CORE_DIR/wp-content/client-mu-plugins && cp -r $WP_CORE_DIR/wp-content/plugins/jetpack $WP_CORE_DIR/wp-content/client-mu-plugins/jetpack', $retcode );
+
+					if ( 0 !== $retcode ) {
+						Utils::error( "Failed to copy Jetpack to client-mu-plugins: \n" . implode( "\n", $output ) );
+						exit( $retcode );
+					}
+				} ),
+	)
 	->install_plugin( 'logger', 'https://github.com/alleyinteractive/logger/archive/refs/heads/develop.zip' )
 	->install_plugins(
 		[ 'byline-manager', 'https://github.com/alleyinteractive/byline-manager/archive/refs/heads/production.zip' ],
-		[ 'jetpack', '12.4' ],
+		[ 'jetpack', '13.9' ],
 		'co-authors-plus',
 	)
 	->plugins( [

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,19 +27,27 @@ if ( Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ) )  {
 	->maybe_rsync_plugin()
 	->when(
 		Utils::env_bool( 'MANTLE_INSTALL_VIP_MU_PLUGINS', false ),
-		fn ( Installation_Manager $manager ) => $manager
-				->with_vip_mu_plugins()
-				->before( function (): void {
-					// Copy plugins/jetpack to client-mu-plugins/jetpack to allow it to be pinned to a specific version.
-					// VIP requires it to be placed in client-mu-plugins/jetpack.
-					$retcode = 0;
-					$output = Utils::command( 'WP_CORE_DIR && mkdir $WP_CORE_DIR/wp-content/client-mu-plugins && cp -r $WP_CORE_DIR/wp-content/plugins/jetpack $WP_CORE_DIR/wp-content/client-mu-plugins/jetpack', $retcode );
+		fn ( Installation_Manager $manager ) => $manager->with_vip_mu_plugins()->before( function () use ( $manager ): void {
+			if ( $manager->is_within_wordpress_install() ) {
+				return;
+			}
 
-					if ( 0 !== $retcode ) {
-						Utils::error( "Failed to copy Jetpack to client-mu-plugins: \n" . implode( "\n", $output ) );
-						exit( $retcode );
-					}
-				} ),
+			// Copy plugins/jetpack to client-mu-plugins/jetpack to allow it to be pinned to a specific version.
+			// VIP requires it to be placed in client-mu-plugins/jetpack.
+			$retcode = 0;
+			$output  = Utils::command(
+				sprintf(
+					'WP_CORE_DIR=%s mkdir $WP_CORE_DIR/wp-content/client-mu-plugins && cp -r $WP_CORE_DIR/wp-content/plugins/jetpack $WP_CORE_DIR/wp-content/client-mu-plugins/jetpack',
+					Utils::shell_safe( $manager->get_installation_path() ),
+				),
+				$retcode,
+			);
+
+			if ( 0 !== $retcode ) {
+				Utils::error( "Failed to copy Jetpack to client-mu-plugins: \n" . implode( "\n", $output ) );
+				exit( $retcode );
+			}
+		} ),
 	)
 	->install_plugin( 'logger', 'https://github.com/alleyinteractive/logger/archive/refs/heads/develop.zip' )
 	->install_plugins(


### PR DESCRIPTION
- Fix an issue with a pinned version of WordPress isn't working with the out of the box VIP `mu-plugins`.
- Break out testing to include/exclude VIP mu-plugins for better testing.
- Test with `prefer-lowest` in specific cases.