### PR TITLE
Add changelog entry for wp-type-extensions requirement update (#878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.19.4
+
+### Changed
+
+- Updated `alleyinteractive/wp-type-extensions` requirement to allow `>=3.0.0 <6.0.0`.
+
 ## v1.19.3
 
 ### Fixed


### PR DESCRIPTION
Adds a `v1.19.4` changelog entry documenting the dependency requirement update in #878, which bumps the allowed `alleyinteractive/wp-type-extensions` range to `>=3.0.0 <6.0.0`.

Dependabot owns the branch on #878, so this change is submitted as a PR targeting that branch. Merging this into #878 will fold the changelog note into that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169RJ72vZhNMNmsgiXxifEZ)_