### PR TITLE
Fix lint, static analysis, and paratest failures on 1.x

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -9,14 +9,19 @@ use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
+use Rector\CodeQuality\Rector\If_\ObjectExplicitBoolCompareRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\Closure\ClosureDelegatingCallToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\CodingStyle\Rector\FunctionLike\FunctionLikeToFirstClassCallableRector;
+use Rector\CodingStyle\Rector\If_\AlternativeIfToBracketRector;
 use Rector\CodingStyle\Rector\If_\NullableCompareToNullRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveDuplicatedReturnSelfDocblockRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveMixedDocblockOverruledByNativeTypeRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUselessUnionReturnDocblockRector;
 use Rector\DeadCode\Rector\MethodCall\RemoveNullArgOnNullDefaultParamRector;
 use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
 
@@ -101,6 +106,12 @@ return RectorConfig::configure()
 			__DIR__ . '/src/Mantle/Database/Model/Relations',
 		],
 		ArrayToFirstClassCallableRector::class,
+		// Rector re-prints the nodes it edits with four tabs per indent level instead of
+		// one, so any rule that rewrites a docblock or an if-block mangles the file.
+		RemoveDuplicatedReturnSelfDocblockRector::class,
+		RemoveMixedDocblockOverruledByNativeTypeRector::class,
+		RemoveUselessUnionReturnDocblockRector::class,
+		AlternativeIfToBracketRector::class,
 		RemoveUselessParamTagRector::class,
 		StrContainsRector::class,
 		AddArrowFunctionReturnTypeRector::class,
@@ -118,6 +129,7 @@ return RectorConfig::configure()
 		],
 		ReturnUnionTypeRector::class => [
 			__DIR__ . '/src/Mantle/Framework/Exceptions/Handler.php',
+			__DIR__ . '/src/Mantle/Support/Traits/Enumerates_Values.php',
 		],
 		ReturnTypeFromStrictFluentReturnRector::class => [
 			__DIR__ . '/src/Mantle/Database/Query/Collection.php',
@@ -125,6 +137,10 @@ return RectorConfig::configure()
 			__DIR__ . '/src/Mantle/Support/Traits/Enumerates_Values.php',
 		],
 		ExplicitBoolCompareRector::class => [
+			__DIR__ . '/src/Mantle/Database/Model/Post.php',
+			__DIR__ . '/src/Mantle/Testing',
+		],
+		ObjectExplicitBoolCompareRector::class => [
 			__DIR__ . '/src/Mantle/Database/Model/Post.php',
 			__DIR__ . '/src/Mantle/Testing',
 		],

--- a/src/Mantle/Application/Application.php
+++ b/src/Mantle/Application/Application.php
@@ -558,9 +558,7 @@ class Application extends Container implements \Mantle\Contracts\Application {
 			return true;
 		}
 
-		if ( null === $this->is_running_in_console ) {
-			$this->is_running_in_console = Environment::get( 'APP_RUNNING_IN_CONSOLE' ) || ( defined( 'WP_CLI' ) && WP_CLI && ! wp_doing_cron() );
-		}
+		$this->is_running_in_console ??= Environment::get( 'APP_RUNNING_IN_CONSOLE' ) || ( defined( 'WP_CLI' ) && WP_CLI && ! wp_doing_cron() );
 
 		return $this->is_running_in_console;
 	}

