### PR TITLE
Preserve $_wp_post_type_features between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.19.4
+
+### Fixed
+
+- Preserve `$_wp_post_type_features` between tests in `Preserves_Globals`.
+
+  When a test called `unregister_post_type()`, the post type itself was restored from the snapshot on the next test, but its features (title, editor, etc.) were not. `post_type_supports()` then returned false for the supposedly-restored post type.
+
 ## v1.19.3
 
 ### Fixed

--- a/src/mantle/testing/concerns/trait-preserves-globals.php
+++ b/src/mantle/testing/concerns/trait-preserves-globals.php
@@ -44,6 +44,7 @@ trait Preserves_Globals {
 	 * @var string[]
 	 */
 	protected const GLOBALS_TO_BACKUP = [
+		'_wp_post_type_features',
 		'wp_meta_keys',
 		'wp_post_statuses',
 		'wp_post_types',

--- a/tests/Testing/Concerns/PreserveGlobalsTest.php
+++ b/tests/Testing/Concerns/PreserveGlobalsTest.php
@@ -121,6 +121,29 @@ class PreserveGlobalsTest extends FrameworkTestCase {
 	}
 
 	/**
+	 * Ensure that post type features (title, editor, etc.) are restored
+	 * alongside the post type itself when a test unregisters it.
+	 *
+	 * Previously, $wp_post_types was preserved between tests but
+	 * $_wp_post_type_features was not. A test that called
+	 * unregister_post_type() would leave the features global empty for the
+	 * next test, causing post_type_supports() to return false even though
+	 * the post type itself was restored.
+	 *
+	 * @dataProvider dataprovider_twice
+	 */
+	#[DataProvider( 'dataprovider_twice' )]
+	public function test_post_type_features_preserved_between_tests(): void {
+		$this->assertTrue( post_type_exists( 'persistent_post_type' ) );
+		$this->assertTrue( post_type_supports( 'persistent_post_type', 'title' ) );
+		$this->assertTrue( post_type_supports( 'persistent_post_type', 'editor' ) );
+
+		// Unregister the post type. The next iteration of this test must
+		// still see it with its features intact, restored from the snapshot.
+		unregister_post_type( 'persistent_post_type' );
+	}
+
+	/**
 	 * Ensure that rewrite extra permastructs are preserved and originally stored correctly.
 	 *
 	 * @dataProvider dataprovider_twice


### PR DESCRIPTION
When a test calls unregister_post_type(), the post type itself is restored from the snapshot on the next test via the preserved $wp_post_types global, but its features (title, editor, etc.) were not. post_type_supports() then returned false for the supposedly-restored post type, breaking downstream code that depends on it (e.g. plugins reading post titles).

Add _wp_post_type_features to GLOBALS_TO_BACKUP so the features global is captured and restored alongside the post type.

Includes a regression test that unregisters the persistent post type in one iteration and asserts post_type_supports() still returns true on the next.