### PR TITLE
Improve admin_screen_tear_down for missing backup case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.19.3
+
+### Fixed
+
+- Improve `admin_screen_tear_down` for missing backup case.
+
+  Modify `Admin_Screen` trait tear down to (un)set current screen when no backup exists.
+
 ## v1.19.2
 
 ### Fixed

--- a/src/mantle/testing/concerns/trait-admin-screen.php
+++ b/src/mantle/testing/concerns/trait-admin-screen.php
@@ -54,13 +54,12 @@ trait Admin_Screen {
 			$GLOBALS['hook_suffix'],
 			$GLOBALS['plugin_page'],
 			$GLOBALS['typenow'],
-			$GLOBALS['taxnow']
+			$GLOBALS['taxnow'],
+			$GLOBALS['current_screen'],
 		);
 		
 		if ( isset( $this->backup_screen ) ) {
 			set_current_screen( $this->backup_screen );
-		} else {
-			set_current_screen();
 		}
 	}
 }

--- a/src/mantle/testing/concerns/trait-admin-screen.php
+++ b/src/mantle/testing/concerns/trait-admin-screen.php
@@ -48,10 +48,6 @@ trait Admin_Screen {
 	 * Restore the backed up screen.
 	 */
 	public function admin_screen_tear_down(): void {
-		if ( isset( $this->backup_screen ) ) {
-			set_current_screen( $this->backup_screen );
-		}
-
 		unset(
 			$GLOBALS['pagenow'],
 			$GLOBALS['wp_importers'],
@@ -60,5 +56,11 @@ trait Admin_Screen {
 			$GLOBALS['typenow'],
 			$GLOBALS['taxnow']
 		);
+		
+		if ( isset( $this->backup_screen ) ) {
+			set_current_screen( $this->backup_screen );
+		} else {
+			set_current_screen();
+		}
 	}
 }


### PR DESCRIPTION
Modify tear down to (un)set current screen when no backup exists.

fixes #877 