### PR TITLE
Restore shared WordPress hooks that tests clear

### DIFF
--- a/tests/Database/Model/Registration/RegisterPostTypeTest.php
+++ b/tests/Database/Model/Registration/RegisterPostTypeTest.php
@@ -14,9 +14,21 @@ use Mantle\Support\Registration\Post_Type_Arguments;
 use Mantle\Testing\FrameworkTestCase;
 
 class RegisterPostTypeTest extends FrameworkTestCase {
+	protected ?\WP_Hook $rest_api_init = null;
+
 	protected function setUp(): void {
 		parent::setUp();
+
+		$this->rest_api_init = isset( $GLOBALS['wp_filter']['rest_api_init'] )
+			? clone $GLOBALS['wp_filter']['rest_api_init']
+			: null;
+
 		remove_all_actions( 'init' );
+
+		// The test fires rest_api_init by hand and needs only its own callbacks on it:
+		// core's callbacks call register_rest_route(), which re-enters rest_get_server()
+		// and fires rest_api_init a second time, double-registering the test's fields.
+		remove_all_actions( 'rest_api_init' );
 	}
 
 	protected function tearDown(): void {
@@ -24,7 +36,14 @@ class RegisterPostTypeTest extends FrameworkTestCase {
 		m::close();
 
 		unregister_post_type( 'test-post-type' );
-		remove_all_actions( 'rest_api_init' );
+
+		// Restore what setUp() cleared; leaving it empty would strip core's
+		// create_initial_rest_routes() for every later test in the process.
+		if ( $this->rest_api_init ) {
+			$GLOBALS['wp_filter']['rest_api_init'] = $this->rest_api_init;
+		} else {
+			unset( $GLOBALS['wp_filter']['rest_api_init'] );
+		}
 	}
 
 	public function test_register_post_type_fluent(): void {

--- a/tests/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Testing/Concerns/MakesHttpRequestsTest.php
@@ -35,14 +35,32 @@ class MakesHttpRequestsTest extends FrameworkTestCase {
 	use Refresh_Database;
 	use Reset_Server;
 
+	protected ?\WP_Hook $template_redirect = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		putenv( 'MANTLE_EXPERIMENTAL_TESTING_USE_HOME_URL_HOST=' );
 
+		$this->template_redirect = isset( $GLOBALS['wp_filter']['template_redirect'] )
+			? clone $GLOBALS['wp_filter']['template_redirect']
+			: null;
+
 		remove_all_actions( 'template_redirect' );
 
 		$this->flush_default_headers();
+	}
+
+	protected function tearDown(): void {
+		// Without this, the hooks cleared above stay cleared for every later test in
+		// the process, e.g. WP_Sitemaps' template_redirect callback.
+		if ( $this->template_redirect ) {
+			$GLOBALS['wp_filter']['template_redirect'] = $this->template_redirect;
+		} else {
+			unset( $GLOBALS['wp_filter']['template_redirect'] );
+		}
+
+		parent::tearDown();
 	}
 
 	#[DataProvider( 'dataprovider_run_multiple_requests' )]


### PR DESCRIPTION
## Problem

`1.x` fails the `parallel-unit-tests` (paratest) job intermittently — **3 of 5 runs** on the branch as it stands today, with no code change involved. Two tests are responsible.

`RegisterPostTypeTest` and `MakesHttpRequestsTest` each call `remove_all_actions()` on a hook they share with WordPress core, and never restore it. That call mutates process state, so the wipe outlives the test: every later test in the same PHPUnit process sees the hook empty. The default sequential order happens to be safe, which is why `composer phpunit` stays green. paratest is not — it runs many test files per worker process, and the order varies per run.

Two failures follow from it:

- Wiping `rest_api_init` strips core's `create_initial_rest_routes()`, so any later REST request in that worker 404s with `rest_no_route`. `RestFieldTest::test_rest_field` was the usual casualty, failing with `Failed asserting that null is identical to 6` because the response body was `{"code":"rest_no_route",...}`.
- Wiping `template_redirect` strips `WP_Sitemaps`' callback, which breaks `PreserveGlobalsTest::test_sitemap_hooked_once_to_template_redirect`.

## Fix

Both tests now snapshot the hook in `setUp()` and reassign it in `tearDown()`. The snapshot has to be a `clone` — `remove_all_actions()` mutates the `WP_Hook` in place, so holding a reference to it restores nothing.

`RegisterPostTypeTest` genuinely needs an empty `rest_api_init` while it runs, so its wipe moves from `tearDown()` to `setUp()` rather than going away. With core's callbacks present, `register_rest_route()` re-enters `rest_get_server()` — `Makes_Http_Requests` nulls `$wp_rest_server` for each test — which fires `rest_api_init` a second time and registers the test's REST fields twice (`LogicException`: attribute `testable-field` is already registered to object type `post`).

Nothing in `Preserves_Globals` covers `$wp_filter` (it backs up `wp_post_types`, `wp_taxonomies`, `wp_meta_keys`, `wp_post_statuses`, `_wp_post_type_features`, `wp_rewrite`, `wp_sitemaps` and `$wp->public_query_vars`), so this has to be handled per test.

## Verification

Run locally on PHP 8.5.8, WordPress latest, MySQL 9.7.1:

| Suite | Before | After |
| --- | --- | --- |
| paratest (`WP_MULTISITE=1`, 6 runs) | 3 of 5 runs failed | **6 of 6 passed** |
| `composer phpunit` | 1844 tests pass | 1844 tests pass |
| `composer phpunit:multisite` | 1844 tests pass | 1844 tests pass |

## Follow-up, not in this PR

The same unrestored-wipe pattern remains on `remove_all_actions( 'init' )` in `RegisterPostTypeTest`, `RegisterTaxonomyTest`, `DelayedFeatureTest` and `ServiceProviderTest`. It causes no failure today, so I have left it alone. Separately, `vendor/bin/phpunit --order-by=random` reliably fails `PrinterTest > make class` and `PreserveGlobalsTest > disable global preservation` — pre-existing order dependence that CI never exercises.