--- a/src/Mantle/Assets/Asset_Loader.php
+++ b/src/Mantle/Assets/Asset_Loader.php
@@ -31,13 +31,9 @@ class Asset_Loader {
 		protected ?string $build_directory = null,
 		protected ?string $base_url = null,
 	) {
-		if ( is_null( $this->build_directory ) ) {
-			$this->build_directory = base_path( config_mixed( 'asset.path', 'build' )->string() );
-		}
+		$this->build_directory ??= base_path( config_mixed( 'asset.path', 'build' )->string() );
 
-		if ( is_null( $this->base_url ) ) {
-			$this->base_url = config_mixed( 'assets.url', '/' )->string();
-		}
+		$this->base_url ??= config_mixed( 'assets.url', '/' )->string();
 	}
 
 	/**

--- a/src/Mantle/Console/Command.php
+++ b/src/Mantle/Console/Command.php
@@ -227,9 +227,7 @@ abstract class Command extends Symfony_Command {
 	 * @throws Manually_Failed_Exception|Throwable Thrown exception.
 	 */
 	public function fail( Throwable|string|null $exception = null ): void {
-		if ( is_null( $exception ) ) {
-			$exception = 'Command manually failed.';
-		}
+		$exception ??= 'Command manually failed.';
 
 		if ( is_string( $exception ) ) {
 			$exception = new Manually_Failed_Exception( $exception );

--- a/src/Mantle/Console/Parser.php
+++ b/src/Mantle/Console/Parser.php
@@ -83,23 +83,23 @@ class Parser {
 	protected static function parse_argument( $token ): \Symfony\Component\Console\Input\InputArgument {
 		[ $token, $description ] = static::extract_description( $token );
 
-		if ( str_ends_with( (string) $token, '?*' ) ) {
-			return new InputArgument( trim( (string) $token, '?*' ), InputArgument::IS_ARRAY, $description );
+		if ( str_ends_with( $token, '?*' ) ) {
+			return new InputArgument( trim( $token, '?*' ), InputArgument::IS_ARRAY, $description );
 		}
 
-		if ( str_ends_with( (string) $token, '*' ) ) {
-			return new InputArgument( trim( (string) $token, '*' ), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description );
+		if ( str_ends_with( $token, '*' ) ) {
+			return new InputArgument( trim( $token, '*' ), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description );
 		}
 
-		if ( str_ends_with( (string) $token, '?' ) ) {
-			return new InputArgument( trim( (string) $token, '?' ), InputArgument::OPTIONAL, $description );
+		if ( str_ends_with( $token, '?' ) ) {
+			return new InputArgument( trim( $token, '?' ), InputArgument::OPTIONAL, $description );
 		}
 
-		if ( preg_match( '/(.+)\=\*(.+)/', (string) $token, $matches ) ) {
+		if ( preg_match( '/(.+)\=\*(.+)/', $token, $matches ) ) {
 			return new InputArgument( $matches[1], InputArgument::IS_ARRAY, $description, preg_split( '/,\s?/', $matches[2] ) );
 		}
 
-		if ( preg_match( '/(.+)\=(.+)/', (string) $token, $matches ) ) {
+		if ( preg_match( '/(.+)\=(.+)/', $token, $matches ) ) {
 			return new InputArgument( $matches[1], InputArgument::OPTIONAL, $description, $matches[2] );
 		}
 
@@ -114,7 +114,7 @@ class Parser {
 	protected static function parse_option( $token ): \Symfony\Component\Console\Input\InputOption {
 		[$token, $description] = static::extract_description( $token );
 
-		$matches = preg_split( '/\s*\|\s*/', (string) $token, 2 );
+		$matches = preg_split( '/\s*\|\s*/', $token, 2 );
 
 		if ( isset( $matches[1] ) ) {
 			$shortcut = $matches[0];

--- a/src/Mantle/Container/Container.php
+++ b/src/Mantle/Container/Container.php
@@ -208,9 +208,7 @@ class Container implements ArrayAccess, \Mantle\Contracts\Container {
 		// If no concrete type was given, we will simply set the concrete type to the
 		// abstract type. After that, the concrete type to be registered as shared
 		// without being forced to state their classes in both of the parameters.
-		if ( is_null( $concrete ) ) {
-			$concrete = $abstract;
-		}
+		$concrete ??= $abstract;
 
 		// If the factory is not a Closure, it means it is just a class name which is
 		// bound into this container to the abstract type and we will just wrap it
@@ -1137,9 +1135,7 @@ class Container implements ArrayAccess, \Mantle\Contracts\Container {
 	 * Get the globally available instance of the container.
 	 */
 	public static function get_instance(): static {
-		if ( ! isset( static::$instance ) ) {
-			static::$instance = new static();
-		}
+		static::$instance ??= new static();
 
 		return static::$instance;
 	}

--- a/src/Mantle/Database/Model/Attachment.php
+++ b/src/Mantle/Database/Model/Attachment.php
@@ -81,9 +81,7 @@ class Attachment extends Post {
 
 		$disk = $settings['disk'];
 
-		if ( is_null( $expiration ) ) {
-			$expiration = Carbon::now()->addSeconds( max( 1, (int) config( "filesystem.disks.{$disk}.temporary_url_expiration" ) ) );
-		}
+		$expiration ??= Carbon::now()->addSeconds( max( 1, (int) config( "filesystem.disks.{$disk}.temporary_url_expiration" ) ) );
 
 		return Storage::drive( $disk )->temporary_url( untrailingslashit( $settings['path'] ) . $settings['name'], $expiration );
 	}

--- a/src/Mantle/Framework/Console/Hook_Usage_Command.php
+++ b/src/Mantle/Framework/Console/Hook_Usage_Command.php
@@ -301,7 +301,7 @@ class Hook_Usage_Command extends Command {
 			->trim()
 			->unique()
 			->filter(
-				fn( $path ): bool => ! ( ! is_file( $path ) && ! is_dir( $path ) )
+				fn( $path ): bool => is_file( $path ) || is_dir( $path )
 			)
 			->values();
 	}

--- a/src/Mantle/Framework/Events/Discover_Events.php
+++ b/src/Mantle/Framework/Events/Discover_Events.php
@@ -43,9 +43,7 @@ class Discover_Events {
 			[ $events, $priority ] = $events;
 
 			foreach ( $events as $event ) {
-				if ( ! isset( $discovered_events[ $event ] ) ) {
-					$discovered_events[ $event ] = [];
-				}
+				$discovered_events[ $event ] ??= [];
 
 				$discovered_events[ $event ][] = [ $listener, $priority ];
 			}

--- a/src/Mantle/Framework/Providers/Routing_Service_Provider.php
+++ b/src/Mantle/Framework/Providers/Routing_Service_Provider.php
@@ -35,9 +35,7 @@ class Routing_Service_Provider extends Service_Provider {
 		$this->register_response_factory();
 
 		// Setup the default request object.
-		if ( ! isset( $this->app['request'] ) ) {
-			$this->app['request'] = new Request();
-		}
+		$this->app['request'] ??= new Request();
 	}
 
 	/**

--- a/src/Mantle/Http/Interacts_With_Input.php
+++ b/src/Mantle/Http/Interacts_With_Input.php
@@ -323,9 +323,7 @@ trait Interacts_With_Input {
 	public function all_files() {
 		$files = $this->files->all();
 
-		if ( ! isset( $this->converted_files ) ) {
-			$this->converted_files = $this->convert_uploaded_files( $files );
-		}
+		$this->converted_files ??= $this->convert_uploaded_files( $files );
 
 		return $this->converted_files;
 	}

--- a/src/Mantle/Http/Routing/Route.php
+++ b/src/Mantle/Http/Routing/Route.php
@@ -8,12 +8,10 @@
 namespace Mantle\Http\Routing;
 
 use ArrayAccess;
-use ArrayObject;
 use JsonSerializable;
 use Mantle\Contracts\Container;
 use Mantle\Contracts\Http\Routing\Router;
 use Mantle\Contracts\Support\Arrayable;
-use Mantle\Database\Model\Model;
 use Mantle\Http\Controller;
 use Mantle\Support\Arr;
 use Mantle\Support\Str;
@@ -414,8 +412,6 @@ class Route extends Symfony_Route {
 			|| $response instanceof Arrayable
 			|| $response instanceof ArrayAccess
 			|| $response instanceof JsonSerializable
-			|| $response instanceof ArrayObject
-			|| $response instanceof Model
 		) {
 			return new JsonResponse( $response );
 		}

--- a/src/Mantle/Http/Routing/Router.php
+++ b/src/Mantle/Http/Routing/Router.php
@@ -258,9 +258,7 @@ class Router implements Router_Contract {
 	protected function with_registrar( \Closure $callback, bool $clear = false ): mixed {
 		$set = ! is_null( $this->registrar );
 
-		if ( is_null( $this->registrar ) ) {
-			$this->registrar = new Route_Registrar( $this );
-		}
+		$this->registrar ??= new Route_Registrar( $this );
 
 		$value = $callback( $this->registrar );
 

--- a/src/Mantle/Http/Routing/Url_Generator.php
+++ b/src/Mantle/Http/Routing/Url_Generator.php
@@ -254,9 +254,7 @@ class Url_Generator extends UrlGenerator implements Generator_Contract {
 	 * @param  string|null $root
 	 */
 	public function format_root( string $scheme, ?string $root = null ): string {
-		if ( is_null( $root ) ) {
-			$root = $this->root_url;
-		}
+		$root ??= $this->root_url;
 
 		$start = str_starts_with( $root, 'http://' ) ? 'http://' : 'https://';
 

--- a/src/Mantle/Http/Uploaded_File.php
+++ b/src/Mantle/Http/Uploaded_File.php
@@ -105,9 +105,7 @@ class Uploaded_File extends SymfonyUploadedFile {
 		$options = $this->parse_options( $options );
 
 		// Set the default visibility for attachments to public.
-		if ( ! isset( $options['visibility'] ) ) {
-			$options['visibility'] = 'public';
-		}
+		$options['visibility'] ??= 'public';
 
 		$uploaded_file = $name ? $this->store_as( $path, $name, $options ) : $this->store( $path, $options );
 

--- a/src/Mantle/Http_Client/Pending_Request.php
+++ b/src/Mantle/Http_Client/Pending_Request.php
@@ -183,9 +183,7 @@ class Pending_Request {
 	 * @param string|null $url URL for the request.
 	 */
 	public function set_url( ?string $url = null ): static {
-		if ( is_null( $url ) ) {
-			$url = '';
-		}
+		$url ??= '';
 
 		$this->url = $this->base_url ? "{$this->base_url}{$url}" : $url;
 

--- a/src/Mantle/Http_Client/Response.php
+++ b/src/Mantle/Http_Client/Response.php
@@ -382,9 +382,7 @@ class Response implements ArrayAccess, ResponseContract {
 	 * @return mixed
 	 */
 	public function json( ?string $key = null, mixed $default = null ) {
-		if ( $this->decoded === null ) {
-			$this->decoded = json_decode( $this->body(), true );
-		}
+		$this->decoded ??= json_decode( $this->body(), true );
 
 		if ( is_null( $key ) ) {
 			return $this->decoded;

--- a/src/Mantle/Query_Monitor/Collector/Remote_Request_Collector.php
+++ b/src/Mantle/Query_Monitor/Collector/Remote_Request_Collector.php
@@ -274,17 +274,15 @@ class Remote_Request_Collector extends \QM_Collector {
 
 		foreach ( $this->requests as $key => $request ) {
 			// Provide a timeout response if none exists).
-			if ( ! isset( $this->responses[ $key ] ) ) {
-				$this->responses[ $key ] = [
-					'args'     => $request['args'],
-					'response' => new WP_Error(
-						'http_request_timed_out',
-						__( 'The HTTP request did not receive a response before the timeout period expired.', 'mantle' ),
-					),
-					'stop'     => floatval( $request['start'] + ( $request['args']['timeout'] ?? 0 ) ),
-					'url'      => $request['url'],
-				];
-			}
+			$this->responses[ $key ] ??= [
+				'args'     => $request['args'],
+				'response' => new WP_Error(
+					'http_request_timed_out',
+					__( 'The HTTP request did not receive a response before the timeout period expired.', 'mantle' ),
+				),
+				'stop'     => floatval( $request['start'] + ( $request['args']['timeout'] ?? 0 ) ),
+				'url'      => $request['url'],
+			];
 
 			// Convert the response to a Http Client Response instance.
 			$response = match ( true ) {

--- a/src/Mantle/Query_Monitor/Output/Output_Remote_Request.php
+++ b/src/Mantle/Query_Monitor/Output/Output_Remote_Request.php
@@ -55,8 +55,6 @@ class Output_Remote_Request extends \QM_Output_Html {
 	public function output(): void {
 		$collector = $this->collector;
 
-		assert( $collector instanceof Remote_Request_Collector );
-
 		$requests = $collector->get_data()->requests;
 
 		if ( empty( $requests ) ) {

--- a/src/Mantle/Queue/Queue_Manager.php
+++ b/src/Mantle/Queue/Queue_Manager.php
@@ -45,9 +45,7 @@ class Queue_Manager implements Queue_Manager_Contract {
 	public function get_provider( ?string $name = null ): Provider {
 		$name = $name ?: $this->get_default_driver();
 
-		if ( ! isset( $this->connections[ $name ] ) ) {
-			$this->connections[ $name ] = $this->resolve( $name );
-		}
+		$this->connections[ $name ] ??= $this->resolve( $name );
 
 		return $this->connections[ $name ];
 	}

--- a/src/Mantle/Support/Arr.php
+++ b/src/Mantle/Support/Arr.php
@@ -263,10 +263,7 @@ class Arr {
 				}
 			}
 
-			$part = array_shift( $parts );
-			if ( null !== $part ) {
-				unset( $array[ $part ] );
-			}
+			unset( $array[ array_shift( $parts ) ] );
 		}
 	}
 

--- a/src/Mantle/Support/Collection.php
+++ b/src/Mantle/Support/Collection.php
@@ -105,9 +105,7 @@ class Collection implements ArrayAccess, Enumerable {
 
 		$items = range( 1, $number );
 
-		if ( is_null( $callback ) ) {
-			$callback = fn( $value ) => $value;
-		}
+		$callback ??= fn( $value ) => $value;
 
 		return ( new static( $items ) )->map( $callback );
 	}
@@ -202,15 +200,7 @@ class Collection implements ArrayAccess, Enumerable {
 
 		$collection = isset( $key ) ? $this->pluck( $key ) : $this;
 
-		$counts = new self();
-
-		$collection->each(
-			function ( $value ) use ( $counts ): void {
-				$counts[ $value ] = isset( $counts[ $value ] ) ? $counts[ $value ] + 1 : 1;
-			}
-		);
-
-		$sorted = $counts->sort();
+		$sorted = $collection->count_by()->sort();
 
 		$highest_value = $sorted->last();
 
@@ -868,9 +858,7 @@ class Collection implements ArrayAccess, Enumerable {
 
 			$value = reset( $pair );
 
-			if ( ! isset( $dictionary[ $key ] ) ) {
-				$dictionary[ $key ] = [];
-			}
+			$dictionary[ $key ] ??= [];
 
 			$dictionary[ $key ][] = $value;
 		}

--- a/src/Mantle/Support/Memoize.php
+++ b/src/Mantle/Support/Memoize.php
@@ -68,9 +68,7 @@ class Memoize {
 
 		$object = $memoizable->object ?: $this;
 
-		if ( ! isset( $this->values[ $object ] ) ) {
-			$this->values[ $object ] = [];
-		}
+		$this->values[ $object ] ??= [];
 
 		if ( ! array_key_exists( $memoizable->hash, $this->values[ $object ] ) ) {
 			$this->values[ $object ][ $memoizable->hash ] = call_user_func( $memoizable->callable );

--- a/src/Mantle/Support/Pluralizer.php
+++ b/src/Mantle/Support/Pluralizer.php
@@ -101,9 +101,7 @@ class Pluralizer {
 	 * Get the inflector instance.
 	 */
 	public static function inflector(): Inflector {
-		if ( ! isset( static::$inflector ) ) {
-			static::$inflector = InflectorFactory::createForLanguage( static::$language )->build();
-		}
+		static::$inflector ??= InflectorFactory::createForLanguage( static::$language )->build();
 
 		return static::$inflector;
 	}

--- a/src/Mantle/Support/Str.php
+++ b/src/Mantle/Support/Str.php
@@ -1115,9 +1115,7 @@ class Str {
 	 * @return string|string[]
 	 */
 	public static function substr_replace( $string, $replace, $offset = 0, $length = null ): array|string {
-		if ( is_null( $length ) ) {
-			$length = is_array( $string ) ? null : strlen( $string );
-		}
+		$length ??= is_array( $string ) ? null : strlen( $string );
 
 		return substr_replace( $string, $replace, $offset, $length );
 	}

--- a/src/Mantle/Support/Traits/Enumerates_Values.php
+++ b/src/Mantle/Support/Traits/Enumerates_Values.php
@@ -784,9 +784,7 @@ trait Enumerates_Values {
 	 * @return static
 	 */
 	public function count_by( $callback = null ) {
-		if ( is_null( $callback ) ) {
-			$callback = fn ( $value ) => $value;
-		}
+		$callback ??= fn ( $value ) => $value;
 
 		return new static(
 			$this->group_by( $callback )->map( // @phpstan-ignore-line argument.templateType

--- a/src/Mantle/Support/Traits/Singleton.php
+++ b/src/Mantle/Support/Traits/Singleton.php
@@ -26,9 +26,7 @@ trait Singleton {
 	public static function instance() {
 		$class = static::class;
 
-		if ( ! isset( static::$instances[ $class ] ) ) {
-			static::$instances[ $class ] = new static();
-		}
+		static::$instances[ $class ] ??= new static();
 
 		return self::$instances[ $class ];
 	}

--- a/src/Mantle/Support/helpers/helpers-array.php
+++ b/src/Mantle/Support/helpers/helpers-array.php
@@ -105,9 +105,7 @@ function data_set( mixed &$target, string|array $key, mixed $value, bool $overwr
 		}
 	} elseif ( is_object( $target ) ) {
 		if ( $segments !== [] ) {
-			if ( ! isset( $target->{$segment} ) ) {
-				$target->{$segment} = [];
-			}
+			$target->{$segment} ??= [];
 
 			data_set( $target->{$segment}, $segments, $value, $overwrite );
 		} elseif ( $overwrite || ! isset( $target->{$segment} ) ) {

--- a/src/Mantle/Support/helpers/helpers-general.php
+++ b/src/Mantle/Support/helpers/helpers-general.php
@@ -204,10 +204,8 @@ function object_get( $object, $key, $default = null ) {
 function preg_replace_array( $pattern, array $replacements, $subject ): ?string {
 	return preg_replace_callback(
 		$pattern,
-		function () use ( &$replacements ) {
-			foreach ( $replacements as $replacement ) {
-				return array_shift( $replacements );
-			}
+		function () use ( &$replacements ): string {
+			return array_shift( $replacements ) ?? '';
 		},
 		$subject
 	);
@@ -451,7 +449,10 @@ function html_string( string $html ): HTML {
 function capture( callable $callback ): string {
 	ob_start();
 	$callback();
-	return ob_get_clean();
+
+	$output = ob_get_clean();
+
+	return false === $output ? '' : $output;
 }
 
 /**

--- a/src/Mantle/Testing/Concerns/Interacts_With_Hooks.php
+++ b/src/Mantle/Testing/Concerns/Interacts_With_Hooks.php
@@ -44,9 +44,7 @@ trait Interacts_With_Hooks {
 					return $value;
 				}
 
-				if ( ! isset( $this->hooks_fired[ $filter ] ) ) {
-					$this->hooks_fired[ $filter ] = 0;
-				}
+				$this->hooks_fired[ $filter ] ??= 0;
 
 				$this->hooks_fired[ $filter ]++;
 

--- a/src/Mantle/Testing/Concerns/Interacts_With_Requests.php
+++ b/src/Mantle/Testing/Concerns/Interacts_With_Requests.php
@@ -220,9 +220,7 @@ trait Interacts_With_Requests {
 		$url = $url_or_callback ?? '*';
 
 		// If no arguments passed, assume that all requests should return an 200 response.
-		if ( is_null( $response ) ) {
-			$response = new Mock_Http_Response();
-		}
+		$response ??= new Mock_Http_Response();
 
 		if ( is_array( $response ) ) {
 			$response = Mock_Http_Response::json( $response );

--- a/src/Mantle/Testing/Concerns/Rsync_Installation.php
+++ b/src/Mantle/Testing/Concerns/Rsync_Installation.php
@@ -319,9 +319,7 @@ trait Rsync_Installation {
 			exit( 1 );
 		}
 
-		if ( is_null( $version_or_url ) ) {
-			$version_or_url = 'latest';
-		}
+		$version_or_url ??= 'latest';
 
 		$this->plugins[] = [ $plugin, $version_or_url ];
 

--- a/src/Mantle/Testing/Doubles/Spy_REST_Server.php
+++ b/src/Mantle/Testing/Doubles/Spy_REST_Server.php
@@ -109,8 +109,12 @@ class Spy_REST_Server extends WP_REST_Server {
 	 */
 	public function serve_request( $path = null ) {
 		ob_start();
-		$result          = parent::serve_request( $path );
-		$this->sent_body = ob_get_clean();
+
+		$result = parent::serve_request( $path );
+		$body   = ob_get_clean();
+
+		$this->sent_body = false === $body ? '' : $body;
+
 		return $result;
 	}
 

--- a/src/Mantle/Testing/Exceptions/Exit_Simulation_Exception.php
+++ b/src/Mantle/Testing/Exceptions/Exit_Simulation_Exception.php
@@ -28,9 +28,7 @@ class Exit_Simulation_Exception extends Response_Exception {
 	 */
 	public function __construct( public readonly int $exit_status = 0, public readonly ?int $response_code = null, array $headers = [], ?string $message = null ) {
 		// If no response code is provided, use the current HTTP response code.
-		if ( null === $response_code ) {
-			$response_code = http_response_code();
-		}
+		$response_code ??= http_response_code();
 
 		parent::__construct(
 			status: is_int( $response_code ) ? $response_code : 200,

--- a/src/Mantle/Testing/Exceptions/WP_Redirect_Exception.php
+++ b/src/Mantle/Testing/Exceptions/WP_Redirect_Exception.php
@@ -24,9 +24,7 @@ class WP_Redirect_Exception extends Response_Exception {
 		// Ensure headers are all keyed by lowercase.
 		$headers = array_change_key_case( $headers, CASE_LOWER );
 
-		if ( ! isset( $headers['location'] ) ) {
-			$headers['location'] = $location;
-		}
+		$headers['location'] ??= $location;
 
 		parent::__construct( $status, $headers, "Redirect to {$location} with status {$status}" );
 	}

--- a/src/Mantle/Testing/Pending_Testable_Request.php
+++ b/src/Mantle/Testing/Pending_Testable_Request.php
@@ -439,7 +439,7 @@ class Pending_Testable_Request {
 			remove_filter( 'wp_headers', $intercept_headers, 9999 );
 			remove_filter( 'wp_redirect', $intercept_redirect, 9999 );
 
-			$response_content = false === $response_content ? null : $response_content; // @phpstan-ignore-line identical.alwaysFalse
+			$response_content = false === $response_content ? null : $response_content;
 
 			$response = new Test_Response(
 				$response_content,

--- a/src/Mantle/Testing/TestCase.php
+++ b/src/Mantle/Testing/TestCase.php
@@ -373,9 +373,7 @@ abstract class TestCase extends BaseTestCase {
 	 * Fetches the factory object for generating WordPress fixtures.
 	 */
 	public static function factory(): Factory_Container {
-		if ( ! isset( static::$factory ) ) {
-			static::$factory = Container::get_instance()->make( Factory_Container::class );
-		}
+		static::$factory ??= Container::get_instance()->make( Factory_Container::class );
 
 		assert( static::$factory instanceof Factory_Container );
 

--- a/src/Mantle/View/Engines/Blade_Engine.php
+++ b/src/Mantle/View/Engines/Blade_Engine.php
@@ -154,6 +154,8 @@ class Blade_Engine extends Php_Engine {
 			$this->handle_view_exception( $e, $ob_level );
 		}
 
-		return ltrim( ob_get_clean() );
+		$output = ob_get_clean();
+
+		return false === $output ? '' : ltrim( $output );
 	}
 }

--- a/src/Mantle/View/Engines/Php_Engine.php
+++ b/src/Mantle/View/Engines/Php_Engine.php
@@ -49,7 +49,9 @@ class Php_Engine implements Engine {
 			$this->handle_view_exception( $e, $ob_level );
 		}
 
-		return ltrim( ob_get_clean() );
+		$output = ob_get_clean();
+
+		return false === $output ? '' : ltrim( $output );
 	}
 
 	/**

--- a/tests/Database/Model/Registration/RegisterPostTypeTest.php
+++ b/tests/Database/Model/Registration/RegisterPostTypeTest.php
@@ -14,9 +14,21 @@ use Mantle\Support\Registration\Post_Type_Arguments;
 use Mantle\Testing\FrameworkTestCase;
 
 class RegisterPostTypeTest extends FrameworkTestCase {
+	protected ?\WP_Hook $rest_api_init = null;
+
 	protected function setUp(): void {
 		parent::setUp();
+
+		$this->rest_api_init = isset( $GLOBALS['wp_filter']['rest_api_init'] )
+			? clone $GLOBALS['wp_filter']['rest_api_init']
+			: null;
+
 		remove_all_actions( 'init' );
+
+		// The test fires rest_api_init by hand and needs only its own callbacks on it:
+		// core's callbacks call register_rest_route(), which re-enters rest_get_server()
+		// and fires rest_api_init a second time, double-registering the test's fields.
+		remove_all_actions( 'rest_api_init' );
 	}
 
 	protected function tearDown(): void {
@@ -24,7 +36,14 @@ class RegisterPostTypeTest extends FrameworkTestCase {
 		m::close();
 
 		unregister_post_type( 'test-post-type' );
-		remove_all_actions( 'rest_api_init' );
+
+		// Restore what setUp() cleared; leaving it empty would strip core's
+		// create_initial_rest_routes() for every later test in the process.
+		if ( $this->rest_api_init ) {
+			$GLOBALS['wp_filter']['rest_api_init'] = $this->rest_api_init;
+		} else {
+			unset( $GLOBALS['wp_filter']['rest_api_init'] );
+		}
 	}
 
 	public function test_register_post_type_fluent(): void {

--- a/tests/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Testing/Concerns/MakesHttpRequestsTest.php
@@ -35,14 +35,32 @@ class MakesHttpRequestsTest extends FrameworkTestCase {
 	use Refresh_Database;
 	use Reset_Server;
 
+	protected ?\WP_Hook $template_redirect = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		putenv( 'MANTLE_EXPERIMENTAL_TESTING_USE_HOME_URL_HOST=' );
 
+		$this->template_redirect = isset( $GLOBALS['wp_filter']['template_redirect'] )
+			? clone $GLOBALS['wp_filter']['template_redirect']
+			: null;
+
 		remove_all_actions( 'template_redirect' );
 
 		$this->flush_default_headers();
+	}
+
+	protected function tearDown(): void {
+		// Without this, the hooks cleared above stay cleared for every later test in
+		// the process, e.g. WP_Sitemaps' template_redirect callback.
+		if ( $this->template_redirect ) {
+			$GLOBALS['wp_filter']['template_redirect'] = $this->template_redirect;
+		} else {
+			unset( $GLOBALS['wp_filter']['template_redirect'] );
+		}
+
+		parent::tearDown();
 	}
 
 	#[DataProvider( 'dataprovider_run_multiple_requests' )]


### PR DESCRIPTION
`1.x` is currently red in two independent ways, neither caused by a code change. This fixes both. Two commits, reviewable separately:

1. **`Restore shared WordPress hooks that tests clear`** — the paratest job (2 test files).
2. **`Fix lint and static analysis failures from tooling drift`** — PHPStan and Rector (`rector.php` + 38 files under `src/Mantle/`).

I originally opened these as a stack (#912 + this one), but neither half is green on its own — the lint drift fails the bottom PR's required checks regardless of which concern goes first — so they are combined here to give one mergeable, green PR. #912 is closed; its commit is the first one here.

---

# 1. paratest flakiness

### Why it fails

`1.x` fails the `parallel-unit-tests` (paratest) job intermittently — **3 of 5 runs** on the branch as it stands today, with no code change involved. Two tests are responsible.

`RegisterPostTypeTest` and `MakesHttpRequestsTest` each call `remove_all_actions()` on a hook they share with WordPress core, and never restore it. That call mutates process state, so the wipe outlives the test: every later test in the same PHPUnit process sees the hook empty. The default sequential order happens to be safe, which is why `composer phpunit` stays green. paratest is not — it runs many test files per worker process, and the order varies per run.

Two failures follow from it:

- Wiping `rest_api_init` strips core's `create_initial_rest_routes()`, so any later REST request in that worker 404s with `rest_no_route`. `RestFieldTest::test_rest_field` was the usual casualty, failing with `Failed asserting that null is identical to 6` because the response body was `{"code":"rest_no_route",...}`.
- Wiping `template_redirect` strips `WP_Sitemaps`' callback, which breaks `PreserveGlobalsTest::test_sitemap_hooked_once_to_template_redirect`.

### Fix

Both tests now snapshot the hook in `setUp()` and reassign it in `tearDown()`. The snapshot has to be a `clone` — `remove_all_actions()` mutates the `WP_Hook` in place, so holding a reference to it restores nothing.

`RegisterPostTypeTest` genuinely needs an empty `rest_api_init` while it runs, so its wipe moves from `tearDown()` to `setUp()` rather than going away. With core's callbacks present, `register_rest_route()` re-enters `rest_get_server()` — `Makes_Http_Requests` nulls `$wp_rest_server` for each test — which fires `rest_api_init` a second time and registers the test's REST fields twice (`LogicException`: attribute `testable-field` is already registered to object type `post`).

Nothing in `Preserves_Globals` covers `$wp_filter` (it backs up `wp_post_types`, `wp_taxonomies`, `wp_meta_keys`, `wp_post_statuses`, `_wp_post_type_features`, `wp_rewrite`, `wp_sitemaps` and `$wp->public_query_vars`), so this has to be handled per test.

### Verification

Run locally on PHP 8.5.8, WordPress latest, MySQL 9.7.1:

| Suite | Before | After |
| --- | --- | --- |
| paratest (`WP_MULTISITE=1`, 6 runs) | 3 of 5 runs failed | **6 of 6 passed** |
| `composer phpunit` | 1844 tests pass | 1844 tests pass |
| `composer phpunit:multisite` | 1844 tests pass | 1844 tests pass |

### Follow-up, not in this PR

The same unrestored-wipe pattern remains on `remove_all_actions( 'init' )` in `RegisterPostTypeTest`, `RegisterTaxonomyTest`, `DelayedFeatureTest` and `ServiceProviderTest`. It causes no failure today, so I have left it alone. Separately, `vendor/bin/phpunit --order-by=random` reliably fails `PrinterTest > make class` and `PreserveGlobalsTest > disable global preservation` — pre-existing order dependence that CI never exercises.

---

# 2. Lint and static analysis drift

### Why it fails

`composer.lock` is gitignored, so CI resolves the newest PHPStan, WordPress stubs and Rector on every run. `composer lint` therefore drifts red with no code change: as of today `1.x` reports **10 PHPStan errors** and **51 files** Rector wants to rewrite. This brings the branch back to green against the current versions.

### PHPStan

All 10 fixed at the source — no baseline entries, no `@phpstan-ignore` comments, no casts added to silence anything:

- `Route::ensure_response()` checked `instanceof ArrayObject` and `instanceof Model` after `instanceof ArrayAccess` had already matched both, so those two branches were unreachable. Removed, along with the now-unused imports.
- `Arr::forget()` null-checked an `array_shift()` off a list that cannot be empty at that point.
- `Collection::mode()` built its counts with `new self()`, which infers `Collection<never, never>` and makes the comparison against `last()` always false. It now uses `count_by()`, which carries the generics and is behaviorally identical (`group_by()` + `count()` keys on the same values).
- `preg_replace_array()`'s callback fell off the end of its `foreach` and returned `null` once the replacements ran out, so it did not satisfy `callable(array<string>): string`.
- `capture()`, `Blade_Engine`, `Php_Engine` and `Spy_REST_Server` all ignored the `false` that `ob_get_clean()` can return. Each keeps its existing behavior exactly — `false` coerced to `''` in every one of these paths, as the property and return types are non-strict `?string`/`string`.
- Dropped a stale `@phpstan-ignore-line` in `Pending_Testable_Request` whose error is no longer reported.

### Rector

Four of the newly-enabled rules are skipped in `rector.php` because Rector re-prints the nodes it edits with **four tabs per indent level instead of one**, mangling any docblock or if-block it touches. Passing `indentSize: 1` does not help — the pretty-printer emits four spaces per level and each becomes a tab. The rules: `RemoveMixedDocblockOverruledByNativeTypeRector`, `RemoveDuplicatedReturnSelfDocblockRector`, `RemoveUselessUnionReturnDocblockRector`, `AlternativeIfToBracketRector`.

Two more are scoped rather than skipped outright: `ReturnUnionTypeRector` wanted `each(): object|array` on a `static`-returning API in `Enumerates_Values`, and `ObjectExplicitBoolCompareRector` is skipped on the same paths where its sibling `ExplicitBoolCompareRector` already is.

The remaining 31 files are applied, almost entirely `IfToNullCoalescingAssignRector` turning if-isset blocks into `??=`. `Remote_Request_Collector` needed `phpcbf` afterwards, since `??=` de-indents a statement without re-indenting the array literal beneath it.

**Pinning Rector below the regression is not an option.** `"rector/rector": "^2.0 <2.5.3"` is the fix currently carried on `feature/mantle-queue-tables` and `chore/merge-1.x-into-2.x`, and it no longer works: 2.5.2 requires `phpstan/phpstan ^2.2.2` but reads a private `$container` off `PHPStan\Parser\RichParser` that PHPStan has since removed, so it dies with `MissingPrivatePropertyException` and exit 255, taking `composer lint` with it. Those two branches will fail lint in CI until that pin is dropped.

### Dependencies

No dependency changes were needed — `composer.json` is byte-identical to `origin/1.x`. For the record, on a fresh resolve: `composer audit` reports no advisories, `composer validate --strict` and `composer monorepo-validate` pass, and all 29 packages under `src/Mantle/` pass `composer install` + `composer validate --strict` + `composer audit --no-dev --locked`.

### Verification

Run locally on PHP 8.5.8 (the version CI's lint job uses), WordPress latest, MySQL 9.7.1, from cold PHPCS and PHPStan caches:

- `composer lint` — PHPCS clean across 562 files, PHPStan `[OK] No errors` across 512 files, Rector `[OK] Rector is done!`
- `composer phpunit` — 1844 tests, 0 failures
- `composer phpunit:multisite` — 1844 tests, 0 failures
- paratest — 6 of 6 runs green (with #912)

The unit matrix also covers PHP 8.3 and 8.4, which I did not run locally.
